### PR TITLE
fix(security): Allow username change in Account section

### DIFF
--- a/_build/test/Tests/Processors/Security/Profile/UpdateTest.php
+++ b/_build/test/Tests/Processors/Security/Profile/UpdateTest.php
@@ -1,0 +1,186 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+
+namespace MODX\Revolution\Tests\Processors\Security\Profile;
+
+use MODX\Revolution\modUser;
+use MODX\Revolution\modUserProfile;
+use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Processors\Security\Profile\Update;
+
+/**
+ * Tests for Security/Profile/Update processor (username validation and save).
+ *
+ * @package modx-test
+ * @subpackage Processors
+ * @group Processors
+ * @group Security
+ * @group Profile
+ */
+class UpdateTest extends MODxTestCase
+{
+    /** @var modUser */
+    protected $testUser;
+
+    /** @var modUserProfile */
+    protected $testProfile;
+
+    /** @var modUser */
+    protected $originalUser;
+
+    /** @var string */
+    protected $originalUsername;
+
+    /**
+     * @before
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+        $this->originalUser = $this->modx->user;
+
+        $this->testUser = $this->modx->getObject(modUser::class, 1);
+        if (!$this->testUser || !$this->testUser->getOne('Profile')) {
+            $this->markTestSkipped('Test requires admin user with profile in database');
+        }
+
+        $this->originalUsername = $this->testUser->get('username');
+        $this->testProfile = $this->testUser->getOne('Profile');
+        $this->modx->user = $this->testUser;
+    }
+
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
+    {
+        if ($this->testUser && $this->originalUsername !== null) {
+            $this->testUser->set('username', $this->originalUsername);
+            $this->testUser->save();
+        }
+        if ($this->originalUser) {
+            $this->modx->user = $this->originalUser;
+        }
+        $this->modx->error->reset();
+        parent::tearDownFixtures();
+    }
+
+    /**
+     * @param bool $shouldPass
+     * @param string $username
+     * @dataProvider providerUsernameValidation
+     */
+    public function testUsernameValidation($shouldPass, $username)
+    {
+        $result = $this->modx->runProcessor(Update::class, [
+            'username' => $username,
+            'fullname' => $this->testProfile->get('fullname'),
+            'email' => $this->testProfile->get('email'),
+            'newpassword' => 'false',
+        ]);
+
+        $this->assertNotNull($result, 'Processor did not run');
+        $passed = !$result->isError();
+        $this->assertSame($shouldPass, $passed, $result->getMessage());
+    }
+
+    public function providerUsernameValidation()
+    {
+        return [
+            [false, ''],
+            [false, '  '],
+            [false, 'user<name'],
+            [false, 'user>name'],
+            [false, "user'name"],
+            [false, 'user;name'],
+            [false, 'user"name'],
+            [false, 'user(name)'],
+            [true, 'valid_username'],
+            [true, 'ValidUser123'],
+        ];
+    }
+
+    /**
+     * Rejects username already taken by another user.
+     */
+    public function testUsernameUniqueness()
+    {
+        $takenUsername = 'taken_username_' . time();
+        $otherUser = $this->modx->newObject(modUser::class);
+        $otherUser->fromArray([
+            'username' => $takenUsername,
+            'password' => $this->testUser->get('password'),
+            'cachepwd' => '',
+            'class_key' => modUser::class,
+            'active' => true,
+            'remote_key' => '',
+            'remote_data' => [],
+            'hash_class' => $this->testUser->get('hash_class'),
+            'salt' => $this->testUser->get('salt'),
+            'primary_group' => 1,
+        ], '', true, true);
+        $otherUser->save();
+
+        $profile = $this->modx->newObject(modUserProfile::class);
+        $profile->fromArray([
+            'internalKey' => $otherUser->get('id'),
+            'fullname' => 'Other User',
+            'email' => 'other_' . time() . '@example.com',
+        ], '', true, true);
+        $profile->save();
+
+        $result = $this->modx->runProcessor(Update::class, [
+            'username' => $takenUsername,
+            'fullname' => $this->testProfile->get('fullname'),
+            'email' => $this->testProfile->get('email'),
+            'newpassword' => 'false',
+        ]);
+
+        $profile->remove();
+        $otherUser->remove();
+
+        $this->assertNotNull($result);
+        $this->assertTrue($result->isError(), 'Expected failure when username is taken');
+        $errors = $result->getFieldErrors();
+        $usernameErrors = array_filter($errors, function ($e) {
+            return $e->field === 'username';
+        });
+        $this->assertNotEmpty($usernameErrors, 'Expected username field error');
+    }
+
+    /**
+     * Accepts valid username change and returns updated username in response.
+     */
+    public function testUsernameChangeSuccess()
+    {
+        $newUsername = 'profile_updated_' . time();
+
+        $result = $this->modx->runProcessor(Update::class, [
+            'username' => $newUsername,
+            'fullname' => $this->testProfile->get('fullname'),
+            'email' => $this->testProfile->get('email'),
+            'newpassword' => 'false',
+        ]);
+
+        $this->assertNotNull($result);
+        $this->assertFalse($result->isError(), $result->getMessage());
+
+        $object = $result->getObject();
+        $this->assertArrayHasKey('username', $object);
+        $this->assertSame($newUsername, $object['username']);
+
+        $reloaded = $this->modx->getObject(modUser::class, $this->testUser->get('id'));
+        $this->assertNotNull($reloaded);
+        $this->assertSame($newUsername, $reloaded->get('username'));
+    }
+}

