### PR TITLE
test(dashboard): regression for widget removal sync (#15390)

### DIFF
--- a/_build/test/Tests/Model/Dashboard/modDashboardTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -11,9 +12,11 @@
 */
 namespace MODX\Revolution\Tests\Model\Dashboard;
 
-
 use MODX\Revolution\modDashboard;
+use MODX\Revolution\modDashboardWidget;
+use MODX\Revolution\modDashboardWidgetPlacement;
 use MODX\Revolution\modManagerController;
+use MODX\Revolution\Processors\System\Dashboard\Update;
 use MODX\Revolution\MODxTestCase;
 use xPDO\xPDOException;
 
@@ -26,7 +29,8 @@ use xPDO\xPDOException;
  * @group Dashboard
  * @group modDashboard
  */
-class modDashboardTest extends MODxTestCase {
+class modDashboardTest extends MODxTestCase
+{
     /**
      * Load some utility classes this case uses
      *
@@ -34,26 +38,29 @@ class modDashboardTest extends MODxTestCase {
      * @return void
      * @throws xPDOException
      */
-    public function setUpFixtures() {
+    public function setUpFixtures()
+    {
         parent::setUpFixtures();
-        require_once MODX_MANAGER_PATH.'controllers/default/welcome.class.php';
+        require_once MODX_MANAGER_PATH . 'controllers/default/welcome.class.php';
     }
 
     /**
      * Ensure the static getDefaultDashboard method works, returning the default dashboard for the user
      */
-    public function testGetDefaultDashboard() {
+    public function testGetDefaultDashboard()
+    {
         /** @var modDashboard $dashboard */
         $dashboard = modDashboard::getDefaultDashboard($this->modx);
-        $this->assertInstanceOf(modDashboard::class,$dashboard);
+        $this->assertInstanceOf(modDashboard::class, $dashboard);
     }
 
     /**
      * Ensure the rendering of the dashboard works properly
      *
-     * @medium 
+     * @medium
      */
-    public function testRender() {
+    public function testRender()
+    {
         /** @var modManagerController $controller Fake running the welcome controller */
         $controller = new \WelcomeManagerController($this->modx, [
             'namespace' => 'core',
@@ -66,5 +73,131 @@ class modDashboardTest extends MODxTestCase {
         $dashboard = modDashboard::getDefaultDashboard($this->modx);
         $output = $dashboard->render($controller);
         $this->assertNotEmpty($output);
+    }
+
+    /**
+     * Regression test for #15390: when the template dashboard (user=0) is saved with fewer
+     * widgets, user-specific placements must stay in sync and render() must not show removed widgets.
+     * #14753 is the original report; core behavior was addressed in #15390 — this test guards that path.
+     *
+     * @medium
+     */
+    public function testRemovedWidgetsNotShownAfterUpdate()
+    {
+        $dashboardId = 10001;
+        $widget1Id = 10002;
+        $widget2Id = 10003;
+
+        /** @var modDashboard $dashboard */
+        $dashboard = $this->modx->newObject(modDashboard::class);
+        if ($dashboard === null) {
+            $this->markTestSkipped('modDashboard model not available');
+        }
+        $dashboard->fromArray([
+            'id' => $dashboardId,
+            'name' => 'Unit Test Dashboard Widget Removal',
+            'description' => '',
+            'customizable' => true,
+        ], '', true, true);
+        $dashboard->save();
+
+        foreach ([$widget1Id => 'Widget One', $widget2Id => 'Widget Two'] as $id => $name) {
+            /** @var modDashboardWidget|null $widget */
+            $widget = $this->modx->newObject(modDashboardWidget::class);
+            if ($widget === null) {
+                $dashboard->remove();
+                $this->markTestSkipped('modDashboardWidget model not available');
+            }
+            $widget->fromArray([
+                'id' => $id,
+                'name' => 'Unit Test ' . $name,
+                'type' => 'html',
+                'content' => '<div data-widget="' . $id . '">' . $name . '</div>',
+                'namespace' => 'core',
+                'lexicon' => 'core:dashboards',
+                'size' => 'half',
+            ], '', true, true);
+            $widget->save();
+        }
+
+        $placement1 = $this->modx->newObject(modDashboardWidgetPlacement::class);
+        if ($placement1 === null) {
+            $dashboard->remove();
+            $this->modx->removeObject(modDashboardWidget::class, $widget1Id);
+            $this->modx->removeObject(modDashboardWidget::class, $widget2Id);
+            $this->markTestSkipped('modDashboardWidgetPlacement model not available');
+        }
+        $placement1->fromArray([
+            'dashboard' => $dashboardId,
+            'user' => 0,
+            'widget' => $widget1Id,
+            'rank' => 0,
+        ], '', true, true);
+        $placement1->save();
+
+        $placement2 = $this->modx->newObject(modDashboardWidgetPlacement::class);
+        if ($placement2 === null) {
+            $dashboard->remove();
+            $this->modx->removeObject(modDashboardWidget::class, $widget1Id);
+            $this->modx->removeObject(modDashboardWidget::class, $widget2Id);
+            $this->markTestSkipped('modDashboardWidgetPlacement model not available');
+        }
+        $placement2->fromArray([
+            'dashboard' => $dashboardId,
+            'user' => 0,
+            'widget' => $widget2Id,
+            'rank' => 1,
+        ], '', true, true);
+        $placement2->save();
+
+        $controller = new \WelcomeManagerController($this->modx, [
+            'namespace' => 'core',
+            'namespace_name' => 'core',
+            'namespace_path' => MODX_MANAGER_PATH,
+            'lang_topics' => 'dashboards',
+            'controller' => 'system/dashboards',
+        ]);
+
+        $dashboard->render($controller);
+        if ($this->modx->user === null) {
+            $dashboard->remove();
+            $this->modx->removeCollection(modDashboardWidgetPlacement::class, ['dashboard' => $dashboardId]);
+            $this->modx->removeObject(modDashboardWidget::class, $widget1Id);
+            $this->modx->removeObject(modDashboardWidget::class, $widget2Id);
+            $this->markTestSkipped('modx user not available');
+        }
+        $userId = $this->modx->user->get('id');
+        $userPlacementsBefore = $this->modx->getCollection(modDashboardWidgetPlacement::class, [
+            'dashboard' => $dashboardId,
+            'user' => $userId,
+        ]);
+        $this->assertCount(2, $userPlacementsBefore, 'User must have 2 placements after first render (addUserWidgets)');
+
+        $widgetsPayload = json_encode([
+            ['widget' => $widget1Id, 'rank' => 0],
+        ]);
+        $result = $this->modx->runProcessor(Update::class, [
+            'id' => $dashboardId,
+            'name' => 'Unit Test Dashboard Widget Removal',
+            'widgets' => $widgetsPayload,
+        ]);
+        $this->assertFalse($result->isError(), 'Dashboard update must succeed: ' . $result->getMessage());
+
+        $userPlacementsAfter = $this->modx->getCollection(modDashboardWidgetPlacement::class, [
+            'dashboard' => $dashboardId,
+            'user' => $userId,
+        ]);
+        $this->assertCount(1, $userPlacementsAfter, 'Removed widget must be removed from user placements');
+
+        $reloaded = $this->modx->getObject(modDashboard::class, $dashboardId);
+        $this->assertInstanceOf(modDashboard::class, $reloaded);
+        $output = $reloaded->render($controller);
+        $this->assertStringContainsString('Widget One', $output);
+        $this->assertStringNotContainsString('Widget Two', $output);
+
+        $dashboard->remove();
+        $this->modx->removeCollection(modDashboardWidgetPlacement::class, ['dashboard' => $dashboardId]);
+        $this->modx->removeObject(modDashboardWidget::class, $widget1Id);
+        $this->modx->removeObject(modDashboardWidget::class, $widget2Id);
     }
 }

--- a/_build/test/Tests/Model/Dashboard/modDashboardTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -11,6 +10,7 @@
  * @package modx-test
 */
 namespace MODX\Revolution\Tests\Model\Dashboard;
+
 
 use MODX\Revolution\modDashboard;
 use MODX\Revolution\modDashboardWidget;
@@ -29,8 +29,7 @@ use xPDO\xPDOException;
  * @group Dashboard
  * @group modDashboard
  */
-class modDashboardTest extends MODxTestCase
-{
+class modDashboardTest extends MODxTestCase {
     /**
      * Load some utility classes this case uses
      *
@@ -38,29 +37,26 @@ class modDashboardTest extends MODxTestCase
      * @return void
      * @throws xPDOException
      */
-    public function setUpFixtures()
-    {
+    public function setUpFixtures() {
         parent::setUpFixtures();
-        require_once MODX_MANAGER_PATH . 'controllers/default/welcome.class.php';
+        require_once MODX_MANAGER_PATH.'controllers/default/welcome.class.php';
     }
 
     /**
      * Ensure the static getDefaultDashboard method works, returning the default dashboard for the user
      */
-    public function testGetDefaultDashboard()
-    {
+    public function testGetDefaultDashboard() {
         /** @var modDashboard $dashboard */
         $dashboard = modDashboard::getDefaultDashboard($this->modx);
-        $this->assertInstanceOf(modDashboard::class, $dashboard);
+        $this->assertInstanceOf(modDashboard::class,$dashboard);
     }
 
     /**
      * Ensure the rendering of the dashboard works properly
      *
-     * @medium
+     * @medium 
      */
-    public function testRender()
-    {
+    public function testRender() {
         /** @var modManagerController $controller Fake running the welcome controller */
         $controller = new \WelcomeManagerController($this->modx, [
             'namespace' => 'core',
@@ -82,122 +78,134 @@ class modDashboardTest extends MODxTestCase
      *
      * @medium
      */
-    public function testRemovedWidgetsNotShownAfterUpdate()
-    {
-        $dashboardId = 10001;
-        $widget1Id = 10002;
-        $widget2Id = 10003;
+    public function testRemovedWidgetsNotShownAfterUpdate() {
+        $suffix = uniqid('widget_removal_', true);
+        $dashboardName = 'Unit Test Dashboard Widget Removal ' . $suffix;
+        $dashboardId = null;
+        $widgetIds = [];
 
-        /** @var modDashboard $dashboard */
-        $dashboard = $this->modx->newObject(modDashboard::class);
-        if ($dashboard === null) {
-            $this->markTestSkipped('modDashboard model not available');
-        }
-        $dashboard->fromArray([
-            'id' => $dashboardId,
-            'name' => 'Unit Test Dashboard Widget Removal',
-            'description' => '',
-            'customizable' => true,
-        ], '', true, true);
-        $dashboard->save();
-
-        foreach ([$widget1Id => 'Widget One', $widget2Id => 'Widget Two'] as $id => $name) {
-            /** @var modDashboardWidget|null $widget */
-            $widget = $this->modx->newObject(modDashboardWidget::class);
-            if ($widget === null) {
-                $dashboard->remove();
-                $this->markTestSkipped('modDashboardWidget model not available');
+        try {
+            /** @var modDashboard|null $dashboard */
+            $dashboard = $this->modx->newObject(modDashboard::class);
+            if ($dashboard === null) {
+                $this->markTestSkipped('modDashboard model not available');
             }
-            $widget->fromArray([
-                'id' => $id,
-                'name' => 'Unit Test ' . $name,
-                'type' => 'html',
-                'content' => '<div data-widget="' . $id . '">' . $name . '</div>',
+            $dashboard->fromArray([
+                'name' => $dashboardName,
+                'description' => '',
+                'customizable' => true,
+            ]);
+            $this->assertTrue($dashboard->save(), 'Failed to save test dashboard');
+            $dashboardId = (int) $dashboard->get('id');
+
+            foreach (['Widget One', 'Widget Two'] as $rank => $label) {
+                /** @var modDashboardWidget|null $widget */
+                $widget = $this->modx->newObject(modDashboardWidget::class);
+                if ($widget === null) {
+                    $this->markTestSkipped('modDashboardWidget model not available');
+                }
+                $widget->fromArray([
+                    'name' => 'Unit Test ' . $label . ' ' . $suffix,
+                    'type' => 'html',
+                    'content' => '<div data-widget="' . $suffix . '-' . $rank . '">' . $label . '</div>',
+                    'namespace' => 'core',
+                    'lexicon' => 'core:dashboards',
+                    'size' => 'half',
+                ]);
+                $this->assertTrue($widget->save(), 'Failed to save test widget');
+                $widgetIds[] = (int) $widget->get('id');
+            }
+
+            $placement1 = $this->modx->newObject(modDashboardWidgetPlacement::class);
+            if ($placement1 === null) {
+                $this->markTestSkipped('modDashboardWidgetPlacement model not available');
+            }
+            $placement1->fromArray([
+                'dashboard' => $dashboardId,
+                'user' => 0,
+                'widget' => $widgetIds[0],
+                'rank' => 0,
+            ]);
+            $this->assertTrue($placement1->save(), 'Failed to save first template placement');
+
+            $placement2 = $this->modx->newObject(modDashboardWidgetPlacement::class);
+            if ($placement2 === null) {
+                $this->markTestSkipped('modDashboardWidgetPlacement model not available');
+            }
+            $placement2->fromArray([
+                'dashboard' => $dashboardId,
+                'user' => 0,
+                'widget' => $widgetIds[1],
+                'rank' => 1,
+            ]);
+            $this->assertTrue($placement2->save(), 'Failed to save second template placement');
+
+            $controller = new \WelcomeManagerController($this->modx, [
                 'namespace' => 'core',
-                'lexicon' => 'core:dashboards',
-                'size' => 'half',
-            ], '', true, true);
-            $widget->save();
+                'namespace_name' => 'core',
+                'namespace_path' => MODX_MANAGER_PATH,
+                'lang_topics' => 'dashboards',
+                'controller' => 'system/dashboards',
+            ]);
+
+            $dashboard->render($controller);
+            if ($this->modx->user === null) {
+                $this->markTestSkipped('modx user not available');
+            }
+            $userId = $this->modx->user->get('id');
+            $userPlacementsBefore = $this->modx->getCollection(modDashboardWidgetPlacement::class, [
+                'dashboard' => $dashboardId,
+                'user' => $userId,
+            ]);
+            $this->assertCount(
+                2,
+                $userPlacementsBefore,
+                'User must have 2 placements after first render (addUserWidgets)'
+            );
+
+            $widgetsPayload = json_encode([
+                ['widget' => $widgetIds[0], 'rank' => 0],
+            ]);
+            $result = $this->modx->runProcessor(Update::class, [
+                'id' => $dashboardId,
+                'name' => $dashboardName,
+                'widgets' => $widgetsPayload,
+            ]);
+            $this->assertFalse($result->isError(), 'Dashboard update must succeed: ' . $result->getMessage());
+
+            $userPlacementsAfter = $this->modx->getCollection(modDashboardWidgetPlacement::class, [
+                'dashboard' => $dashboardId,
+                'user' => $userId,
+            ]);
+            $this->assertCount(1, $userPlacementsAfter, 'Removed widget must be removed from user placements');
+
+            $reloaded = $this->modx->getObject(modDashboard::class, $dashboardId);
+            $this->assertInstanceOf(modDashboard::class, $reloaded);
+            $output = $reloaded->render($controller);
+            $this->assertStringContainsString('Widget One', $output);
+            $this->assertStringNotContainsString('Widget Two', $output);
+        } finally {
+            $this->removeDashboardWidgetRemovalFixtures($dashboardId, $widgetIds);
         }
+    }
 
-        $placement1 = $this->modx->newObject(modDashboardWidgetPlacement::class);
-        if ($placement1 === null) {
-            $dashboard->remove();
-            $this->modx->removeObject(modDashboardWidget::class, $widget1Id);
-            $this->modx->removeObject(modDashboardWidget::class, $widget2Id);
-            $this->markTestSkipped('modDashboardWidgetPlacement model not available');
-        }
-        $placement1->fromArray([
-            'dashboard' => $dashboardId,
-            'user' => 0,
-            'widget' => $widget1Id,
-            'rank' => 0,
-        ], '', true, true);
-        $placement1->save();
-
-        $placement2 = $this->modx->newObject(modDashboardWidgetPlacement::class);
-        if ($placement2 === null) {
-            $dashboard->remove();
-            $this->modx->removeObject(modDashboardWidget::class, $widget1Id);
-            $this->modx->removeObject(modDashboardWidget::class, $widget2Id);
-            $this->markTestSkipped('modDashboardWidgetPlacement model not available');
-        }
-        $placement2->fromArray([
-            'dashboard' => $dashboardId,
-            'user' => 0,
-            'widget' => $widget2Id,
-            'rank' => 1,
-        ], '', true, true);
-        $placement2->save();
-
-        $controller = new \WelcomeManagerController($this->modx, [
-            'namespace' => 'core',
-            'namespace_name' => 'core',
-            'namespace_path' => MODX_MANAGER_PATH,
-            'lang_topics' => 'dashboards',
-            'controller' => 'system/dashboards',
-        ]);
-
-        $dashboard->render($controller);
-        if ($this->modx->user === null) {
-            $dashboard->remove();
+    /**
+     * @param int|null $dashboardId
+     * @param int[] $widgetIds
+     */
+    private function removeDashboardWidgetRemovalFixtures(?int $dashboardId, array $widgetIds): void {
+        if ($dashboardId !== null) {
             $this->modx->removeCollection(modDashboardWidgetPlacement::class, ['dashboard' => $dashboardId]);
-            $this->modx->removeObject(modDashboardWidget::class, $widget1Id);
-            $this->modx->removeObject(modDashboardWidget::class, $widget2Id);
-            $this->markTestSkipped('modx user not available');
+            $dashboard = $this->modx->getObject(modDashboard::class, $dashboardId);
+            if ($dashboard !== null) {
+                $dashboard->remove();
+            }
         }
-        $userId = $this->modx->user->get('id');
-        $userPlacementsBefore = $this->modx->getCollection(modDashboardWidgetPlacement::class, [
-            'dashboard' => $dashboardId,
-            'user' => $userId,
-        ]);
-        $this->assertCount(2, $userPlacementsBefore, 'User must have 2 placements after first render (addUserWidgets)');
-
-        $widgetsPayload = json_encode([
-            ['widget' => $widget1Id, 'rank' => 0],
-        ]);
-        $result = $this->modx->runProcessor(Update::class, [
-            'id' => $dashboardId,
-            'name' => 'Unit Test Dashboard Widget Removal',
-            'widgets' => $widgetsPayload,
-        ]);
-        $this->assertFalse($result->isError(), 'Dashboard update must succeed: ' . $result->getMessage());
-
-        $userPlacementsAfter = $this->modx->getCollection(modDashboardWidgetPlacement::class, [
-            'dashboard' => $dashboardId,
-            'user' => $userId,
-        ]);
-        $this->assertCount(1, $userPlacementsAfter, 'Removed widget must be removed from user placements');
-
-        $reloaded = $this->modx->getObject(modDashboard::class, $dashboardId);
-        $this->assertInstanceOf(modDashboard::class, $reloaded);
-        $output = $reloaded->render($controller);
-        $this->assertStringContainsString('Widget One', $output);
-        $this->assertStringNotContainsString('Widget Two', $output);
-
-        $dashboard->remove();
-        $this->modx->removeCollection(modDashboardWidgetPlacement::class, ['dashboard' => $dashboardId]);
-        $this->modx->removeObject(modDashboardWidget::class, $widget1Id);
-        $this->modx->removeObject(modDashboardWidget::class, $widget2Id);
+        foreach ($widgetIds as $widgetId) {
+            $widget = $this->modx->getObject(modDashboardWidget::class, $widgetId);
+            if ($widget !== null) {
+                $widget->remove();
+            }
+        }
     }
 }

--- a/_build/test/Tests/Model/Dashboard/modDashboardTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -10,7 +11,6 @@
  * @package modx-test
 */
 namespace MODX\Revolution\Tests\Model\Dashboard;
-
 
 use MODX\Revolution\modDashboard;
 use MODX\Revolution\modDashboardWidget;
@@ -29,7 +29,8 @@ use xPDO\xPDOException;
  * @group Dashboard
  * @group modDashboard
  */
-class modDashboardTest extends MODxTestCase {
+class modDashboardTest extends MODxTestCase
+{
     /**
      * Load some utility classes this case uses
      *
@@ -37,26 +38,29 @@ class modDashboardTest extends MODxTestCase {
      * @return void
      * @throws xPDOException
      */
-    public function setUpFixtures() {
+    public function setUpFixtures()
+    {
         parent::setUpFixtures();
-        require_once MODX_MANAGER_PATH.'controllers/default/welcome.class.php';
+        require_once MODX_MANAGER_PATH . 'controllers/default/welcome.class.php';
     }
 
     /**
      * Ensure the static getDefaultDashboard method works, returning the default dashboard for the user
      */
-    public function testGetDefaultDashboard() {
+    public function testGetDefaultDashboard()
+    {
         /** @var modDashboard $dashboard */
         $dashboard = modDashboard::getDefaultDashboard($this->modx);
-        $this->assertInstanceOf(modDashboard::class,$dashboard);
+        $this->assertInstanceOf(modDashboard::class, $dashboard);
     }
 
     /**
      * Ensure the rendering of the dashboard works properly
      *
-     * @medium 
+     * @medium
      */
-    public function testRender() {
+    public function testRender()
+    {
         /** @var modManagerController $controller Fake running the welcome controller */
         $controller = new \WelcomeManagerController($this->modx, [
             'namespace' => 'core',
@@ -78,7 +82,8 @@ class modDashboardTest extends MODxTestCase {
      *
      * @medium
      */
-    public function testRemovedWidgetsNotShownAfterUpdate() {
+    public function testRemovedWidgetsNotShownAfterUpdate()
+    {
         $suffix = uniqid('widget_removal_', true);
         $dashboardName = 'Unit Test Dashboard Widget Removal ' . $suffix;
         $dashboardId = null;
@@ -193,7 +198,8 @@ class modDashboardTest extends MODxTestCase {
      * @param int|null $dashboardId
      * @param int[] $widgetIds
      */
-    private function removeDashboardWidgetRemovalFixtures(?int $dashboardId, array $widgetIds): void {
+    private function removeDashboardWidgetRemovalFixtures(?int $dashboardId, array $widgetIds): void
+    {
         if ($dashboardId !== null) {
             $this->modx->removeCollection(modDashboardWidgetPlacement::class, ['dashboard' => $dashboardId]);
             $dashboard = $this->modx->getObject(modDashboard::class, $dashboardId);

--- a/_build/test/Tests/Model/Dashboard/modDashboardTest.php
+++ b/_build/test/Tests/Model/Dashboard/modDashboardTest.php
@@ -130,7 +130,8 @@ class modDashboardTest extends MODxTestCase
                 'user' => 0,
                 'widget' => $widgetIds[0],
                 'rank' => 0,
-            ]);
+                'size' => 'half',
+            ], '', true);
             $this->assertTrue($placement1->save(), 'Failed to save first template placement');
 
             $placement2 = $this->modx->newObject(modDashboardWidgetPlacement::class);
@@ -142,7 +143,8 @@ class modDashboardTest extends MODxTestCase
                 'user' => 0,
                 'widget' => $widgetIds[1],
                 'rank' => 1,
-            ]);
+                'size' => 'half',
+            ], '', true);
             $this->assertTrue($placement2->save(), 'Failed to save second template placement');
 
             $controller = new \WelcomeManagerController($this->modx, [


### PR DESCRIPTION
### What does it do?
Adds `testRemovedWidgetsNotShownAfterUpdate()` to guard the widget-removal sync path from #15390.

### Why is it needed?
#14753 reported default dashboard widgets persisting after removal. #15390 fixed runtime behavior in `Dashboard\Update::setWidgets()`. This test locks that path so it does not regress.

Fixtures use xPDO-assigned IDs and `try/finally` cleanup so failed assertions do not leave dashboard data in the test DB.

### How to test
With a configured test DB:

```
core/vendor/bin/phpunit -c _build/test/phpunit.xml --filter testRemovedWidgetsNotShownAfterUpdate
```

### Related issue(s)/PR(s)
- Related: #14753
- Behavior under test: #15390