### PR TITLE
fix(system): Correct issues with data formatting in database tables grid

### DIFF
--- a/core/lexicon/en/system_info.inc.php
+++ b/core/lexicon/en/system_info.inc.php
@@ -28,7 +28,7 @@ $_lang['database_table_totalsize'] = 'Total size';
 $_lang['database_table_totals'] = 'Totals:';
 $_lang['database_type'] = 'Database type';
 $_lang['database_version'] = 'Database version';
-$_lang['database_query_err_dbname_empty'] = 'Query for current database name returned an empty value.';
+$_lang['database_dbname_err_empty'] = 'Can not query current database because the cached name used to access it is empty.';
 $_lang['database_query_err_table_stat'] = 'Query for TABLE STATUS from [[+db]] returned a null result.';
 $_lang['extjs_version'] = '<a href="http://extjs.com/" target="_blank">ExtJS</a> Version';
 $_lang['localtime'] = 'Local Time';

--- a/core/lexicon/en/system_info.inc.php
+++ b/core/lexicon/en/system_info.inc.php
@@ -28,6 +28,8 @@ $_lang['database_table_totalsize'] = 'Total size';
 $_lang['database_table_totals'] = 'Totals:';
 $_lang['database_type'] = 'Database type';
 $_lang['database_version'] = 'Database version';
+$_lang['database_query_err_dbname_empty'] = 'Query for current database name returned an empty value.';
+$_lang['database_query_err_table_stat'] = 'Query for TABLE STATUS from [[+db]] returned a null result.';
 $_lang['extjs_version'] = '<a href="http://extjs.com/" target="_blank">ExtJS</a> Version';
 $_lang['localtime'] = 'Local Time';
 $_lang['magpie_version'] = '<a href="http://magpierss.sourceforge.net/" target="_blank">MagpieRSS</a> Version';

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -71,6 +71,7 @@ public function getTables(): array
         $dataLength = (int) $row['Data_length'];
         $dataFree = (int) $row['Data_free'];
         $indexLength = (int) $row['Index_length'];
+$dataSize = $dataLength + $dataFree;
 
         $row['Data_size'] = $this->formatSize($dataSize);
         $row['Effective_size'] = $this->formatSize(abs($dataLength - $dataFree));

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -68,7 +68,6 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
         $dataLength = (int) $row['Data_length'];
         $dataFree = (int) $row['Data_free'];
         $indexLength = (int) $row['Index_length'];
-        $dataSize = $dataLength + $dataFree;
 
         $row['Data_size'] = $this->formatSize($dataSize);
         $row['Effective_size'] = $this->formatSize(abs($dataLength - $dataFree));

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -87,10 +87,8 @@ public function getTables(): array
 
     /**
      * Current database name from connection (MySQL 8–compatible), fallback to config.
-     *
-     * @return string|null
      */
-    protected function getDatabaseName()
+    protected function getDatabaseName(): ?string
     {
         try {
             $stmt = $this->modx->query('SELECT DATABASE()');

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -69,9 +69,9 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
         $dataFree = (int) $row['Data_free'];
         $indexLength = (int) $row['Index_length'];
 
-        $row['Data_size'] = $this->formatSize($dataSize);
-        $row['Effective_size'] = $this->formatSize(abs($dataLength - $dataFree));
-        $row['Total_size'] = $this->formatSize($indexLength + $dataSize);
+        $row['Data_size'] = $this->formatSize($dataLength);
+        $row['Effective_size'] = $this->formatSize($dataLength + $indexLength);
+        $row['Total_size'] = $this->formatSize($dataLength + $indexLength);
         $row['Data_length'] = $this->formatSize($dataLength);
         $row['Data_free'] = $this->formatSize($dataFree);
         $row['Index_length'] = $this->formatSize($indexLength);

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -84,24 +84,4 @@ public function getTables(): array
         return $row;
     }
 
-    /**
-     * Current database name from connection (MySQL 8–compatible), fallback to config.
-     */
-    protected function getDatabaseName(): ?string
-    {
-        try {
-            $stmt = $this->modx->query('SELECT DATABASE()');
-            if ($stmt !== false) {
-                $name = $stmt->fetchColumn();
-                if ($name !== false && $name !== null && $name !== '') {
-                    return $name;
-                }
-            }
-        } catch (\Throwable $e) {
-            // use config fallback
-        }
-
-        $name = (string) $this->modx->getOption('dbname');
-        return $name !== '' ? $name : null;
-    }
 }

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -47,7 +47,7 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
             $tables[] = $this->formatTableRow($row, $canManageSettings, $managerLogTable);
         }
 
