### PR TITLE
fix(tv): allow Smarty in date TV config for min/max values

### DIFF
--- a/_build/test/Tests/Processors/Element/TemplateVar/Renders/mgr/input/DateInputRenderTest.php
+++ b/_build/test/Tests/Processors/Element/TemplateVar/Renders/mgr/input/DateInputRenderTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+
+namespace MODX\Revolution\Tests\Processors\Element\TemplateVar\Renders\mgr\input;
+
+use MODX\Revolution\modTemplateVar;
+use MODX\Revolution\MODxTestCase;
+
+/**
+ * Tests for date TV input render (minTimeValue/maxTimeValue with Smarty placeholder handling).
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Processors
+ * @group Element
+ * @group TemplateVar
+ */
+class DateInputRenderTest extends MODxTestCase
+{
+    /**
+     * @before
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+        $this->modx->getService('smarty', 'MODX\Revolution\Smarty\modSmarty', '');
+    }
+
+    /**
+     * Test that static time values are converted to date format.
+     */
+    public function testProcessConvertsStaticTimeValues()
+    {
+        $placeholders = [];
+        $controller = new \stdClass();
+        $controller->setPlaceholder = function ($k, $v) use (&$placeholders) {
+            $placeholders[$k] = $v;
+        };
+        $this->modx->controller = $controller;
+
+        $tv = $this->modx->newObject(modTemplateVar::class);
+        $tv->fromArray(['id' => 1, 'name' => 'test'], '', true, true);
+
+        $dateClassPath = dirname(__DIR__, 9)
+            . '/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/date.class.php';
+        $renderClass = include $dateClassPath;
+        $render = new $renderClass($tv, []);
+        $render->process('2025-01-15 14:30:00', [
+            'maxTimeValue' => '14:30',
+            'minTimeValue' => '09:00',
+        ]);
+
+        $this->assertArrayHasKey('params', $placeholders);
+        $params = $placeholders['params'];
+        $this->assertEquals('2:30 PM', $params['maxTimeValue']);
+        $this->assertEquals('9:00 AM', $params['minTimeValue']);
+    }
+
+    /**
+     * Test that Smarty placeholders in time values are not converted.
+     */
+    public function testProcessSkipsSmartyPlaceholdersInTimeValues()
+    {
+        $placeholders = [];
+        $controller = new \stdClass();
+        $controller->setPlaceholder = function ($k, $v) use (&$placeholders) {
+            $placeholders[$k] = $v;
+        };
+        $this->modx->controller = $controller;
+
+        $tv = $this->modx->newObject(modTemplateVar::class);
+        $tv->fromArray(['id' => 1, 'name' => 'test'], '', true, true);
+
+        $dateClassPath = dirname(__DIR__, 9)
+            . '/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/date.class.php';
+        $renderClass = include $dateClassPath;
+        $render = new $renderClass($tv, []);
+        $smartyMax = '{$smarty.now|date_format:\'%H:%M\'}';
+        $smartyMin = '{$smarty.now|date_format:\'%I:%M %p\'}';
+        $render->process('', [
+            'maxTimeValue' => $smartyMax,
+            'minTimeValue' => $smartyMin,
+        ]);
+
+        $this->assertArrayHasKey('params', $placeholders);
+        $params = $placeholders['params'];
+        $this->assertEquals($smartyMax, $params['maxTimeValue']);
+        $this->assertEquals($smartyMin, $params['minTimeValue']);
+    }
+}

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/date.class.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/mgr/input/date.class.php
@@ -31,10 +31,10 @@ class modTemplateVarInputRenderDate extends modTemplateVarInputRender
         if (!empty($params['disabledDays'])) {
             $params['disabledDays'] = $this->modx->toJSON(explode(',', $params['disabledDays']));
         }
-        if (!empty($params['maxTimeValue'])) {
+        if (!empty($params['maxTimeValue']) && strpos($params['maxTimeValue'], '{$') === false) {
             $params['maxTimeValue'] = date('g:i A', strtotime($params['maxTimeValue']));
         }
-        if (!empty($params['minTimeValue'])) {
+        if (!empty($params['minTimeValue']) && strpos($params['minTimeValue'], '{$') === false) {
             $params['minTimeValue'] = date('g:i A', strtotime($params['minTimeValue']));
         }
         $this->setPlaceholder('params', $params);
@@ -47,4 +47,6 @@ class modTemplateVarInputRenderDate extends modTemplateVarInputRender
     }
 }
 
+// phpcs:disable PSR1.Files.SideEffects.FoundWithSymbols -- MODX processor loader pattern
 return 'modTemplateVarInputRenderDate';
+// phpcs:enable PSR1.Files.SideEffects.FoundWithSymbols

--- a/manager/templates/default/element/tv/renders/input/date.tpl
+++ b/manager/templates/default/element/tv/renders/input/date.tpl
@@ -16,11 +16,11 @@ Ext.onReady(function() {
         ,timeFormat: MODx.config.manager_time_format
         {if $params.disabledDays|default},disabledDays: {$params.disabledDays|default}{/if}
         {if $params.disabledDates|default},disabledDates: {$params.disabledDates|default}{/if}
-        {if $params.minDateValue|default},minDateValue: '{$params.minDateValue|default}'{/if}
-        {if $params.maxDateValue|default},maxDateValue: '{$params.maxDateValue|default}'{/if}
+        {if $params.minDateValue|default},minDateValue: '{eval var=$params.minDateValue|default}'{/if}
+        {if $params.maxDateValue|default},maxDateValue: '{eval var=$params.maxDateValue|default}'{/if}
         {if $params.startDay|default},startDay: {$params.startDay|default}{/if}
-        {if $params.minTimeValue|default},minTimeValue: '{$params.minTimeValue|default}'{/if}
-        {if $params.maxTimeValue|default},maxTimeValue: '{$params.maxTimeValue|default}'{/if}
+        {if $params.minTimeValue|default},minTimeValue: '{eval var=$params.minTimeValue|default}'{/if}
+        {if $params.maxTimeValue|default},maxTimeValue: '{eval var=$params.maxTimeValue|default}'{/if}
         {if $params.timeIncrement|default},timeIncrement: {$params.timeIncrement|default}{/if}
         {if $params.hideTime|default},hideTime: {$params.hideTime|default}{/if}
         ,allowBlank: {if $params.allowBlank == 1 || $params.allowBlank == 'true'}true{else}false{/if}


### PR DESCRIPTION
### What does it do?
- Uses `{eval}` in date.tpl for `minDateValue`, `maxDateValue`, `minTimeValue`, `maxTimeValue` so Smarty placeholders are processed at render time
- Skips `strtotime`/`date` conversion in the date processor when the value contains a Smarty placeholder (`{$`), avoiding incorrect output for dynamic expressions

### Why is it needed?
In JSON TV config (MIGX, CMP), date constraints were output as literal strings. Dynamic values like `"maxDateValue":"{$smarty.now|date_format:'%Y-%m-%d'}"` were not evaluated, making it impossible to limit date selection to today or other runtime values.

### How to test
1. Create a date TV with JSON config: `{"maxDateValue":"{$smarty.now|date_format:'%Y-%m-%d'}","allowBlank":true,"hideTime":true}`
2. Edit a resource with that TV — the date picker should restrict selection to today or earlier
3. Verify static values (e.g. `"maxDateValue":"2025-12-31"`) still work

### Related issue(s)/PR(s)
Resolves #14575
