### PR TITLE
fix(core): replace deprecated strftime() for PHP 8.1+ compatibility

### DIFF
--- a/core/src/Revolution/File/modFile.php
+++ b/core/src/Revolution/File/modFile.php
@@ -10,6 +10,7 @@
 
 namespace MODX\Revolution\File;
 
+use MODX\Revolution\Util\DateFormatHelper;
 
 /**
  * File implementation of modFileSystemResource
@@ -190,7 +191,7 @@ class modFile extends modFileSystemResource
      */
     public function getLastAccessed($timeFormat = '%b %d, %Y %I:%M:%S %p')
     {
-        return strftime($timeFormat, fileatime($this->path));
+        return DateFormatHelper::format($timeFormat, (int) fileatime($this->path));
     }
 
     /**
@@ -202,7 +203,7 @@ class modFile extends modFileSystemResource
      */
     public function getLastModified($timeFormat = '%b %d, %Y %I:%M:%S %p')
     {
-        return strftime($timeFormat, filemtime($this->path));
+        return DateFormatHelper::format($timeFormat, (int) filemtime($this->path));
     }
 
     /**

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -18,6 +18,7 @@ use MODX\Revolution\modTag;
 use MODX\Revolution\modTemplateVar;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modX;
+use MODX\Revolution\Util\DateFormatHelper;
 
 /**
  * Base output filter implementation for modElement processing, based on phX.
@@ -456,7 +457,7 @@ class modOutputFilter
                             if (($value = filter_var($output, FILTER_VALIDATE_INT)) === false) {
                                 $value = strtotime($output);
                             }
-                            $output = ($value !== false) ? strftime($m_val, $value) : '';
+                            $output = ($value !== false) ? DateFormatHelper::format($m_val, (int) $value) : '';
                             break;
 
                         case 'strtotime':
@@ -479,12 +480,12 @@ class modOutputFilter
                             if (!empty($output)) {
                                 $time = strtotime($output);
                                 if ($time >= strtotime('today')) {
-                                    $output = $this->modx->lexicon('today_at', ['time' => strftime('%I:%M %p', $time)]);
+                                    $output = $this->modx->lexicon('today_at', ['time' => DateFormatHelper::format('%I:%M %p', $time)]);
                                 } elseif ($time >= strtotime('yesterday')) {
                                     $output = $this->modx->lexicon('yesterday_at',
-                                        ['time' => strftime('%I:%M %p', $time)]);
+                                        ['time' => DateFormatHelper::format('%I:%M %p', $time)]);
                                 } else {
-                                    $output = strftime($m_val, $time);
+                                    $output = DateFormatHelper::format($m_val, $time);
                                 }
                             } else {
                                 $output = '&mdash;';

--- a/core/src/Revolution/Processors/Element/TemplateVar/Configs/GetInputPropertyConfigs.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Configs/GetInputPropertyConfigs.php
@@ -15,6 +15,7 @@ use MODX\Revolution\modNamespace;
 use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modTemplateVar;
 use MODX\Revolution\Processors\Element\TemplateVar\Configs\Controllers\TvInputPropertiesManagerController;
+use MODX\Revolution\Util\DateFormatHelper;
 
 /**
  * Grabs a list of input properties for a TV type
@@ -29,7 +30,6 @@ use MODX\Revolution\Processors\Element\TemplateVar\Configs\Controllers\TvInputPr
  */
 class GetInputPropertyConfigs extends Processor
 {
-
     public $propertiesKey = 'input_properties';
     public $configDirectory = 'inputproperties';
     public $onPropertiesListEvent = 'OnTVInputPropertiesList';
@@ -102,21 +102,22 @@ class GetInputPropertyConfigs extends Processor
             'example_6a' => $nextYear . '.03.15',
             'example_6b' => $nextYear . '<span class="deemphasize">\\\.</span>03<span class="deemphasize">\\\.</span>15'
         ];
