### PR TITLE
feat(manager): warn when closing or leaving with unsaved changes (Resources, Elements, Files)

### DIFF
--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -297,9 +297,18 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
             }
         } else {
             // if just doing a URL redirect
-            var params = itm.params || {};
+            const params = itm.params || {};
             Ext.applyIf(params, o.baseParams || {});
-            MODx.loadPage('?' + Ext.urlEncode(params));
+            const fp = o.formpanel ? Ext.getCmp(o.formpanel) : null;
+            if (fp && fp.isDirty && fp.isDirty()) {
+                Ext.Msg.confirm(_('warning'), _('resource_cancel_dirty_confirm'), function(btn) {
+                    if (btn === 'yes') {
+                        MODx.loadPage('?' + Ext.urlEncode(params));
+                    }
+                });
+            } else {
+                MODx.loadPage('?' + Ext.urlEncode(params));
+            }
         }
         return false;
     }

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -374,9 +374,19 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
                     },
                     beforetabchange: {
                         fn: function(panel, newTab, currentTab) {
-                            if (newTab && currentTab && newTab.id !== currentTab.id && newTab.id !== 'modx-trash-link' && this.hasDirtyContentForm()) {
+                            if (this._allowNextLeftTabChange) {
+                                this._allowNextLeftTabChange = false;
+                            } else if (
+                                newTab
+                                && currentTab
+                                && newTab.id !== currentTab.id
+                                && newTab.id !== 'modx-trash-link'
+                                && this.hasDirtyContentForm()
+                            ) {
+                                const layout = this;
                                 Ext.Msg.confirm(_('warning'), _('resource_cancel_dirty_confirm'), function(btn) {
                                     if (btn === 'yes') {
+                                        layout._allowNextLeftTabChange = true;
                                         panel.setActiveTab(newTab);
                                     }
                                 });
@@ -906,6 +916,8 @@ MODx.LayoutMgr = function() {
                     middleMouseButtonClick = (e && (e.button === 4 || e.which === 2)),
                     keyboardKeyPressed = (e && (e.button === 1 || e.ctrlKey === true || e.metaKey === true || e.shiftKey === true))
                 ;
+                // Intentional manager navigation: skip native beforeunload after our own confirms.
+                MODx.suppressUnsavedWarning = true;
                 if (middleMouseButtonClick || keyboardKeyPressed) {
                     // Middle mouse button click or keyboard key pressed,
                     // let the browser handle the way it should be opened (new tab/window)
@@ -931,6 +943,31 @@ MODx.LayoutMgr = function() {
         }
     };
 }();
+
+
+/**
+ * Bind a single beforeunload handler that checks dirty content forms.
+ * FormPanel.onReady calls this so multiple panels do not overwrite each other.
+ */
+MODx.bindUnsavedBeforeUnload = function() {
+    if (MODx._unsavedBeforeUnloadBound) {
+        return;
+    }
+    MODx._unsavedBeforeUnloadBound = true;
+    window.onbeforeunload = function() {
+        if (MODx.suppressUnsavedWarning) {
+            return undefined;
+        }
+        if (parseInt(MODx.config.confirm_navigation, 10) !== 1) {
+            return undefined;
+        }
+        const layout = Ext.getCmp('modx-layout');
+        if (layout && layout.hasDirtyContentForm && layout.hasDirtyContentForm()) {
+            return _('unsaved_changes');
+        }
+        return undefined;
+    };
+};
 
 /* aliases for quicker reference */
 MODx.getPage = MODx.LayoutMgr.getPage;

--- a/manager/assets/modext/core/modx.layout.js
+++ b/manager/assets/modext/core/modx.layout.js
@@ -373,9 +373,17 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
                         }
                     },
                     beforetabchange: {
-                        fn: function(panel, tab) {
-                            if (tab && tab.id === 'modx-trash-link') {
-                                if (tab.tabEl.classList.contains('active')) {
+                        fn: function(panel, newTab, currentTab) {
+                            if (newTab && currentTab && newTab.id !== currentTab.id && newTab.id !== 'modx-trash-link' && this.hasDirtyContentForm()) {
+                                Ext.Msg.confirm(_('warning'), _('resource_cancel_dirty_confirm'), function(btn) {
+                                    if (btn === 'yes') {
+                                        panel.setActiveTab(newTab);
+                                    }
+                                });
+                                return false;
+                            }
+                            if (newTab && newTab.id === 'modx-trash-link') {
+                                if (newTab.tabEl.classList.contains('active')) {
                                     const tree = Ext.getCmp('modx-resource-tree');
                                     if (tree) {
                                         tree.redirect('?a=resource/trash');
@@ -675,6 +683,31 @@ Ext.extend(MODx.Layout, Ext.Viewport, {
             submenu.classList.remove('active');
             buttons[i].classList.remove('active');
         }
+    },
+
+    /**
+     * Whether any content form panel (resource, element, file) has unsaved changes.
+     *
+     * @returns {Boolean}
+     */
+    hasDirtyContentForm: function() {
+        const formPanelIds = [
+            'modx-panel-resource',
+            'modx-panel-chunk',
+            'modx-panel-snippet',
+            'modx-panel-template',
+            'modx-panel-plugin',
+            'modx-panel-tv',
+            'modx-panel-file-edit',
+            'modx-panel-file-create'
+        ];
+        for (let i = 0; i < formPanelIds.length; i++) {
+            const fp = Ext.getCmp(formPanelIds[i]);
+            if (fp && fp.isDirty && fp.isDirty()) {
+                return true;
+            }
+        }
+        return false;
     },
 
     /**

--- a/manager/assets/modext/widgets/core/modx.panel.js
+++ b/manager/assets/modext/widgets/core/modx.panel.js
@@ -271,6 +271,14 @@ Ext.extend(MODx.FormPanel, Ext.FormPanel, {
             this.mask.hide();
         }
         this.fireEvent('postReady');
+        if (parseInt(MODx.config.confirm_navigation, 10) === 1) {
+            const panel = this;
+            window.onbeforeunload = function() {
+                if (panel.isDirty && panel.isDirty()) {
+                    return _('unsaved_changes');
+                }
+            };
+        }
     },
 
     loadDropZones: function() {

--- a/manager/assets/modext/widgets/core/modx.panel.js
+++ b/manager/assets/modext/widgets/core/modx.panel.js
@@ -271,13 +271,8 @@ Ext.extend(MODx.FormPanel, Ext.FormPanel, {
             this.mask.hide();
         }
         this.fireEvent('postReady');
-        if (parseInt(MODx.config.confirm_navigation, 10) === 1) {
-            const panel = this;
-            window.onbeforeunload = function() {
-                if (panel.isDirty && panel.isDirty()) {
-                    return _('unsaved_changes');
-                }
-            };
+        if (parseInt(MODx.config.confirm_navigation, 10) === 1 && MODx.bindUnsavedBeforeUnload) {
+            MODx.bindUnsavedBeforeUnload();
         }
     },
 

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -97,15 +97,6 @@ Ext.extend(MODx.panel.Resource, MODx.FormPanel, {
                 this.markDirty();
             }
 
-            // Prevent accidental navigation when stuff has not been saved
-            if (parseInt(MODx.config.confirm_navigation, 10) === 1) {
-                const panel = this;
-                window.onbeforeunload = function() {
-                    if (panel.warnUnsavedChanges) {
-                        return _('unsaved_changes');
-                    }
-                };
-            }
         }
         if (MODx.config.use_editor && MODx.loadRTE) {
             /** @todo [1] Where are the load and unload RTE functions defined? They're not found in the core codebase. [2] Appears that this field's value will only ever be undefined or true. */


### PR DESCRIPTION
### What does it do?

Unsaved-change warnings work the same for Resources, Elements, and Files when `confirm_navigation` is on:

1. Browser close/refresh: one `beforeunload` via `MODx.bindUnsavedBeforeUnload()`, checking `hasDirtyContentForm()` (any content form dirty; no field blur required).
2. Left sidebar tab switch: confirm when dirty; after Yes, a one-shot bypass avoids re-prompt loops.
3. Cancel (toolbar redirect): confirm when the form is dirty, then `MODx.loadPage` sets `suppressUnsavedWarning` so the browser does not ask again.

The resource-only `warnUnsavedChanges` beforeunload handler is removed.

### Why is it needed?

Closing or leaving a dirty resource was inconsistent, and Elements/Files did not warn the same way (#16277). That loses work and hurts accessibility.

### How to test

1. Enable **Confirm Navigation with unsaved changes**.
2. Resource: change a field without blurring → refresh/close → warning; switch left tab → Yes once (no loop); Cancel → one confirm then leave; after save → no warning.
3. Chunk/Snippet/Template/Plugin/TV: same for refresh, left tab, Cancel.
4. File create/edit: same.
5. Trash tab still opens trash when already active.

### Related issue(s)/PR(s)

Resolves #16277