-        return $dt;
+        return $tables;
     }
 
     /**

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -59,7 +59,13 @@ public function getTables(): array
      * @param string $managerLogTable
      * @return array
      */
-    protected function formatTableRow(array $row, bool $canManageSettings, string $managerLogTable)
+    /**
+     * Calculates and formats a table's status-related attributes
+     * @param array $row The collection of table data being formatted
+     * @param bool $canManageSettings Whether the current user has permissions to manipulate table data
+     * @param string $managerLogTable The name, including prefix, of the table containing the manager logs
+     */
+    protected function formatTableRow(array $row, bool $canManageSettings, string $managerLogTable): array
     {
         $dataLength = (int) $row['Data_length'];
         $dataFree = (int) $row['Data_free'];

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -54,12 +54,6 @@ public function getTables(): array
     }
 
     /**
-     * @param array  $row
-     * @param bool   $canManageSettings
-     * @param string $managerLogTable
-     * @return array
-     */
-    /**
      * Calculates and formats a table's status-related attributes
      * @param array $row The collection of table data being formatted
      * @param bool $canManageSettings Whether the current user has permissions to manipulate table data

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -63,10 +63,10 @@ public function getTables(): array
     /**
      * Calculates and formats a table's status-related attributes
      * @param array $row The collection of table data being formatted
-     * @param bool $canManageSettings Whether the current user has permissions to manipulate table data
-     * @param string $managerLogTable The name, including prefix, of the table containing the manager logs
+     * @param array $permissions The current user's permissions to manipulate table data
+     * @param array $truncateWhitelist A list of tables that are candidates for truncation
      */
