### PR TITLE
fix(transport): avoid filesize() on URLs when downloading packages

### DIFF
--- a/_build/test/Tests/Model/Transport/modTransportPackageTest.php
+++ b/_build/test/Tests/Model/Transport/modTransportPackageTest.php
@@ -11,8 +11,55 @@
 */
 namespace MODX\Revolution\Tests\Model\Transport;
 
-
 use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Transport\modTransportPackage;
+use ReflectionMethod;
+
+/**
+ * Stream wrapper for testing getStreamOrFileSize with Content-Length header.
+ */
+class ModTransportPackageTestStreamWrapper
+{
+    public $context;
+    public $wrapper_data;
+    private $position = 0;
+    private $content = '';
+
+    public function stream_open($path, $mode, $options, &$opened_path)
+    {
+        $this->content = 'test';
+        $this->position = 0;
+        $this->wrapper_data = ['Content-Length: 12345'];
+        return true;
+    }
+
+    public function stream_stat()
+    {
+        return [];
+    }
+
+    public function stream_read($count)
+    {
+        $ret = substr($this->content, $this->position, $count);
+        $this->position += strlen($ret);
+        return $ret;
+    }
+
+    public function stream_eof()
+    {
+        return $this->position >= strlen($this->content);
+    }
+
+    public function stream_seek($offset, $whence = SEEK_SET)
+    {
+        return true;
+    }
+
+    public function stream_tell()
+    {
+        return $this->position;
+    }
+}
 
 /**
  * Tests related to the modTransportPackage class.
@@ -23,8 +70,84 @@ use MODX\Revolution\MODxTestCase;
  * @group Transport
  * @group modTransportPackage
  */
-class modTransportPackageTest extends MODxTestCase {
-    public function testExample() {
+class modTransportPackageTest extends MODxTestCase
+{
+    public function testExample()
+    {
         $this->assertTrue(true);
+    }
+
+    /**
+     * Test getReadByteLimit returns positive integer (half of memory_limit).
+     */
+    public function testGetReadByteLimit()
+    {
+        $pkg = $this->modx->newObject(modTransportPackage::class);
+        $method = new ReflectionMethod(modTransportPackage::class, 'getReadByteLimit');
+        $method->setAccessible(true);
+
+        $limit = $method->invoke($pkg);
+        $this->assertIsInt($limit);
+        $this->assertGreaterThan(0, $limit);
+    }
+
+    /**
+     * Test getStreamOrFileSize for local file path returns filesize.
+     */
+    public function testGetStreamOrFileSizeLocalFile()
+    {
+        $tmpFile = tempnam(sys_get_temp_dir(), 'modx_test_');
+        $content = 'test content for filesize';
+        file_put_contents($tmpFile, $content);
+        $expectedSize = strlen($content);
+
+        $pkg = $this->modx->newObject(modTransportPackage::class);
+        $method = new ReflectionMethod(modTransportPackage::class, 'getStreamOrFileSize');
+        $method->setAccessible(true);
+
+        $handle = fopen($tmpFile, 'rb');
+        $size = $method->invoke($pkg, $tmpFile, $handle);
+        fclose($handle);
+        unlink($tmpFile);
+
+        $this->assertSame($expectedSize, $size);
+    }
+
+    /**
+     * Test getStreamOrFileSize for URL source with empty wrapper_data returns null.
+     */
+    public function testGetStreamOrFileSizeUrlEmptyWrapperData()
+    {
+        $pkg = $this->modx->newObject(modTransportPackage::class);
+        $method = new ReflectionMethod(modTransportPackage::class, 'getStreamOrFileSize');
+        $method->setAccessible(true);
+
+        $handle = fopen('php://temp', 'rb');
+        $size = $method->invoke($pkg, 'http://example.com/file.zip', $handle);
+        fclose($handle);
+
+        $this->assertNull($size);
+    }
+
+    /**
+     * Test getStreamOrFileSize for URL source with Content-Length in wrapper_data.
+     */
+    public function testGetStreamOrFileSizeUrlWithContentLength()
+    {
+        if (in_array('modxtest', stream_get_wrappers(), true)) {
+            stream_wrapper_unregister('modxtest');
+        }
+        stream_wrapper_register('modxtest', ModTransportPackageTestStreamWrapper::class);
+
+        $pkg = $this->modx->newObject(modTransportPackage::class);
+        $method = new ReflectionMethod(modTransportPackage::class, 'getStreamOrFileSize');
+        $method->setAccessible(true);
+
+        $handle = fopen('modxtest://file.zip', 'rb');
+        $size = $method->invoke($pkg, 'http://example.com/file.zip', $handle);
+        fclose($handle);
+        stream_wrapper_unregister('modxtest');
+
+        $this->assertSame(12345, $size);
     }
 }

--- a/_build/test/Tests/Model/Transport/modTransportPackageTest.php
+++ b/_build/test/Tests/Model/Transport/modTransportPackageTest.php
@@ -1,4 +1,6 @@
 <?php
+
+// phpcs:disable PSR1.Classes.ClassDeclaration.MultipleClasses -- stream wrapper fixture
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -156,5 +158,16 @@ class modTransportPackageTest extends MODxTestCase
         stream_wrapper_unregister('modxtest');
 
         $this->assertSame(12345, $size);
+    }
+
+    public function testBytesParsesMemoryLimit()
+    {
+        $pkg = $this->modx->newObject(modTransportPackage::class);
+        $method = new ReflectionMethod(modTransportPackage::class, '_bytes');
+        $method->setAccessible(true);
+
+        $this->assertSame(268435456, $method->invoke($pkg, '256M'));
+        $this->assertSame(1024, $method->invoke($pkg, '1K'));
+        $this->assertSame(-1, $method->invoke($pkg, '-1'));
     }
 }

