### PR TITLE
feat(core): add error_log_max_size setting and trim on append

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -2149,6 +2149,15 @@ $settings['error_log_filepath']->fromArray([
     'area' => 'system',
     'editedon' => null,
 ], '', true, true);
+$settings['error_log_max_size'] = $xpdo->newObject(modSystemSetting::class);
+$settings['error_log_max_size']->fromArray([
+    'key' => 'error_log_max_size',
+    'value' => '0',
+    'xtype' => 'numberfield',
+    'namespace' => 'core',
+    'area' => 'system',
+    'editedon' => null,
+], '', true, true);
 $settings['passwordless_activated'] = $xpdo->newObject(modSystemSetting::class);
 $settings['passwordless_activated']->fromArray([
     'key' => 'passwordless_activated',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -841,6 +841,9 @@ $_lang['setting_error_log_filename_desc'] = 'Customize the filename of the MODX 
 $_lang['setting_error_log_filepath'] = 'Error log path';
 $_lang['setting_error_log_filepath_desc'] = 'Optionally set a absolute path the a custom error log location. You might use placeholders like {cache_path}.';
 
+$_lang['setting_error_log_max_size'] = 'Error log max size';
+$_lang['setting_error_log_max_size_desc'] = 'Maximum size of the error log file in bytes. When exceeded, older entries are removed. Set to 0 for no limit.';
+
 $_lang['setting_passwordless_activated'] = 'Activate passwordless login';
 $_lang['setting_passwordless_activated_desc'] = 'When enabled, users will enter their email address to receive a one-time login link, rather than entering a username and password.';
 

--- a/core/src/Revolution/modCacheManager.php
+++ b/core/src/Revolution/modCacheManager.php
@@ -56,6 +56,93 @@ class modCacheManager extends xPDOCacheManager
     }
 
     /**
+     * Writes a file to the filesystem. When appending to the error log and error_log_max_size is set,
+     * trims the file to the last 50% of the limit before appending.
+     *
+     * @param string $filename The absolute path to the file.
+     * @param string $content  The content to write.
+     * @param string $mode    The write mode. Only 'a' (append) is subject to error log size limiting.
+     * @param array  $options Options for the function.
+     * @return bool True if the write succeeded.
+     */
+    public function writeFile($filename, $content, $mode = 'wb', $options = [])
+    {
+        $modeNormalized = str_replace('+', '', $mode);
+        if (($modeNormalized === '' || $modeNormalized[0] !== 'a') || !$this->modx) {
+            return parent::writeFile($filename, $content, $mode, $options);
+        }
+
+        if (!$this->isErrorLogPath($filename)) {
+            return parent::writeFile($filename, $content, $mode, $options);
+        }
+
+        $maxSize = (int) $this->modx->getOption('error_log_max_size', null, 0);
+        if ($maxSize <= 0 || !is_file($filename)) {
+            return parent::writeFile($filename, $content, $mode, $options);
+        }
+
+        $fileSize = @filesize($filename);
+        if ($fileSize === false || $fileSize <= $maxSize) {
+            return parent::writeFile($filename, $content, $mode, $options);
+        }
+
+        $maxRetain = (int) ($maxSize * 0.5);
+        if ($maxRetain < 1 || !$this->trimErrorLogFile($filename, $maxRetain)) {
+            return parent::writeFile($filename, $content, $mode, $options);
+        }
+
+        return parent::writeFile($filename, $content, $mode, $options);
+    }
+
+    /**
+     * Returns whether the given path is the configured error log file.
+     */
+    protected function isErrorLogPath(string $filename): bool
+    {
+        $filepath = $this->modx->getOption('error_log_filepath', null, '');
+        $basePath = $filepath !== ''
+            ? rtrim(str_replace('\\', '/', $filepath), '/') . '/'
+            : $this->getCachePath() . xPDOCacheManager::LOG_DIR;
+        $logFilename = $this->modx->getOption('error_log_filename', null, 'error.log');
+        $errorLogPath = $basePath . $logFilename;
+
+        $targetResolved = @realpath($filename) ?: str_replace('\\', '/', $filename);
+        $errorLogResolved = @realpath($errorLogPath) ?: str_replace('\\', '/', $errorLogPath);
+
+        return $targetResolved !== '' && $errorLogResolved !== '' && $targetResolved === $errorLogResolved;
+    }
+
+    /**
+     * Trims the error log file to the last maxRetain bytes, dropping a possible partial first line.
+     *
+     * @return bool True if trim succeeded.
+     */
+    protected function trimErrorLogFile(string $filename, int $maxRetain): bool
+    {
+        $file = @fopen($filename, 'r+');
+        if (!$file) {
+            return false;
+        }
+
+        if (!flock($file, LOCK_EX)) {
+            fclose($file);
+            return false;
+        }
+
+        $fileSize = filesize($filename);
+        fseek($file, $fileSize - $maxRetain);
+        fgets($file);
+        $kept = stream_get_contents($file);
+        ftruncate($file, 0);
+        rewind($file);
+        $written = fwrite($file, $kept);
+        flock($file, LOCK_UN);
+        fclose($file);
+
+        return $written !== false;
+    }
+
+    /**
      * Generates a cache entry for a MODX site Context.
      *
      * Context cache entries can override site configuration settings and are responsible for

--- a/core/src/Revolution/modCacheManager.php
+++ b/core/src/Revolution/modCacheManager.php
@@ -57,7 +57,7 @@ class modCacheManager extends xPDOCacheManager
 
     /**
      * Writes a file to the filesystem. When appending to the error log and error_log_max_size is set,
-     * trims the file to the last 50% of the limit before appending.
+     * keeps the log within the limit under a single exclusive lock.
      *
      * @param string $filename The absolute path to the file.
      * @param string $content  The content to write.
@@ -77,21 +77,11 @@ class modCacheManager extends xPDOCacheManager
         }
 
         $maxSize = (int) $this->modx->getOption('error_log_max_size', null, 0);
-        if ($maxSize <= 0 || !is_file($filename)) {
+        if ($maxSize <= 0) {
             return parent::writeFile($filename, $content, $mode, $options);
         }
 
-        $fileSize = @filesize($filename);
-        if ($fileSize === false || $fileSize <= $maxSize) {
-            return parent::writeFile($filename, $content, $mode, $options);
-        }
-
-        $maxRetain = (int) ($maxSize * 0.5);
-        if ($maxRetain < 1 || !$this->trimErrorLogFile($filename, $maxRetain)) {
-            return parent::writeFile($filename, $content, $mode, $options);
-        }
-
-        return parent::writeFile($filename, $content, $mode, $options);
+        return $this->appendErrorLogBounded($filename, (string) $content, $maxSize);
     }
 
     /**
@@ -113,33 +103,77 @@ class modCacheManager extends xPDOCacheManager
     }
 
     /**
-     * Trims the error log file to the last maxRetain bytes, dropping a possible partial first line.
-     *
-     * @return bool True if trim succeeded.
+     * Appends to the error log while enforcing error_log_max_size under LOCK_EX.
      */
-    protected function trimErrorLogFile(string $filename, int $maxRetain): bool
+    protected function appendErrorLogBounded(string $filename, string $content, int $maxSize): bool
     {
-        $file = @fopen($filename, 'r+');
-        if (!$file) {
+        $dir = dirname($filename);
+        if (!is_dir($dir) && !$this->writeTree($dir)) {
             return false;
         }
 
+        $file = @fopen($filename, 'c+');
+        if ($file === false) {
+            return false;
+        }
         if (!flock($file, LOCK_EX)) {
             fclose($file);
             return false;
         }
 
-        $fileSize = filesize($filename);
-        fseek($file, $fileSize - $maxRetain);
+        try {
+            clearstatcache(true, $filename);
+            $fileSize = filesize($filename);
+            if ($fileSize === false) {
+                $fileSize = 0;
+            }
+            $contentLength = strlen($content);
+
+            if ($contentLength >= $maxSize) {
+                // Single entry exceeds the cap: keep only the trailing maxSize bytes.
+                ftruncate($file, 0);
+                rewind($file);
+                return fwrite($file, substr($content, -$maxSize)) !== false;
+            }
+
+            $projected = $fileSize + $contentLength;
+            if ($projected > $maxSize && $fileSize > 0) {
+                $maxRetain = min((int) floor($maxSize / 2), $maxSize - $contentLength);
+                if ($maxRetain < 1) {
+                    $maxRetain = $maxSize - $contentLength;
+                }
+                if (!$this->trimOpenErrorLogHandle($file, $fileSize, $maxRetain)) {
+                    return false;
+                }
+            }
+
+            fseek($file, 0, SEEK_END);
+            return fwrite($file, $content) !== false;
+        } finally {
+            flock($file, LOCK_UN);
+            fclose($file);
+        }
+    }
+
+    /**
+     * Trims an already-locked error log handle to the last maxRetain bytes.
+     */
+    protected function trimOpenErrorLogHandle($file, int $fileSize, int $maxRetain): bool
+    {
+        if ($maxRetain < 1) {
+            return ftruncate($file, 0) !== false;
+        }
+
+        fseek($file, max(0, $fileSize - $maxRetain));
+        // Drop a possible partial first line after the seek point.
         fgets($file);
         $kept = stream_get_contents($file);
+        if ($kept === false) {
+            return false;
+        }
         ftruncate($file, 0);
         rewind($file);
-        $written = fwrite($file, $kept);
-        flock($file, LOCK_UN);
-        fclose($file);
-
-        return $written !== false;
+        return fwrite($file, $kept) !== false;
     }
 
     /**

--- a/setup/includes/upgrades/common/3.2.1-error-log-max-size.php
+++ b/setup/includes/upgrades/common/3.2.1-error-log-max-size.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Add error_log_max_size system setting for limiting error log file size.
  *

--- a/setup/includes/upgrades/common/3.2.1-error-log-max-size.php
+++ b/setup/includes/upgrades/common/3.2.1-error-log-max-size.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ * Add error_log_max_size system setting for limiting error log file size.
+ *
+ * @var modInstallVersion $this
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+use MODX\Revolution\modSystemSetting;
+
+$setting = $modx->getObject(modSystemSetting::class, ['key' => 'error_log_max_size']);
+if (!$setting) {
+    $setting = $modx->newObject(modSystemSetting::class);
+    $setting->fromArray([
+        'key' => 'error_log_max_size',
+        'value' => '0',
+        'xtype' => 'numberfield',
+        'namespace' => 'core',
+        'area' => 'system',
+    ], '', true, true);
+    if ($setting->save()) {
+        $messageTemplate = '<p class="%s">%s</p>';
+        $this->runner->addResult(
+            modInstallRunner::RESULT_SUCCESS,
+            sprintf($messageTemplate, 'ok', 'System Setting `error_log_max_size` added.')
+        );
+    }
+}

--- a/setup/includes/upgrades/mysql/3.2.1-pl.php
+++ b/setup/includes/upgrades/mysql/3.2.1-pl.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Specific upgrades for Revolution 3.2.1-pl
+ *
+ * @var modX $modx
+ * @var modInstallVersion $this
+ * @package setup
+ * @subpackage upgrades
+ */
+
+include dirname(__DIR__) . '/common/3.2.1-error-log-max-size.php';


### PR DESCRIPTION
### What does it do?
Adds `error_log_max_size` (bytes, `0` = unlimited). Appends to the error log under one exclusive lock: if the next write would exceed the cap, older content is trimmed (about half the limit, line-aligned) before writing. A single entry larger than the cap keeps only its trailing `maxSize` bytes.

### Why is it needed?
#15313: the error log can grow without bound and fill the disk.

### How to test
1. Set `error_log_max_size` to a small value (e.g. 1024)
2. Trigger enough log lines to pass the limit
3. Confirm the file stays near the cap and recent lines remain
4. Set `0` and confirm no trimming

### Related issue(s)/PR(s)
Resolves #15313