-    protected function formatTableRow(array $row, bool $canManageSettings, string $managerLogTable): array
+    protected function formatTableRow(array $row, array $permissions, array $truncateWhitelist): array
     {
         $dataLength = (int) $row['Data_length'];
         $dataFree = (int) $row['Data_free'];

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -10,6 +10,7 @@
 
 namespace MODX\Revolution\Processors\System\DatabaseTable\mysql;
 
+use MODX\Revolution\modX;
 use PDO;
 use xPDO\Om\xPDOCriteria;
 
@@ -26,11 +27,15 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
     {
         $dbName = $this->getDatabaseName();
         if ($dbName === null || $dbName === '') {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, '[DatabaseTable/GetList] Could not determine database name');
             return [];
         }
 
         $c = new xPDOCriteria($this->modx,
             'SHOW TABLE STATUS FROM ' . $this->modx->escape($dbName));
+        if ($c->stmt === null) {
+            return [];
+        }
         $c->stmt->execute();
 
         $canManageSettings = $this->modx->hasPermission('settings');
@@ -50,7 +55,7 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
      * @param string $managerLogTable
      * @return array
      */
-    private function formatTableRow(array $row, bool $canManageSettings, string $managerLogTable)
+    protected function formatTableRow(array $row, bool $canManageSettings, string $managerLogTable)
     {
         $dataLength = (int) $row['Data_length'];
         $dataFree = (int) $row['Data_free'];
@@ -75,7 +80,7 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
      *
      * @return string|null
      */
-    private function getDatabaseName()
+    protected function getDatabaseName()
     {
         try {
             $stmt = $this->modx->query('SELECT DATABASE()');
@@ -89,6 +94,7 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
             // use config fallback
         }
 
-        return $this->modx->getOption('dbname');
+        $name = (string) $this->modx->getOption('dbname');
+        return $name !== '' ? $name : null;
     }
 }

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -75,7 +75,7 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
         $row['Data_length'] = $this->formatSize($dataLength);
         $row['Data_free'] = $this->formatSize($dataFree);
         $row['Index_length'] = $this->formatSize($indexLength);
-        $row['canTruncate'] = $permissions['canTruncate'] && in_array($row['Name'], $truncateWhitelist) && $dataSize > 0;
+        $row['canTruncate'] = $permissions['canTruncate'] && in_array($row['Name'], $truncateWhitelist) && $dataLength > 0;
         $row['canOptimize'] = $permissions['canOptimize'] && $dataFree > 0;
 
         return $row;

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -21,12 +22,9 @@ use xPDO\Om\xPDOCriteria;
 class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAbstract
 {
     /**
-     * @return array
+     * Fetch the status data for every table in the current database
      */
-/**
-    * Fetch the status data for every table in the current database
-    */
-public function getTables(): array
+    public function getTables(): array
     {
         $dbName = $this->modx->getOption('dbname');
         if (!$dbName) {
@@ -34,8 +32,7 @@ public function getTables(): array
             return [];
         }
 
-        $c = new xPDOCriteria($this->modx,
-            'SHOW TABLE STATUS FROM ' . $this->modx->escape($dbName));
+        $c = new xPDOCriteria($this->modx, 'SHOW TABLE STATUS FROM ' . $this->modx->escape($dbName));
         if ($c->stmt === null) {
             $this->modx->log(modX::LOG_LEVEL_ERROR, $this->modx->lexicon('database_query_err_table_stat', ['db' => $dbName]));
             return [];
@@ -71,7 +68,7 @@ public function getTables(): array
         $dataLength = (int) $row['Data_length'];
         $dataFree = (int) $row['Data_free'];
         $indexLength = (int) $row['Index_length'];
-$dataSize = $dataLength + $dataFree;
+        $dataSize = $dataLength + $dataFree;
 
         $row['Data_size'] = $this->formatSize($dataSize);
         $row['Effective_size'] = $this->formatSize(abs($dataLength - $dataFree));
@@ -84,5 +81,4 @@ $dataSize = $dataLength + $dataFree;
 
         return $row;
     }
-
 }

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -54,7 +54,7 @@ public function getTables(): array
         $tables = [];
 
         while ($row = $c->stmt->fetch(PDO::FETCH_ASSOC)) {
-            $tables[] = $this->formatTableRow($row, $canManageSettings, $managerLogTable);
+            $tables[] = $this->formatTableRow($row, $permissions, $truncateWhitelist);
         }
 
         return $tables;

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -42,8 +42,15 @@ public function getTables(): array
         }
         $c->stmt->execute();
 
-        $canManageSettings = $this->modx->hasPermission('settings');
-        $managerLogTable = $this->modx->getOption('table_prefix') . 'manager_log';
+        $tablePrefix = $this->modx->getOption('table_prefix');
+        $permissions = [
+            'canTruncate' => $this->modx->hasPermission('database_truncate'),
+            'canOptimize' => $this->modx->hasPermission('settings')
+        ];
+        $truncateWhitelist = array_map(fn(string $table): string => $tablePrefix . $table, [
+            // Add un-prefixed table names that are candidates for truncation to this array
+            'manager_log'
+        ]);
         $tables = [];
 
         while ($row = $c->stmt->fetch(PDO::FETCH_ASSOC)) {

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -24,24 +24,71 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
      */
     public function getTables()
     {
-        $c = new xPDOCriteria($this->modx,
-            'SHOW TABLE STATUS FROM ' . $this->modx->escape($this->modx->getOption('dbname')));
-        $c->stmt->execute();
-        $dt = [];
-        while ($row = $c->stmt->fetch(PDO::FETCH_ASSOC)) {
-            /* calculations first */
-            $row['canTruncate'] = $this->modx->hasPermission('settings') && $row['Name'] === $this->modx->getOption('table_prefix') . 'manager_log' && $row['Data_length'] + $row['Data_free'] > 0 ? true : false ;
-            $row['Data_size'] = $this->formatSize($row['Data_length'] + $row['Data_free']);
-            $row['Effective_size'] = $this->formatSize($row['Data_length'] - $row['Data_free']);
-            $row['Total_size'] = $this->formatSize($row['Index_length'] + $row['Data_length'] + $row['Data_free']);
-
-            /* now the non-calculated fields */
-            $row['Data_length'] = $this->formatSize($row['Data_length']);
-            $row['Data_free'] = $this->formatSize($row['Data_free']);
-            $row['canOptimize'] = $this->modx->hasPermission('settings') && $row['Data_free'] > 0 ? true : false ;
-            $row['Index_length'] = $this->formatSize($row['Index_length']);
-            $dt[] = $row;
+        $dbName = $this->getDatabaseName();
+        if ($dbName === null || $dbName === '') {
+            return [];
         }
+
+        $c = new xPDOCriteria($this->modx,
+            'SHOW TABLE STATUS FROM ' . $this->modx->escape($dbName));
+        $c->stmt->execute();
+
+        $canManageSettings = $this->modx->hasPermission('settings');
+        $managerLogTable = $this->modx->getOption('table_prefix') . 'manager_log';
+        $dt = [];
+
+        while ($row = $c->stmt->fetch(PDO::FETCH_ASSOC)) {
+            $dt[] = $this->formatTableRow($row, $canManageSettings, $managerLogTable);
+        }
+
         return $dt;
+    }
+
+    /**
+     * @param array  $row
+     * @param bool   $canManageSettings
+     * @param string $managerLogTable
+     * @return array
+     */
+    private function formatTableRow(array $row, bool $canManageSettings, string $managerLogTable)
+    {
+        $dataLength = (int) $row['Data_length'];
+        $dataFree = (int) $row['Data_free'];
+        $indexLength = (int) $row['Index_length'];
+
+        $row['canTruncate'] = $canManageSettings
+            && $row['Name'] === $managerLogTable
+            && $dataLength + $dataFree > 0;
+        $row['Data_size'] = $this->formatSize($dataLength + $dataFree);
+        $row['Effective_size'] = $this->formatSize(max(0, $dataLength - $dataFree));
+        $row['Total_size'] = $this->formatSize($indexLength + $dataLength + $dataFree);
+        $row['Data_length'] = $this->formatSize($dataLength);
+        $row['Data_free'] = $this->formatSize($dataFree);
+        $row['canOptimize'] = $canManageSettings && $dataFree > 0;
+        $row['Index_length'] = $this->formatSize($indexLength);
+
+        return $row;
+    }
+
+    /**
+     * Current database name from connection (MySQL 8–compatible), fallback to config.
+     *
+     * @return string|null
+     */
+    private function getDatabaseName()
+    {
+        try {
+            $stmt = $this->modx->query('SELECT DATABASE()');
+            if ($stmt !== false) {
+                $name = $stmt->fetchColumn();
+                if ($name !== false && $name !== null && $name !== '') {
+                    return $name;
+                }
+            }
+        } catch (\Throwable $e) {
+            // use config fallback
+        }
+
+        return $this->modx->getOption('dbname');
     }
 }

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -28,9 +28,9 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
     */
 public function getTables(): array
     {
-        $dbName = $this->getDatabaseName();
-        if ($dbName === null || $dbName === '') {
-            $this->modx->log(modX::LOG_LEVEL_ERROR, $this->modx->lexicon('database_query_err_dbname_empty'));
+        $dbName = $this->modx->getOption('dbname');
+        if (!$dbName) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, $this->modx->lexicon('database_dbname_err_empty'));
             return [];
         }
 

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -44,7 +44,7 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
         $tables = [];
 
         while ($row = $c->stmt->fetch(PDO::FETCH_ASSOC)) {
-            $dt[] = $this->formatTableRow($row, $canManageSettings, $managerLogTable);
+            $tables[] = $this->formatTableRow($row, $canManageSettings, $managerLogTable);
         }
 
         return $dt;

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -23,7 +23,10 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
     /**
      * @return array
      */
-    public function getTables()
+/**
+    * Fetch the status data for every table in the current database
+    */
+public function getTables(): array
     {
         $dbName = $this->getDatabaseName();
         if ($dbName === null || $dbName === '') {

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -27,7 +27,7 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
     {
         $dbName = $this->getDatabaseName();
         if ($dbName === null || $dbName === '') {
-            $this->modx->log(modX::LOG_LEVEL_ERROR, '[DatabaseTable/GetList] Could not determine database name');
+            $this->modx->log(modX::LOG_LEVEL_ERROR, $this->modx->lexicon('database_query_err_dbname_empty'));
             return [];
         }
 

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -72,16 +72,14 @@ public function getTables(): array
         $dataFree = (int) $row['Data_free'];
         $indexLength = (int) $row['Index_length'];
 
-        $row['canTruncate'] = $canManageSettings
-            && $row['Name'] === $managerLogTable
-            && $dataLength + $dataFree > 0;
-        $row['Data_size'] = $this->formatSize($dataLength + $dataFree);
-        $row['Effective_size'] = $this->formatSize(max(0, $dataLength - $dataFree));
-        $row['Total_size'] = $this->formatSize($indexLength + $dataLength + $dataFree);
+        $row['Data_size'] = $this->formatSize($dataSize);
+        $row['Effective_size'] = $this->formatSize(abs($dataLength - $dataFree));
+        $row['Total_size'] = $this->formatSize($indexLength + $dataSize);
         $row['Data_length'] = $this->formatSize($dataLength);
         $row['Data_free'] = $this->formatSize($dataFree);
-        $row['canOptimize'] = $canManageSettings && $dataFree > 0;
         $row['Index_length'] = $this->formatSize($indexLength);
+        $row['canTruncate'] = $permissions['canTruncate'] && in_array($row['Name'], $truncateWhitelist) && $dataSize > 0;
+        $row['canOptimize'] = $permissions['canOptimize'] && $dataFree > 0;
 
         return $row;
     }

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -34,6 +34,7 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
         $c = new xPDOCriteria($this->modx,
             'SHOW TABLE STATUS FROM ' . $this->modx->escape($dbName));
         if ($c->stmt === null) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, $this->modx->lexicon('database_query_err_table_stat', ['db' => $dbName]));
             return [];
         }
         $c->stmt->execute();

--- a/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
+++ b/core/src/Revolution/Processors/System/DatabaseTable/mysql/GetList.php
@@ -41,7 +41,7 @@ class GetList extends \MODX\Revolution\Processors\System\DatabaseTable\GetListAb
 
         $canManageSettings = $this->modx->hasPermission('settings');
         $managerLogTable = $this->modx->getOption('table_prefix') . 'manager_log';
-        $dt = [];
+        $tables = [];
 
         while ($row = $c->stmt->fetch(PDO::FETCH_ASSOC)) {
             $dt[] = $this->formatTableRow($row, $canManageSettings, $managerLogTable);


### PR DESCRIPTION
### What does it do?
- Casts `Data_length` / `Data_free` / `Index_length` to int before size math (MySQL 8 can return NULL)
- Uses raw sizes for optimize/truncate eligibility; truncate UI matches `database_truncate`
- Logs and returns empty when the name or `SHOW TABLE STATUS` statement is missing

### Why is it needed?
On MySQL 8 the Database Tables grid can come back empty when config `dbname` is blank, and NULL size columns break the old arithmetic and the optimize link.

### How to test
1. Open **Reports → System Information → Database Tables**
2. Confirm tables list with sizes
3. Confirm Optimize only when overhead (`Data_free > 0`)
4. Confirm Truncate only on `manager_log` with `database_truncate`

### Related issue(s)/PR(s)
Resolves #14976