+        $now = time();
         $this->exampleData['date_format_desc'] = [
             'example_1a' => '%A %d, %B %Y',
-            'example_1b' => strftime('%A %d, %B %Y'),
+            'example_1b' => DateFormatHelper::format('%A %d, %B %Y', $now),
             'example_2a' => '%a, %b %e, %Y',
-            'example_2b' => strftime('%a, %b %e, %Y'),
+            'example_2b' => DateFormatHelper::format('%a, %b %e, %Y', $now),
             'example_3a' => '%m/%d/%Y',
-            'example_3b' => strftime('%m/%d/%Y'),
+            'example_3b' => DateFormatHelper::format('%m/%d/%Y', $now),
             'example_4a' => '%Y-%m-%d',
-            'example_4b' => strftime('%Y-%m-%d'),
+            'example_4b' => DateFormatHelper::format('%Y-%m-%d', $now),
             'example_5a' => '%Y-%m-%d %T',
-            'example_5b' => strftime('%Y-%m-%d %T'),
+            'example_5b' => DateFormatHelper::format('%Y-%m-%d %T', $now),
             'example_6a' => '%b %e, %Y',
-            'example_6b' => strftime('%b %e, %Y'),
+            'example_6b' => DateFormatHelper::format('%b %e, %Y', $now),
             'example_7a' => '%e %h %Y %l:%M %p',
-            'example_7b' => strftime('%e %h %Y %l:%M %p')
+            'example_7b' => DateFormatHelper::format('%e %h %Y %l:%M %p', $now),
         ];
 
         /* Resource list example */

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/date.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/web/output/date.class.php
@@ -38,7 +38,7 @@ class modTemplateVarOutputRenderDate extends modTemplateVarOutputRender {
         }
 
         /* return formatted time */
-        return strftime($params['format'],$timestamp);
+        return \MODX\Revolution\Util\DateFormatHelper::format($params['format'], (int) $timestamp);
     }
 }
 return 'modTemplateVarOutputRenderDate';

--- a/core/src/Revolution/Transport/modTransportProvider.php
+++ b/core/src/Revolution/Transport/modTransportProvider.php
@@ -3,6 +3,7 @@
 namespace MODX\Revolution\Transport;
 
 use MODX\Revolution\modX;
+use MODX\Revolution\Util\DateFormatHelper;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
@@ -364,7 +365,8 @@ class modTransportProvider extends xPDOSimpleObject
             $installed = $this->xpdo->getObject(modTransportPackage::class, (string)$package->signature);
 
             $versionCompiled = rtrim((string)$package->version . '-' . (string)$package->release, '-');