--- a/_build/test/Tests/Processors/Security/Profile/UpdateTest.php
+++ b/_build/test/Tests/Processors/Security/Profile/UpdateTest.php
@@ -107,7 +107,42 @@ class UpdateTest extends MODxTestCase
             [false, 'user(name)'],
             [true, 'valid_username'],
             [true, 'ValidUser123'],
+            [true, str_repeat('a', 100)],
+            [false, str_repeat('a', 101)],
         ];
+    }
+
+    /**
+     * Omitting username keeps the previous profile-update contract (no username error).
+     */
+    public function testUsernameOptionalWhenNotSubmitted()
+    {
+        $result = $this->modx->runProcessor(Update::class, [
+            'fullname' => $this->testProfile->get('fullname'),
+            'email' => $this->testProfile->get('email'),
+            'newpassword' => 'false',
+        ]);
+
+        $this->assertNotNull($result);
+        $this->assertFalse($result->isError(), $result->getMessage());
+        $reloaded = $this->modx->getObject(modUser::class, $this->testUser->get('id'));
+        $this->assertSame($this->originalUsername, $reloaded->get('username'));
+    }
+
+    /**
+     * Submitting the current username must succeed without treating it as a conflict.
+     */
+    public function testUsernameUnchangedAccepted()
+    {
+        $result = $this->modx->runProcessor(Update::class, [
+            'username' => $this->originalUsername,
+            'fullname' => $this->testProfile->get('fullname'),
+            'email' => $this->testProfile->get('email'),
+            'newpassword' => 'false',
+        ]);
+
+        $this->assertNotNull($result);
+        $this->assertFalse($result->isError(), $result->getMessage());
     }
 
     /**
@@ -129,7 +164,7 @@ class UpdateTest extends MODxTestCase
             'salt' => $this->testUser->get('salt'),
             'primary_group' => 1,
         ], '', true, true);
-        $otherUser->save();
+        $this->assertTrue((bool)$otherUser->save(), 'Failed to create competing user');
 
         $profile = $this->modx->newObject(modUserProfile::class);
         $profile->fromArray([
@@ -139,23 +174,33 @@ class UpdateTest extends MODxTestCase
         ], '', true, true);
         $profile->save();
 
-        $result = $this->modx->runProcessor(Update::class, [
-            'username' => $takenUsername,
-            'fullname' => $this->testProfile->get('fullname'),
-            'email' => $this->testProfile->get('email'),
-            'newpassword' => 'false',
-        ]);
+        try {
+            $result = $this->modx->runProcessor(Update::class, [
+                'username' => $takenUsername,
+                'fullname' => $this->testProfile->get('fullname'),
+                'email' => $this->testProfile->get('email'),
+                'newpassword' => 'false',
+            ]);
 
-        $profile->remove();
-        $otherUser->remove();
-
-        $this->assertNotNull($result);
-        $this->assertTrue($result->isError(), 'Expected failure when username is taken');
-        $errors = $result->getFieldErrors();
-        $usernameErrors = array_filter($errors, function ($e) {
-            return $e->field === 'username';
-        });
-        $this->assertNotEmpty($usernameErrors, 'Expected username field error');
+            $this->assertNotNull($result);
+            $this->assertTrue($result->isError(), 'Expected failure when username is taken');
+            $errors = $result->getFieldErrors();
+            $usernameErrors = array_filter($errors, function ($e) {
+                return $e->field === 'username';
+            });
+            $this->assertNotEmpty($usernameErrors, 'Expected username field error');
+        } finally {
+            try {
+                $profile->remove();
+            } catch (\Throwable $e) {
+                // ignore teardown noise from optional logger wiring
+            }
+            try {
+                $otherUser->remove();
+            } catch (\Throwable $e) {
+                // ignore teardown noise from optional logger wiring
+            }
+        }
     }
 
     /**

--- a/_build/test/phpunit.xml
+++ b/_build/test/phpunit.xml
@@ -46,6 +46,7 @@
             <directory>Tests/Processors/Context</directory>
             <directory>Tests/Processors/Element</directory>
             <directory>Tests/Processors/Resource</directory>
+            <directory>Tests/Processors/Security</directory>
         </testsuite>
         <testsuite name="Transport">
             <directory>Tests/Transport</directory>

--- a/core/src/Revolution/Processors/Security/Profile/Update.php
+++ b/core/src/Revolution/Processors/Security/Profile/Update.php
@@ -69,12 +69,19 @@ class Update extends Processor
             return $this->failure($this->modx->lexicon('user_profile_err_save'));
         }
 
+        /* save user if username was changed */
+        if ($this->modx->user->isDirty('username') && $this->modx->user->save() === false) {
+            return $this->failure($this->modx->lexicon('user_profile_err_save'));
+        }
+
         /* log manager action */
         $this->modx->logManagerAction('save_profile', modUser::class, $this->modx->user->get('id'));
 
         /* Change password */
         if ($this->getProperty('newpassword') !== 'false') {
-            if (!$this->modx->user->changePassword($this->getProperty('password_new'), $this->getProperty('password_old'))) {
+            $newPassword = $this->getProperty('password_new');
+            $oldPassword = $this->getProperty('password_old');
+            if (!$this->modx->user->changePassword($newPassword, $oldPassword)) {
                 return $this->failure($this->modx->lexicon('user_err_password_invalid_old'));
             }
 
@@ -85,17 +92,28 @@ class Update extends Processor
             ]));
         }
 
