### PR TITLE
fix(core): re-init session and culture in switchContext

### DIFF
--- a/_build/test/Tests/Model/modXSwitchContextCultureTest.php
+++ b/_build/test/Tests/Model/modXSwitchContextCultureTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+
+namespace MODX\Revolution\Tests\Model;
+
+use MODX\Revolution\modContextSetting;
+use MODX\Revolution\MODxTestCase;
+
+/**
+ * Regression for culture re-init inside switchContext (#14962).
+ *
+ * @group Model
+ * @group modX
+ */
+class modXSwitchContextCultureTest extends MODxTestCase
+{
+    public function testSwitchContextReturnsFalseWhenContextMissing()
+    {
+        $previous = $this->modx->context;
+        $this->modx->context = null;
+        try {
+            $this->assertFalse($this->modx->switchContext('web'));
+        } finally {
+            $this->modx->context = $previous;
+        }
+    }
+
+    public function testSwitchContextReinitializesCultureKey()
+    {
+        $originalKey = $this->modx->context->get('key');
+        $targetKey = ($originalKey === 'web') ? 'mgr' : 'web';
+
+        $setting = $this->modx->getObject(modContextSetting::class, [
+            'context_key' => $targetKey,
+            'key' => 'cultureKey',
+        ]);
+        $created = false;
+        if (!$setting) {
+            $setting = $this->modx->newObject(modContextSetting::class);
+            $setting->fromArray([
+                'context_key' => $targetKey,
+                'key' => 'cultureKey',
+                'value' => 'de',
+                'xtype' => 'textfield',
+                'namespace' => 'core',
+                'area' => 'language',
+            ], '', true);
+            $this->assertTrue((bool)$setting->save());
+            $created = true;
+        }
+        $previousValue = $setting->get('value');
+        $setting->set('value', 'de');
+        $setting->save();
+
+        // Avoid session/request overrides masking the context cultureKey.
+        unset($_SESSION['cultureKey'], $_REQUEST['cultureKey']);
+
+        try {
+            $switched = $this->modx->switchContext($targetKey, true);
+            $this->assertTrue($switched, 'Expected switchContext to succeed');
+            $this->assertSame('de', $this->modx->cultureKey);
+            $this->assertSame('de', $this->modx->getOption('cultureKey'));
+        } finally {
+            $this->modx->switchContext($originalKey, true);
+            if ($created) {
+                $setting->remove();
+            } else {
+                $setting->set('value', $previousValue);
+                $setting->save();
+            }
+        }
+    }
+}

--- a/_build/test/phpunit.xml
+++ b/_build/test/phpunit.xml
@@ -18,6 +18,7 @@
         </testsuite>
         <testsuite name="Model">
             <file>Tests/Model/modXTest.php</file>
+            <file>Tests/Model/modXSwitchContextCultureTest.php</file>
             <file>Tests/Model/modXLoggingTest.php</file>
             <file>Tests/Model/modParserTest.php</file>
             <directory>Tests/Model/Dashboard</directory>

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2135,12 +2135,16 @@ class modX extends xPDO {
      */
     public function switchContext($contextKey, $reload = false) {
         $switched= false;
+        if ($this->context === null) {
+            return $switched;
+        }
         if ($this->context->key != $contextKey) {
             $switched= $this->_initContext($contextKey, $reload);
             if ($switched) {
                 if (is_array($this->config)) {
                     $this->setPlaceholders($this->config, '+');
                 }
+                $this->_initCulture(null);
             }
         }
         return $switched;

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2133,17 +2133,24 @@ class modX extends xPDO {
      * before being switched to.
      * @return boolean True if the switch was successful, otherwise false.
      */
-    public function switchContext($contextKey, $reload = false) {
-        $switched= false;
+    public function switchContext($contextKey, $reload = false)
+    {
+        $switched = false;
         if ($this->context === null) {
             return $switched;
         }
         if ($this->context->key != $contextKey) {
-            $switched= $this->_initContext($contextKey, $reload);
+            $switched = $this->_initContext($contextKey, $reload);
             if ($switched) {
                 if (is_array($this->config)) {
                     $this->setPlaceholders($this->config, '+');
                 }
+                /*
+                 * Reconcile session/culture for the new context options without
+                 * exposing public initSession/initCulture (see #14962 / opengeek).
+                 * _initSession is a no-op when a session is already active.
+                 */
+                $this->_initSession(null);
                 $this->_initCulture(null);
             }
         }


### PR DESCRIPTION
### What does it do?

After a successful `switchContext()`, MODX calls `_initSession(null)` then `_initCulture(null)` so the new context’s `cultureKey` / locale (and session options when a session is not already active) take effect.

Also returns `false` when `$this->context` is null instead of fatalling on `->key`.

Does **not** expose public `initCulture()` / `initSession()` — that was rejected in review; session switching mid-request is still discouraged, and `_initSession` remains a no-op when a session is already initialized.

### Why is it needed?

Context-routing plugins call `switchContext()` after the original init path. Without re-init, lexicon/locale (and sometimes session enablement via context settings) stay on the previous context (#14962).

### How to test

1. Two contexts with different `cultureKey` (e.g. `en` / `de`).
2. From a request on one context, `$modx->switchContext('other', true)` → `$modx->cultureKey` and lexicon match the target.
3. `phpunit --filter modXSwitchContextCultureTest`

### Related issue(s)/PR(s)

Resolves #14962