-            $releasedon = strftime($this->arg('dateFormat', $where), strtotime((string)$package->releasedon));
+            $dateFormat = $this->arg('dateFormat', $where);
+            $releasedon = DateFormatHelper::format($dateFormat, (int) strtotime((string) $package->releasedon));
 
             $supports = '';
             foreach ($package->supports as $support) {

--- a/core/src/Revolution/Util/DateFormatHelper.php
+++ b/core/src/Revolution/Util/DateFormatHelper.php
@@ -1,0 +1,132 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MODX\Revolution\Util;
+
+/**
+ * Replaces deprecated strftime() for PHP 8.1+.
+ * Uses IntlDateFormatter when ext-intl is available, otherwise date() with format conversion.
+ */
+class DateFormatHelper
+{
+    /**
+     * Format a timestamp using strftime-style format string.
+     *
+     * @param string   $strftimeFormat Format string (strftime tokens: %Y, %m, %d, etc.)
+     * @param int      $timestamp      Unix timestamp
+     * @param string|null $locale      Locale for IntlDateFormatter (e.g. 'en_US'). Default null uses PHP default.
+     * @return string Formatted date string
+     */
+    public static function format($strftimeFormat, $timestamp, $locale = null)
+    {
+        if (extension_loaded('intl') && class_exists('IntlDateFormatter')) {
+            $icuPattern = self::strftimeToIcuPattern($strftimeFormat);
+            $locale = $locale ?: 'en_US';
+            $formatter = new \IntlDateFormatter(
+                $locale,
+                \IntlDateFormatter::FULL,
+                \IntlDateFormatter::FULL,
+                null,
+                null,
+                $icuPattern
+            );
+            $result = $formatter->format($timestamp);
+            if ($result !== false) {
+                return $result;
+            }
+        }
+        $dateFormat = self::strftimeToDateFormat($strftimeFormat);
+        return date($dateFormat, $timestamp);
+    }
+
+    /**
+     * Convert strftime format to PHP date() format.
+     *
+     * @param string $strftimeFormat
+     * @return string
+     */
+    public static function strftimeToDateFormat($strftimeFormat)
+    {
+        $map = [
+            '%Y' => 'Y',
+            '%y' => 'y',
+            '%m' => 'm',
+            '%d' => 'd',
+            '%H' => 'H',
+            '%I' => 'h',
+            '%M' => 'i',
+            '%S' => 's',
+            '%p' => 'A',
+            '%P' => 'a',
+            '%T' => 'H:i:s',
+            '%F' => 'Y-m-d',
+            '%e' => 'j',
+            '%A' => 'l',
+            '%a' => 'D',
+            '%B' => 'F',
+            '%b' => 'M',
+            '%h' => 'M',
+            '%x' => 'm/d/Y',
+            '%X' => 'H:i:s',
+            '%c' => 'D M j H:i:s Y',
+            '%r' => 'h:i:s A',
+            '%R' => 'H:i',
+            '%D' => 'm/d/y',
+            '%l' => 'g',
+            '%n' => "\n",
+            '%t' => "\t",
+            '%%' => '%',
+        ];
+        return str_replace(array_keys($map), array_values($map), $strftimeFormat);
+    }
+
+    /**
+     * Convert strftime format to ICU date pattern for IntlDateFormatter.
+     *
+     * @param string $strftimeFormat
+     * @return string ICU pattern
+     */
+    private static function strftimeToIcuPattern($strftimeFormat)
+    {
+        $map = [
+            '%Y' => 'yyyy',
+            '%y' => 'yy',
+            '%m' => 'MM',
+            '%d' => 'dd',
+            '%H' => 'HH',
+            '%I' => 'hh',
+            '%M' => 'mm',
+            '%S' => 'ss',
+            '%p' => 'a',
+            '%P' => 'a',
+            '%T' => 'HH:mm:ss',
+            '%F' => 'yyyy-MM-dd',
+            '%e' => 'd',
+            '%A' => 'EEEE',
+            '%a' => 'EEE',
+            '%B' => 'MMMM',
+            '%b' => 'MMM',
+            '%h' => 'MMM',
+            '%x' => 'MM/dd/yyyy',
+            '%X' => 'HH:mm:ss',
+            '%c' => 'EEE MMM d HH:mm:ss yyyy',
+            '%r' => 'hh:mm:ss a',
+            '%R' => 'HH:mm',
+            '%D' => 'MM/dd/yy',
+            '%l' => 'h',
+            '%n' => "\n",
+            '%t' => "\t",
+            '%%' => "'%'",
+        ];
+        $icu = str_replace(array_keys($map), array_values($map), $strftimeFormat);
+        return $icu;
+    }
+}


### PR DESCRIPTION
### What does it do?
Introduces `DateFormatHelper` utility that replaces deprecated `strftime()` calls. When `ext-intl` is available, it uses `IntlDateFormatter` with ICU patterns; otherwise falls back to `date()` with strftime-to-date format conversion. Replaces all `strftime()` usage in:
- `modFile` (getLastAccessed, getLastModified)
- `modOutputFilter` (strftime, date, fuzzydate filters)
- Date TV output render
- `GetInputPropertyConfigs` (date format examples)
- `modTransportProvider` (package release dates)

### Why is it needed?
`strftime()` and `gmstrftime()` are deprecated in PHP 8.1 and removed in PHP 9.0. This causes deprecation warnings and will break on future PHP versions.

### How to test
1. Run on PHP 8.1+ and verify no deprecation warnings for date formatting
2. Test Date TV output with various formats (e.g. `%A %d, %B %Y`, `%Y-%m-%d %T`)
3. Test output filters: strftime, date, fuzzydate on a resource
4. Check file manager: last accessed/modified times
5. Check Package Management: release dates display correctly

### Related issue(s)/PR(s)
Resolves #16017