### PR TITLE
fix(packages): handle corrupted package zip gracefully

### DIFF
--- a/_build/test/Tests/Processors/Workspace/Packages/InstallErrorHandlingTest.php
+++ b/_build/test/Tests/Processors/Workspace/Packages/InstallErrorHandlingTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+
+namespace MODX\Revolution\Tests\Processors\Workspace\Packages;
+
+use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Processors\Workspace\Packages\Install;
+
+/**
+ * Contract for corrupted package zip error handling (#16454).
+ *
+ * @group Processors
+ * @group Workspace
+ */
+class InstallErrorHandlingTest extends MODxTestCase
+{
+    public function testInstallProcessorMapsZipErrorsToLexicon()
+    {
+        $installSource = file_get_contents(MODX_CORE_PATH . 'src/Revolution/Processors/Workspace/Packages/Install.php');
+        $this->assertStringContainsString('catch (\\Throwable $e)', $installSource);
+        $this->assertStringContainsString('getInstallErrorMessage', $installSource);
+        $this->assertStringContainsString('package_err_zip_invalid', $installSource);
+        $this->assertStringContainsString('instanceof \\ValueError', $installSource);
+
+        $lexicon = file_get_contents(MODX_CORE_PATH . 'lexicon/en/workspace.inc.php');
+        $this->assertStringContainsString('package_err_zip_invalid', $lexicon);
+
+        $transportSource = file_get_contents(MODX_CORE_PATH . 'src/Revolution/Transport/modTransportPackage.php');
+        $this->assertMatchesRegularExpression(
+            '/xPDOTransport::retrieve\([^;]+\);/',
+            $transportSource,
+            'getTransport() should call xPDOTransport::retrieve() without swallowing exceptions'
+        );
+        $this->assertStringNotContainsString(
+            "try {\n                            \$this->package = xPDOTransport::retrieve",
+            $transportSource
+        );
+    }
+
+    public function testGetInstallErrorMessageMapsValueErrorToZipLexicon()
+    {
+        $processor = new Install($this->modx);
+        $method = new \ReflectionMethod(Install::class, 'getInstallErrorMessage');
+        $method->setAccessible(true);
+
+        $zipMessage = $method->invoke($processor, new \ValueError('Invalid or uninitialized Zip object'));
+        $this->assertSame($this->modx->lexicon('package_err_zip_invalid'), $zipMessage);
+
+        $genericMessage = $method->invoke($processor, new \RuntimeException('Something else failed'));
+        $this->assertSame($this->modx->lexicon('package_err_install_gen'), $genericMessage);
+    }
+}

--- a/core/lexicon/en/workspace.inc.php
+++ b/core/lexicon/en/workspace.inc.php
@@ -81,6 +81,7 @@ $_lang['package_err_file_read'] = 'Could not open file for reading: [[+source]]'
 $_lang['package_err_caught'] = 'Install failed with [[+type]] in [[+in]]: [[+message]]';
 $_lang['package_err_install'] = 'Could not install package with signature: [[+signature]]';
 $_lang['package_err_install_gen'] = 'Failed to install the package.';
+$_lang['package_err_zip_invalid'] = 'The package file is corrupted or invalid. Please try downloading the package again.';
 $_lang['package_err_load'] = 'Could not load transport package.';
 $_lang['package_err_nf'] = 'Package not found.';
 $_lang['package_err_nfs'] = 'Could not retrieve package with signature: [[+signature]].';

--- a/core/src/Revolution/Processors/Workspace/Packages/Install.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Install.php
@@ -70,7 +70,13 @@ class Install extends Processor
     {
         $this->modx->log(xPDO::LOG_LEVEL_INFO, $this->modx->lexicon('package_install_info_found'));
 
-        $installed = $this->package->install($this->getProperties());
+        try {
+            $installed = $this->package->install($this->getProperties());
+        } catch (\Throwable $e) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, $e->getMessage());
+            $this->modx->log(modX::LOG_LEVEL_INFO, 'COMPLETED');
+            return $this->failure($this->getInstallErrorMessage($e));
+        }
 
         $this->clearCache();
 
@@ -100,5 +106,17 @@ class Install extends Processor
             $this->modx->getOption('cache_packages_key', null, 'packages') => [],
         ]);
         $this->modx->cacheManager->refresh();
+    }
+
+    /**
+     * Returns a user-facing message for a failed install exception.
+     */
+    private function getInstallErrorMessage(\Throwable $e): string
+    {
+        $isZipError = $e instanceof \ValueError
+            || stripos($e->getMessage(), 'zip') !== false;
+        return $isZipError
+            ? $this->modx->lexicon('package_err_zip_invalid')
+            : $this->modx->lexicon('package_err_install_gen');
     }
 }


### PR DESCRIPTION
### What
Install processor catches install failures and returns a user-facing error instead of leaving the manager modal stuck on a fatal `ValueError` from a corrupted `.transport.zip`.

### Why
Truncated or corrupted package zips triggered an uncaught PHP 8 `ValueError` during install with no feedback in the UI.

### How
- Wrap `$this->package->install()` in `Install` with `try/catch (\Throwable)` and map zip/`ValueError` to `package_err_zip_invalid`.
- Add the English lexicon entry for the corrupted zip message.
- Leave `modTransportPackage::getTransport()` without a try/catch so retrieve errors propagate to the Install processor.
- Add a small processor contract test for the error mapping.

### Related
Resolves #16454