### PR TITLE
feat(install): redirect homepage to setup when config is missing

### DIFF
--- a/index.php
+++ b/index.php
@@ -29,8 +29,15 @@ if (!defined('MODX_CONFIG_KEY')) {
 /* redirect to setup if config does not exist (pre-install) */
 $configPath = MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
 if (!file_exists($configPath)) {
-    $basePath = !empty($_SERVER['SCRIPT_NAME']) ? dirname($_SERVER['SCRIPT_NAME']) : '';
-    $setupUrl = rtrim($basePath, '/\\') . '/setup/';
+    if (defined('MODX_BASE_URL')) {
+        $setupUrl = rtrim(MODX_BASE_URL, '/') . '/setup/';
+    } elseif (!empty($_SERVER['SCRIPT_NAME'])) {
+        /* SCRIPT_NAME can theoretically be manipulated; MODX not initialized yet */
+        $basePath = dirname($_SERVER['SCRIPT_NAME']);
+        $setupUrl = rtrim($basePath, '/\\') . '/setup/';
+    } else {
+        $setupUrl = '/setup/';
+    }
     header('Location: ' . $setupUrl, true, 302);
     exit;
 }

--- a/index.php
+++ b/index.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -25,12 +26,22 @@ if (!defined('MODX_CONFIG_KEY')) {
     define('MODX_CONFIG_KEY', 'config');
 }
 
+/* redirect to setup if config does not exist (pre-install) */
+$configPath = MODX_CORE_PATH . 'config/' . MODX_CONFIG_KEY . '.inc.php';
+if (!file_exists($configPath)) {
+    $basePath = !empty($_SERVER['SCRIPT_NAME']) ? dirname($_SERVER['SCRIPT_NAME']) : '';
+    $setupUrl = rtrim($basePath, '/\\') . '/setup/';
+    header('Location: ' . $setupUrl, true, 302);
+    exit;
+}
+
 /* include the autoloader */
 if (!@require_once MODX_CORE_PATH . "vendor/autoload.php") {
     $errorMessage = 'Site temporarily unavailable';
     @include MODX_CORE_PATH . 'error/unavailable.include.php';
     header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
-    echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
+    echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1>";
+    echo "<p>{$errorMessage}</p></body></html>";
     exit();
 }
 
@@ -44,7 +55,8 @@ if (!is_object($modx) || !($modx instanceof \MODX\Revolution\modX)) {
     $errorMessage = '<a href="setup/">MODX not installed. Install now?</a>';
     @include MODX_CORE_PATH . 'error/unavailable.include.php';
     header($_SERVER['SERVER_PROTOCOL'] . ' 503 Service Unavailable');
-    echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1><p>{$errorMessage}</p></body></html>";
+    echo "<html><title>Error 503: Site temporarily unavailable</title><body><h1>Error 503</h1>";
+    echo "<p>{$errorMessage}</p></body></html>";
     exit();
 }
 

--- a/index.php
+++ b/index.php
@@ -32,9 +32,10 @@ if (!file_exists($configPath)) {
     if (defined('MODX_BASE_URL')) {
         $setupUrl = rtrim(MODX_BASE_URL, '/') . '/setup/';
     } elseif (!empty($_SERVER['SCRIPT_NAME'])) {
-        /* SCRIPT_NAME can theoretically be manipulated; MODX not initialized yet */
-        $basePath = dirname($_SERVER['SCRIPT_NAME']);
-        $setupUrl = rtrim($basePath, '/\\') . '/setup/';
+        $scriptName = str_replace('\\', '/', $_SERVER['SCRIPT_NAME']);
+        $basePath = dirname('/' . ltrim($scriptName, '/'));
+        $basePath = preg_replace('#/+#', '/', $basePath);
+        $setupUrl = rtrim($basePath, '/') . '/setup/';
     } else {
         $setupUrl = '/setup/';
     }


### PR DESCRIPTION
### What does it do?
If `core/config/{key}.inc.php` is missing, `index.php` responds with a 302 to the setup directory (including subfolder installs) instead of a 503.

### Why is it needed?
Fresh uploads hit an unfriendly 503 before setup (#15581).

### How to test
1. Deploy files without creating the config
2. Open the site root — expect redirect to `/setup/` (or `{subdir}/setup/`)
3. Confirm a forged `SCRIPT_NAME` with `//host` still yields a root-relative Location

### Related issue(s)/PR(s)
Resolves #15581