-        return $this->success($this->modx->lexicon('success'), $this->profile->toArray());
+        $data = $this->profile->toArray();
+        $data['username'] = $this->modx->user->get('username');
+
+        return $this->success($this->modx->lexicon('success'), $data);
     }
 
     public function prepare()
     {
         $properties = $this->getProperties();
 
+        /* username is on modUser, not modUserProfile: set on user and exclude from profile */
+        $username = $this->getProperty('username');
+        if ($username !== null && $username !== '' && !$this->hasErrors()) {
+            $this->modx->user->set('username', $username);
+        }
+        unset($properties['username']);
+
         /* format and set data */
         $dob = $this->getProperty('dob');
         if (!empty($dob)) {
-            $date = \DateTimeImmutable::createFromFormat($this->modx->getOption('manager_date_format', null, 'Y-m-d', true), $dob);
+            $dateFormat = $this->modx->getOption('manager_date_format', null, 'Y-m-d', true);
+            $date = \DateTimeImmutable::createFromFormat($dateFormat, $dob);
             if ($date === false) {
                 $this->addFieldError('dob', $this->modx->lexicon('user_err_not_specified_dob'));
             } else {
@@ -108,6 +126,8 @@ class Update extends Processor
 
     public function validate()
     {
+        $this->validateUsername();
+
         if ($this->getProperty('newpassword') !== 'false') {
             $oldPassword = $this->getProperty('password_old');
             $newPassword = $this->getProperty('password_new');
@@ -127,5 +147,39 @@ class Update extends Processor
             }
         }
         return !$this->hasErrors();
+    }
+
+    /**
+     * Validate username format and uniqueness when username is submitted.
+     * Same rules as Security/User Validation::checkUsername.
+     */
+    private function validateUsername()
+    {
+        $username = $this->getProperty('username');
+        if ($username === null || trim((string) $username) === '') {
+            $this->addFieldError('username', $this->modx->lexicon('user_err_not_specified_username'));
+            return;
+        }
+        if (!preg_match('/^[^\'\\x3c\\x3e\\(\\);\\x22]+$/', $username)) {
+            $this->addFieldError('username', $this->modx->lexicon('user_err_username_invalid'));
+            return;
+        }
+        if ($this->usernameAlreadyExists($username)) {
+            $this->addFieldError('username', $this->modx->lexicon('user_err_already_exists'));
+        }
+    }
+
+    /**
+     * Check if username is taken by another user (excluding current user).
+     *
+     * @param string $username
+     * @return bool
+     */
+    private function usernameAlreadyExists($username)
+    {
+        return $this->modx->getCount(modUser::class, [
+            'username' => $username,
+            'id:!=' => $this->modx->user->get('id'),
+        ]) > 0;
     }
 }

--- a/core/src/Revolution/Processors/Security/Profile/Update.php
+++ b/core/src/Revolution/Processors/Security/Profile/Update.php
@@ -14,6 +14,7 @@ namespace MODX\Revolution\Processors\Security\Profile;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserProfile;
 use MODX\Revolution\Processors\Processor;
+use PDOException;
 
 /**
  * Update a user profile
@@ -23,6 +24,8 @@ class Update extends Processor
 {
     /** @var modUserProfile $profile */
     public $profile;
+
+    private const USERNAME_MAX_LENGTH = 100;
 
     /**
      * @return bool
@@ -64,13 +67,45 @@ class Update extends Processor
 
         $this->prepare();
 
-        /* save profile */
-        if ($this->profile->save() === false) {
-            return $this->failure($this->modx->lexicon('user_profile_err_save'));
+        $pdo = $this->modx->pdo;
+        $useTransaction = $pdo instanceof \PDO && $this->modx->user->isDirty('username');
+        if ($useTransaction) {
+            $pdo->beginTransaction();
         }
 
-        /* save user if username was changed */
-        if ($this->modx->user->isDirty('username') && $this->modx->user->save() === false) {
+        try {
+            /* save profile */
+            if ($this->profile->save() === false) {
+                if ($useTransaction) {
+                    $pdo->rollBack();
+                }
+                return $this->failure($this->modx->lexicon('user_profile_err_save'));
+            }
+
+            /* save user if username was changed */
+            if ($this->modx->user->isDirty('username') && $this->modx->user->save() === false) {
+                if ($useTransaction) {
+                    $pdo->rollBack();
+                }
+                if ($this->usernameAlreadyExists((string)$this->modx->user->get('username'))) {
+                    $this->addFieldError('username', $this->modx->lexicon('user_err_already_exists'));
+                    return $this->failure();
+                }
+                return $this->failure($this->modx->lexicon('user_profile_err_save'));
+            }
+
+            if ($useTransaction) {
+                $pdo->commit();
+            }
+        } catch (PDOException $e) {
+            if ($useTransaction && $pdo->inTransaction()) {
+                $pdo->rollBack();
+            }
+            if ($this->isUsernameUniqueViolation($e)) {
+                $this->addFieldError('username', $this->modx->lexicon('user_err_already_exists'));
+                return $this->failure();
+            }
+            $this->modx->log(\xPDO\xPDO::LOG_LEVEL_ERROR, $e->getMessage());
             return $this->failure($this->modx->lexicon('user_profile_err_save'));
         }
 
@@ -103,9 +138,11 @@ class Update extends Processor
         $properties = $this->getProperties();
 
         /* username is on modUser, not modUserProfile: set on user and exclude from profile */
-        $username = $this->getProperty('username');
-        if ($username !== null && $username !== '' && !$this->hasErrors()) {
-            $this->modx->user->set('username', $username);
+        if (array_key_exists('username', $properties) && !$this->hasErrors()) {
+            $username = $properties['username'];
+            if (is_string($username) && $username !== '') {
+                $this->modx->user->set('username', $username);
+            }
         }
         unset($properties['username']);
 
@@ -150,14 +187,22 @@ class Update extends Processor
     }
 
     /**
-     * Validate username format and uniqueness when username is submitted.
-     * Same rules as Security/User Validation::checkUsername.
+     * Validate username when the field is submitted (same rules as User Validation::checkUsername).
      */
     private function validateUsername()
     {
-        $username = $this->getProperty('username');
-        if ($username === null || trim((string) $username) === '') {
+        $properties = $this->getProperties();
+        if (!array_key_exists('username', $properties)) {
+            return;
+        }
+
+        $username = $properties['username'];
+        if (!is_string($username) || trim($username) === '') {
             $this->addFieldError('username', $this->modx->lexicon('user_err_not_specified_username'));
+            return;
+        }
+        if (strlen($username) > self::USERNAME_MAX_LENGTH) {
+            $this->addFieldError('username', $this->modx->lexicon('user_err_username_invalid'));
             return;
         }
         if (!preg_match('/^[^\'\\x3c\\x3e\\(\\);\\x22]+$/', $username)) {
@@ -170,8 +215,6 @@ class Update extends Processor
     }
 
     /**
-     * Check if username is taken by another user (excluding current user).
-     *
      * @param string $username
      * @return bool
      */
@@ -181,5 +224,12 @@ class Update extends Processor
             'username' => $username,
             'id:!=' => $this->modx->user->get('id'),
         ]) > 0;
+    }
+
+    private function isUsernameUniqueViolation(PDOException $e): bool
+    {
+        $message = $e->getMessage();
+        return stripos($message, 'username') !== false
+            && (stripos($message, 'Duplicate') !== false || (string)$e->getCode() === '23000');
     }
 }

--- a/manager/assets/modext/sections/security/profile/update.js
+++ b/manager/assets/modext/sections/security/profile/update.js
@@ -130,7 +130,7 @@ MODx.panel.UpdateProfile = function(config) {
                 ,xtype: 'textfield'
                 ,allowBlank: false
                 ,anchor: '100%'
-                ,maxLength: 255
+                ,maxLength: 100
             },{
                 id: 'modx-user-email'
                 ,name: 'email'

--- a/manager/assets/modext/sections/security/profile/update.js
+++ b/manager/assets/modext/sections/security/profile/update.js
@@ -127,9 +127,10 @@ MODx.panel.UpdateProfile = function(config) {
                 ,name: 'username'
                 ,fieldLabel: _('username')
                 ,description: _('user_username_desc')
-                ,xtype: 'statictextfield'
+                ,xtype: 'textfield'
                 ,allowBlank: false
                 ,anchor: '100%'
+                ,maxLength: 255
             },{
                 id: 'modx-user-email'
                 ,name: 'email'


### PR DESCRIPTION
### What does it do?

Makes the username field editable in Security → Profile → Account (`textfield`, max 100 chars). `Security/Profile/Update` validates format and uniqueness (same character rules as user admin), writes the value on `modUser`, and returns `username` in the success payload.

Username is validated only when the request includes that property, so older clients that omit it still update the profile. When the username changes, profile and user saves run in a DB transaction.

### Why is it needed?

The Account username was shown as read-only after #15539, so users could not rename themselves from Profile (#15575).

### How to test

1. Manager → your Profile → Account: change username and save; header/session should show the new name.
2. Empty / invalid characters (`<>;'\"()`) / taken name → field errors.
3. Omit username in a connector call → profile fields still save; username unchanged.
4. `phpunit --filter 'Processors\\Security\\Profile\\UpdateTest'`

### Related issue(s)/PR(s)

Resolves #15575