### PR TITLE
docs(cache): clarify why context metadata is excluded from generateContext (#15653)

### DIFF
--- a/core/src/Revolution/modCacheManager.php
+++ b/core/src/Revolution/modCacheManager.php
@@ -62,6 +62,11 @@ class modCacheManager extends xPDOCacheManager
      * loading the various listings and maps in the modX class, including resourceMap, aliasMap,
      * and eventMap.  It can also be used to setup or transform any other modX properties.
      *
+     * The cached array deliberately omits mutable context row fields (name, description, rank, etc.);
+     * including them would serve stale labels in the manager after edits until full cache clears.
+     * To read those in front-end code, load the context object from the database when needed, e.g.
+     * $row = $modx->getObject(modContext::class, ['key' => $modx->context->get('key')]);
+     *
      * @todo Further refactor the generation of aliasMap and resourceMap so it uses less memory/file size.
      *
      * @param string $key     The modContext key to be cached.
@@ -79,11 +84,6 @@ class modCacheManager extends xPDOCacheManager
                 $cacheKey = $obj->getCacheKey();
                 $contextKey = is_object($this->modx->context) ? $this->modx->context->get('key') : $key;
                 $contextConfig = array_merge($this->modx->_systemConfig, $options);
-
-                $results['key'] = $obj->get('key');
-                $results['name'] = $obj->get('name');
-                $results['description'] = $obj->get('description');
-                $results['rank'] = $obj->get('rank');
 
                 /* generate the ContextSettings */
                 $results['config'] = [];

--- a/core/src/Revolution/modCacheManager.php
+++ b/core/src/Revolution/modCacheManager.php
@@ -80,6 +80,11 @@ class modCacheManager extends xPDOCacheManager
                 $contextKey = is_object($this->modx->context) ? $this->modx->context->get('key') : $key;
                 $contextConfig = array_merge($this->modx->_systemConfig, $options);
 
+                $results['key'] = $obj->get('key');
+                $results['name'] = $obj->get('name');
+                $results['description'] = $obj->get('description');
+                $results['rank'] = $obj->get('rank');
+
                 /* generate the ContextSettings */
                 $results['config'] = [];
                 if ($settings = $obj->getMany('ContextSettings')) {

--- a/core/src/Revolution/modCacheManager.php
+++ b/core/src/Revolution/modCacheManager.php
@@ -65,7 +65,9 @@ class modCacheManager extends xPDOCacheManager
      * The cached array deliberately omits mutable context row fields (name, description, rank, etc.);
      * including them would serve stale labels in the manager after edits until full cache clears.
      * To read those in front-end code, load the context object from the database when needed, e.g.
-     * $row = $modx->getObject(modContext::class, ['key' => $modx->context->get('key')]);
+     * $context = $modx->getObject(modContext::class, ['key' => $modx->context->key]);
+     * $contextName = $context->get('name');
+     * [ etc... ]
      *
      * @todo Further refactor the generation of aliasMap and resourceMap so it uses less memory/file size.
      *


### PR DESCRIPTION
### What does it do?
Documents why `modCacheManager::generateContext()` omits mutable context row fields (`name`, `description`, `rank`, etc.) and how to load them from the DB when needed.

### Why is it needed?
#15653 asked for those fields in context cache; putting them there would stale manager UI after context edits. The doc records the contract instead of changing the cache payload.

### How to test
1. Read the PHPDoc on `generateContext()`
2. Confirm context cache still has no `name`/`description` after refresh
3. Load a context via `modContext::getObject()` and confirm those fields come from the DB

### Related issue(s)/PR(s)
Related to #15653