--- a/_build/test/Tests/Model/Transport/modTransportPackageTest.php
+++ b/_build/test/Tests/Model/Transport/modTransportPackageTest.php
@@ -17,6 +17,7 @@ use ReflectionMethod;
 
 /**
  * Stream wrapper for testing getStreamOrFileSize with Content-Length header.
+ * PHP stream wrapper interface requires exact method names: stream_open, stream_read, etc.
  */
 class ModTransportPackageTestStreamWrapper
 {
@@ -25,6 +26,7 @@ class ModTransportPackageTestStreamWrapper
     private $position = 0;
     private $content = '';
 
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- PHP stream wrapper requires exact method name
     public function stream_open($path, $mode, $options, &$opened_path)
     {
         $this->content = 'test';
@@ -33,11 +35,13 @@ class ModTransportPackageTestStreamWrapper
         return true;
     }
 
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- PHP stream wrapper requires exact method name
     public function stream_stat()
     {
         return [];
     }
 
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- PHP stream wrapper requires exact method name
     public function stream_read($count)
     {
         $ret = substr($this->content, $this->position, $count);
@@ -45,16 +49,19 @@ class ModTransportPackageTestStreamWrapper
         return $ret;
     }
 
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- PHP stream wrapper requires exact method name
     public function stream_eof()
     {
         return $this->position >= strlen($this->content);
     }
 
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- PHP stream wrapper requires exact method name
     public function stream_seek($offset, $whence = SEEK_SET)
     {
         return true;
     }
 
+    // phpcs:ignore PSR1.Methods.CamelCapsMethodName.NotCamelCaps -- PHP stream wrapper requires exact method name
     public function stream_tell()
     {
         return $this->position;

--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -754,7 +754,11 @@ class modTransportPackage extends xPDOObject
     protected function getReadByteLimit()
     {
         $memoryLimit = @ ini_get('memory_limit') ?: '8M';
-        return (int) ($this->_bytes($memoryLimit) * .5);
+        $bytes = $this->_bytes($memoryLimit);
+        if ($bytes < 0) {
+            return 64 * 1024 * 1024;
+        }
+        return (int) ($bytes * .5);
     }
 
     /**
@@ -776,8 +780,12 @@ class modTransportPackage extends xPDOObject
         }
         $prefix = self::CONTENT_LENGTH_HEADER;
         $prefixLen = strlen($prefix);
-        foreach ((array) $meta['wrapper_data'] as $header) {
-            if (stripos($header, $prefix) === 0) {
+        $wrapperData = (array) $meta['wrapper_data'];
+        if (isset($wrapperData['wrapper_data'])) {
+            $wrapperData = (array) $wrapperData['wrapper_data'];
+        }
+        foreach ($wrapperData as $header) {
+            if (is_string($header) && stripos($header, $prefix) === 0) {
                 return (int) trim(substr($header, $prefixLen));
             }
         }

--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -431,13 +431,9 @@ class modTransportPackage extends xPDOObject
             $proxyHost = $this->xpdo->getOption('proxy_host', null, '');
             if (ini_get('allow_url_fopen') && empty($proxyHost)) {
                 if ($handle = @ fopen($source, 'rb')) {
-                    $filesize = $this->getStreamOrFileSize($source, $handle);
-                    $byteLimit = $this->getReadByteLimit();
-                    if (!$filesize || $filesize > $byteLimit) {
-                        $content = @ file_get_contents($source);
-                    } else {
-                        $content = @ fread($handle, $filesize);
-                    }
+                    // Always drain the open stream; a single fread()/Content-Length pair can
+                    // truncate HTTP bodies (redirects, chunked, short reads). Avoid filesize() on URLs.
+                    $content = @ stream_get_contents($handle);
                     @ fclose($handle);
                 } else {
                     $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, $this->xpdo->lexicon('package_err_file_read', [
@@ -743,7 +739,25 @@ class modTransportPackage extends xPDOObject
      */
     protected function _bytes($value)
     {
-        return ini_parse_quantity(trim($value));
+        $value = trim((string) $value);
+        if ($value === '' || $value === '-1') {
+            return -1;
+        }
+        // ini_parse_quantity() exists since PHP 8.2; keep a safe fallback for 8.1.
+        if (function_exists('ini_parse_quantity')) {
+            return ini_parse_quantity($value);
+        }
+        if (!preg_match('/^(\d+)\s*([KMG])?$/i', $value, $matches)) {
+            return (int) $value;
+        }
+        $bytes = (int) $matches[1];
+        $modifier = strtoupper($matches[2] ?? '');
+        return match ($modifier) {
+            'G' => $bytes * 1024 * 1024 * 1024,
+            'M' => $bytes * 1024 * 1024,
+            'K' => $bytes * 1024,
+            default => $bytes,
+        };
     }
 
     /**
@@ -784,12 +798,18 @@ class modTransportPackage extends xPDOObject
         if (isset($wrapperData['wrapper_data'])) {
             $wrapperData = (array) $wrapperData['wrapper_data'];
         }
+        $length = null;
         foreach ($wrapperData as $header) {
-            if (is_string($header) && stripos($header, $prefix) === 0) {
-                return (int) trim(substr($header, $prefixLen));
+            if (!is_string($header) || stripos($header, $prefix) !== 0) {
+                continue;
+            }
+            $raw = trim(substr($header, $prefixLen));
+            if ($raw !== '' && ctype_digit($raw)) {
+                // Prefer the last Content-Length (final response after redirects).
+                $length = (int) $raw;
             }
         }
-        return null;
+        return $length;
     }
 
     /**

--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -33,6 +33,8 @@ use xPDO\xPDO;
  */
 class modTransportPackage extends xPDOObject
 {
+    private const CONTENT_LENGTH_HEADER = 'Content-Length:';
+
     /** @var xPDO|modX */
     public $xpdo = null;
     /**
@@ -426,17 +428,12 @@ class modTransportPackage extends xPDOObject
             $source = $this->get('service_url') . $sourceFile . (
                 strpos($sourceFile, '?') !== false ? '&' : '?') . 'revolution_version=' . $productVersion;
 
-            /* see if user has allow_url_fopen on and is not behind a proxy */
             $proxyHost = $this->xpdo->getOption('proxy_host', null, '');
             if (ini_get('allow_url_fopen') && empty($proxyHost)) {
                 if ($handle = @ fopen($source, 'rb')) {
-                    $filesize = @ filesize($source);
-                    $memory_limit = @ ini_get('memory_limit');
-                    if (!$memory_limit) {
-                        $memory_limit = '8M';
-                    }
-                    $byte_limit = $this->_bytes($memory_limit) * .5;
-                    if (strpos($source, '://') !== false || $filesize > $byte_limit) {
+                    $filesize = $this->getStreamOrFileSize($source, $handle);
+                    $byteLimit = $this->getReadByteLimit();
+                    if (!$filesize || $filesize > $byteLimit) {
                         $content = @ file_get_contents($source);
                     } else {
                         $content = @ fread($handle, $filesize);
@@ -747,6 +744,44 @@ class modTransportPackage extends xPDOObject
     protected function _bytes($value)
     {
         return ini_parse_quantity(trim($value));
+    }
+
+    /**
+     * Returns the byte limit for reading a stream into memory (half of memory_limit).
+     *
+     * @return int
+     */
+    protected function getReadByteLimit()
+    {
+        $memoryLimit = @ ini_get('memory_limit') ?: '8M';
+        return (int) ($this->_bytes($memoryLimit) * .5);
+    }
+
+    /**
+     * Returns content length for a stream or local file.
+     * For URLs, reads Content-Length from stream wrapper metadata; for local paths, uses filesize().
+     *
+     * @param string   $source URL or path
+     * @param resource $handle Open stream from fopen
+     * @return int|false|null Size in bytes, false on filesize failure, null when URL has no Content-Length
+     */
+    protected function getStreamOrFileSize($source, $handle)
+    {
+        if (strpos($source, '://') === false) {
+            return @ filesize($source);
+        }
+        $meta = stream_get_meta_data($handle);
+        if (empty($meta['wrapper_data'])) {
+            return null;
+        }
+        $prefix = self::CONTENT_LENGTH_HEADER;
+        $prefixLen = strlen($prefix);
+        foreach ((array) $meta['wrapper_data'] as $header) {
+            if (stripos($header, $prefix) === 0) {
+                return (int) trim(substr($header, $prefixLen));
+            }
+        }
+        return null;
     }
 
     /**


### PR DESCRIPTION
### What does it do?

Package download over `allow_url_fopen` no longer calls `filesize()` on the remote URL (that caused PHP warnings). It reads the already-opened stream with `stream_get_contents()` so short `fread()` / wrong Content-Length cannot truncate the zip.

Helpers remain for tests: `getStreamOrFileSize()` (last numeric Content-Length after redirects) and `getReadByteLimit()`. `_bytes()` uses `ini_parse_quantity()` on PHP 8.2+ and a safe fallback on 8.1.

### Why is it needed?

Downloading extras logged `filesize(): stat failed for https://…` and related warnings (#16068).

### How to test

1. `allow_url_fopen` on, no proxy: install a package from a provider; no filesize warnings; zip installs.
2. `phpunit --filter modTransportPackageTest`

### Related issue(s)/PR(s)

Resolves #16068