### PR TITLE
feat(files): add confirmation dialog before moving files/folders via drag-and-drop

### DIFF
--- a/core/lexicon/en/file.inc.php
+++ b/core/lexicon/en/file.inc.php
@@ -61,6 +61,7 @@ $_lang['file_folder_parent'] = 'Parent Directory';
 $_lang['file_folder_parent_desc'] = 'Relative to the basePath of the media source';
 $_lang['file_folder_remove'] = 'Delete Directory';
 $_lang['file_folder_remove_confirm'] = 'Are you sure you want to delete the directory: "[[+directory]]"?<br />This could potentially break your website.';
+$_lang['file_folder_move_confirm'] = 'Are you sure you want to move "[[+item]]" to "[[+destination]]"? This could break your site if done accidentally.';
 $_lang['file_folder_rename'] = 'Rename Directory';
 $_lang['file_last_accessed'] = 'Last Accessed';
 $_lang['file_last_modified'] = 'Last Modified';

--- a/manager/assets/modext/widgets/system/modx.tree.directory.js
+++ b/manager/assets/modext/widgets/system/modx.tree.directory.js
@@ -342,34 +342,55 @@ Ext.extend(MODx.tree.Directory,MODx.tree.Tree,{
             destSource = dropEvent.tree.source;
         }
 
-        MODx.Ajax.request({
-            url: this.config.url
-            ,params: {
-                source: orgSource
-                ,from: from
-                ,destSource: destSource
-                ,to: to
-                ,action: this.config.sortAction || 'Browser/Directory/Sort'
-                ,point: dropEvent.point
+        const dropNode = dropEvent.dropNode;
+        const targetNode = dropEvent.target;
+        // append → drop into target; above/below → sibling insert under parent folder
+        const destNode = (dropEvent.point === 'append' || !targetNode.parentNode)
+            ? targetNode
+            : targetNode.parentNode;
+        const stripHtml = function(value) {
+            return String(value || '').replace(/(<([^>]+)>)/ig, '');
+        };
+        const itemLabel = Ext.util.Format.htmlEncode(stripHtml(dropNode.attributes.text || dropNode.text));
+        const destLabel = Ext.util.Format.htmlEncode(stripHtml(destNode.attributes.text || destNode.text));
+
+        Ext.Msg.confirm(_('warning'), _('file_folder_move_confirm', {
+            item: itemLabel,
+            destination: destLabel
+        }), function(btn) {
+            if (btn !== 'yes') {
+                this.refresh();
+                return;
             }
-            ,listeners: {
-                'success': {fn:function(r) {
-                    var el = dropEvent.dropNode.getUI().getTextEl();
-                    if (el) {Ext.get(el).frame();}
-                    this.fireEvent('afterSort',{event:dropEvent,result:r});
-                },scope:this}
-                ,'failure': {fn:function(r) {
-                    MODx.form.Handler.errorJSON(r);
-                    this.refresh();
-                    if (r.message != '') {
-                        MODx.msg.alert(_('error'), r.message);
-                    } else if (r.data && r.data[0]) {
-                        MODx.msg.alert(r.data[0]['id'], r.data[0]['msg']);
-                    }
-                    return false;
-                },scope:this}
-            }
-        });
+            MODx.Ajax.request({
+                url: this.config.url
+                ,params: {
+                    source: orgSource
+                    ,from: from
+                    ,destSource: destSource
+                    ,to: to
+                    ,action: this.config.sortAction || 'Browser/Directory/Sort'
+                    ,point: dropEvent.point
+                }
+                ,listeners: {
+                    'success': {fn: function(r) {
+                        const el = dropEvent.dropNode.getUI().getTextEl();
+                        if (el) { Ext.get(el).frame(); }
+                        this.fireEvent('afterSort', {event: dropEvent, result: r});
+                    }, scope: this}
+                    ,'failure': {fn: function(r) {
+                        MODx.form.Handler.errorJSON(r);
+                        this.refresh();
+                        if (r.message !== '') {
+                            MODx.msg.alert(_('error'), r.message);
+                        } else if (r.data && r.data[0]) {
+                            MODx.msg.alert(r.data[0]['id'], r.data[0]['msg']);
+                        }
+                        return false;
+                    }, scope: this}
+                }
+            });
+        }, this);
     }
 
     ,getPath: function(node) {


### PR DESCRIPTION
### What does it do?

Before a drag-and-drop move in the Files tree runs `Browser/Directory/Sort`, the manager asks for confirmation with the item name and destination folder. Choosing No refreshes the tree and skips the request.

For drops `above` / `below` a sibling, the dialog shows the parent folder (actual destination). Labels are HTML-encoded.

### Why is it needed?

An accidental drag (for example `core` into `manager`) can break the site without an obvious reload (#16268).

### How to test

1. Manager → Files.
2. Drag a file/folder onto another folder → confirm shows item and destination → No cancels; Yes moves.
3. Drag above/below a sibling → destination is the parent folder, not the sibling name.

### Related issue(s)/PR(s)

Resolves #16268