### PR TITLE
feat(core): add async/defer support to regClientScript and regClientStartupScript

### DIFF
--- a/_build/test/Tests/Model/Filters/modOutputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modOutputFilterTest.php
@@ -800,6 +800,30 @@ goes here'
     }
 
     /**
+     * Test :jsToBottom with async loading attribute
+     */
+    public function testJsToBottomAsync() {
+        $url = 'assets/js/async-script.js';
+        $this->modx->setPlaceholder('utp', $url);
+        $this->tag->set('name', 'utp:jsToBottom=`0,async`');
+        $this->tag->process();
+        $expected = '<script src="' . $url . '" async></script>';
+        $this->assertContains($expected, $this->modx->jscripts);
+    }
+
+    /**
+     * Test :jsToHead with defer loading attribute
+     */
+    public function testJsToHeadDefer() {
+        $url = 'assets/js/defer-script.js';
+        $this->modx->setPlaceholder('utp', $url);
+        $this->tag->set('name', 'utp:jsToHead=`0,defer`');
+        $this->tag->process();
+        $expected = '<script src="' . $url . '" defer></script>';
+        $this->assertContains($expected, $this->modx->sjscripts);
+    }
+
+    /**
      * Tests :dirname filter
      *
      * @param string $filepath

--- a/_build/test/Tests/Model/Filters/modOutputFilterTest.php
+++ b/_build/test/Tests/Model/Filters/modOutputFilterTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -10,7 +11,6 @@
  * @package modx-test
 */
 namespace MODX\Revolution\Tests\Model\Filters;
-
 
 use MODX\Revolution\modPlaceholderTag;
 use MODX\Revolution\MODxTestCase;
@@ -24,7 +24,8 @@ use MODX\Revolution\MODxTestCase;
  * @group Filters
  * @group modOutputFilter
  */
-class modOutputFilterTest extends MODxTestCase {
+class modOutputFilterTest extends MODxTestCase
+{
     /** @var modPlaceholderTag $tag */
     public $tag;
 
@@ -33,12 +34,13 @@ class modOutputFilterTest extends MODxTestCase {
      *
      * @before
      */
-    public function setUpFixtures() {
+    public function setUpFixtures()
+    {
         parent::setUpFixtures();
         $this->modx->getParser();
         $this->tag = new modPlaceholderTag($this->modx);
         $this->tag->setCacheable(false);
-        $this->tag->set('name','utp');
+        $this->tag->set('name', 'utp');
     }
 
     /**
@@ -49,16 +51,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerCat
      */
-    public function testCat($value,$string,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:cat=`'.$string.'`');
+    public function testCat($value, $string, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:cat=`' . $string . '`');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerCat() {
+    public function providerCat()
+    {
         return [
             ['','',''],
             ['This dog',' went home','This dog went home'],
@@ -73,16 +77,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerUppercase
      */
-    public function testUppercase($value,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:uppercase');
+    public function testUppercase($value, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:uppercase');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerUppercase() {
+    public function providerUppercase()
+    {
         return [
             ['',''],
             ['ALREADY THERE','ALREADY THERE'],
@@ -98,16 +104,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerLowercase
      */
-    public function testLowercase($value,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:lowercase');
+    public function testLowercase($value, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:lowercase');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerLowercase() {
+    public function providerLowercase()
+    {
         return [
             ['',''],
             ['BOOYAH','booyah'],
@@ -123,16 +131,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerUCWords
      */
-    public function testUCWords($value,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:ucwords');
+    public function testUCWords($value, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:ucwords');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerUCWords() {
+    public function providerUCWords()
+    {
         return [
             ['',''],
             ['test','Test'],
@@ -148,16 +158,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerUCFirst
      */
-    public function testUCFirst($value,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:ucfirst');
+    public function testUCFirst($value, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:ucfirst');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerUCFirst() {
+    public function providerUCFirst()
+    {
         return [
             ['',''],
             ['test','Test'],
@@ -174,16 +186,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerStripString
      */
-    public function testStripString($value,$strip,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:stripString=`'.$strip.'`');
+    public function testStripString($value, $strip, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:stripString=`' . $strip . '`');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerStripString() {
+    public function providerStripString()
+    {
         return [
             ['','',''],
             ['Don\'t even think about it','Don\'t even ','think about it'],
@@ -198,16 +212,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerReplace
      */
-    public function testReplace($value,$with,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:replace=`'.$with.'`');
+    public function testReplace($value, $with, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:replace=`' . $with . '`');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerReplace() {
+    public function providerReplace()
+    {
         return [
             ['','',''],
             ['Strip it all out','it all==none','Strip none out'],
@@ -222,16 +238,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerStripTags
      */
-    public function testStripTags($value,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:stripTags');
+    public function testStripTags($value, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:stripTags');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerStripTags() {
+    public function providerStripTags()
+    {
         return [
             ['Hi!<br />','Hi!'],
             ['<strong>Boo!</strong> No.','Boo! No.'],
@@ -247,16 +265,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerStrLen
      */
-    public function testStrLen($value,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:strlen');
+    public function testStrLen($value, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:strlen');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerStrLen() {
+    public function providerStrLen()
+    {
         return [
             ['abcdefghijklmnopqrstuvwxyz',26],
             ['',0],
@@ -271,16 +291,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerEsrever
      */
-    public function testEsrever($value,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:reverse');
+    public function testEsrever($value, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:reverse');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerEsrever() {
+    public function providerEsrever()
+    {
         return [
             ['a brown fox','xof nworb a'],
             ['level','level'],
@@ -296,16 +318,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerLimit
      */
-    public function testLimit($value,$limit,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:limit=`'.$limit.'`');
+    public function testLimit($value, $limit, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:limit=`' . $limit . '`');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerLimit() {
+    public function providerLimit()
+    {
         return [
             [
                 'Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'
@@ -327,16 +351,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerEllipsis
      */
-    public function testEllipsis($value,$limit,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:ellipsis=`'.$limit.'`');
+    public function testEllipsis($value, $limit, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:ellipsis=`' . $limit . '`');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerEllipsis() {
+    public function providerEllipsis()
+    {
         return [
             [
                 'Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Ut depeeboos dooee fel megna oornere-a eleeqooem. Preesent ioo messa ut sepeeee sulleecitoodin mulesteee-a. Preesent looctoos, turtur sulleecitoodin sulleecitoodin fooceeboos, iret deeem imperdeeet moorees, nun iecoolees sepeeee mee qooees deeem. Qooeesqooe-a iooeesmud tempoos joostu. Ut iget neesl. Noolla feceelisi. Noolla nun felees. Um gesh dee bork, bork! Prueen iooeesmud toorpees nun toorpees. Um gesh dee bork, bork! Integer ioo iret sed neebh purta pleceret. Um de hur de hur de hur. Iteeem lectoos neebh, mettees feetee-a, deegnissim a, ileeeffend ec, deeem. Coom suceeis netuqooe-a peneteeboos it megnees dees pertooreeent muntes, nescetoor reedicooloos moos. Um gesh dee bork, bork! Iteeem nec felees fel mee teencidoont rhuncoos. Um gesh dee bork, bork! Moorees depeeboos. Um gesh dee bork, bork! Foosce-a qooem reesoos, pleceret sed, deegnissim rootroom, ileeeffend sed, leu. Lurem ipsoom dulur seet emet, cunsectetooer edeepiscing ileet. Um de hur de hur de hur. Eleeqooem lurem.'
@@ -357,16 +383,18 @@ class modOutputFilterTest extends MODxTestCase {
      * @param string $expected
      * @dataProvider providerNL2BR
      */
-    public function testNL2BR($value,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:nl2br');
+    public function testNL2BR($value, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:nl2br');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerNL2BR() {
+    public function providerNL2BR()
+    {
         return [
             [
                 'A test paragraph
@@ -385,16 +413,18 @@ goes here'
      * @param string $expected
      * @dataProvider providerAdd
      */
-    public function testAdd($value,$add,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:add=`'.$add.'`');
+    public function testAdd($value, $add, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:add=`' . $add . '`');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerAdd() {
+    public function providerAdd()
+    {
         return [
             ['',0,0],
             ['123',1,124],
@@ -411,16 +441,18 @@ goes here'
      * @param string $expected
      * @dataProvider providerSubtract
      */
-    public function testSubtract($value,$add,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:subtract=`'.$add.'`');
+    public function testSubtract($value, $add, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:subtract=`' . $add . '`');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerSubtract() {
+    public function providerSubtract()
+    {
         return [
             ['',0,0],
             ['123',1,122],
@@ -438,16 +470,18 @@ goes here'
      * @param string $expected
      * @dataProvider providerMultiply
      */
-    public function testMultiply($value,$multiplier,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:multiply=`'.$multiplier.'`');
+    public function testMultiply($value, $multiplier, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:multiply=`' . $multiplier . '`');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerMultiply() {
+    public function providerMultiply()
+    {
         return [
             ['',0,0],
             [1,5,5],
@@ -464,16 +498,18 @@ goes here'
      * @param string $expected
      * @dataProvider providerDivide
      */
-    public function testDivide($value,$divider,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:divide=`'.$divider.'`');
+    public function testDivide($value, $divider, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:divide=`' . $divider . '`');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerDivide() {
+    public function providerDivide()
+    {
         return [
             [1,0,.5],
             [0,0,0],
@@ -489,16 +525,18 @@ goes here'
      * @param string $expected
      * @dataProvider providerModulus
      */
-    public function testModulus($value,$modulus,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:modulus=`'.$modulus.'`');
+    public function testModulus($value, $modulus, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:modulus=`' . $modulus . '`');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerModulus() {
+    public function providerModulus()
+    {
         return [
             [4,2,0],
             [9,3,0],
@@ -516,16 +554,18 @@ goes here'
      * @param string $expected
      * @dataProvider providerDefault
      */
-    public function testDefault($value,$default,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:default=`'.$default.'`');
+    public function testDefault($value, $default, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:default=`' . $default . '`');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerDefault() {
+    public function providerDefault()
+    {
         return [
             ['','foo','foo'],
             ['z','a','z'],
@@ -540,16 +580,18 @@ goes here'
      * @param string $expected
      * @dataProvider providerNotEmpty
      */
-    public function testNotEmpty($value,$default,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:notempty=`'.$default.'`');
+    public function testNotEmpty($value, $default, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:notempty=`' . $default . '`');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerNotEmpty() {
+    public function providerNotEmpty()
+    {
         return [
             ['','foo',''],
             ['z','a','a'],
@@ -563,16 +605,18 @@ goes here'
      * @param string $value
      * @dataProvider providerStrToTime
      */
-    public function testStrToTime($value) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:strtotime');
+    public function testStrToTime($value)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:strtotime');
         $o = $this->tag->process();
-        $this->assertEquals(strtotime($value),$o);
+        $this->assertEquals(strtotime($value), $o);
     }
     /**
      * @return array
      */
-    public function providerStrToTime() {
+    public function providerStrToTime()
+    {
         return [
             ['2011-05-01 10:23:11'],
             [''],
@@ -585,16 +629,18 @@ goes here'
      * @param string $value
      * @dataProvider providerMD5
      */
-    public function testMD5($value) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:md5');
+    public function testMD5($value)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:md5');
         $o = $this->tag->process();
-        $this->assertEquals(md5($value),$o);
+        $this->assertEquals(md5($value), $o);
     }
     /**
      * @return array
      */
-    public function providerMD5() {
+    public function providerMD5()
+    {
         return [
             ['coolio'],
             [''],
@@ -608,16 +654,18 @@ goes here'
      * @param string $expected
      * @dataProvider providerCData
      */
-    public function testCData($value,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:cdata');
+    public function testCData($value, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:cdata');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerCData() {
+    public function providerCData()
+    {
         return [
             ['code here','<![CDATA[code here]]>'],
             ['','<![CDATA[]]>'],
@@ -631,16 +679,18 @@ goes here'
      * @param string $expected
      * @dataProvider providerUrlEncode
      */
-    public function testUrlEncode($value,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:urlencode');
+    public function testUrlEncode($value, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:urlencode');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerUrlEncode() {
+    public function providerUrlEncode()
+    {
         return [
             ['test','test'],
             ['test with space','test+with+space'],
@@ -654,16 +704,18 @@ goes here'
      * @param string $expected
      * @dataProvider providerUrlDecode
      */
-    public function testUrlDecode($value,$expected) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:urldecode');
+    public function testUrlDecode($value, $expected)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:urldecode');
         $o = $this->tag->process();
-        $this->assertEquals($expected,$o);
+        $this->assertEquals($expected, $o);
     }
     /**
      * @return array
      */
-    public function providerUrlDecode() {
+    public function providerUrlDecode()
+    {
         return [
             ['test','test'],
             ['test+with+space','test with space'],
@@ -677,20 +729,22 @@ goes here'
      * @param boolean $addTag
      * @dataProvider providerCssToHead
      */
-    public function testCssToHead($value,$addTag) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:cssToHead');
+    public function testCssToHead($value, $addTag)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:cssToHead');
         $this->tag->process();
         if ($addTag) {
-            $value = '<link rel="stylesheet" href="'.$value.'" type="text/css" />';
+            $value = '<link rel="stylesheet" href="' . $value . '" type="text/css" />';
         }
-        $this->assertContains($value,$this->modx->sjscripts);
+        $this->assertContains($value, $this->modx->sjscripts);
         unset($this->modx->sjscripts[$value]);
     }
     /**
      * @return array
      */
-    public function providerCssToHead() {
+    public function providerCssToHead()
+    {
         return [
             ['assets/css/style.css',true],
             ['<link rel="stylesheet" href="assets/css/style.css" type="text/css" />',false],
@@ -703,17 +757,19 @@ goes here'
      * @param string $value
      * @dataProvider providerHtmlToHead
      */
-    public function testHtmlToHead($value) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:htmlToHead');
+    public function testHtmlToHead($value)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:htmlToHead');
         $this->tag->process();
-        $this->assertContains($value,$this->modx->sjscripts);
+        $this->assertContains($value, $this->modx->sjscripts);
         unset($this->modx->sjscripts[$value]);
     }
     /**
      * @return array
      */
-    public function providerHtmlToHead() {
+    public function providerHtmlToHead()
+    {
         return [
             ['<style>'],
         ];
@@ -725,17 +781,19 @@ goes here'
      * @param string $value
      * @dataProvider providerHtmlToBottom
      */
-    public function testHtmlToBottom($value) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:htmlToBottom');
+    public function testHtmlToBottom($value)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:htmlToBottom');
         $this->tag->process();
-        $this->assertContains($value,$this->modx->jscripts);
+        $this->assertContains($value, $this->modx->jscripts);
         unset($this->modx->jscripts[$value]);
     }
     /**
      * @return array
      */
-    public function providerHtmlToBottom() {
+    public function providerHtmlToBottom()
+    {
         return [
             ['<footer>'],
         ];
@@ -749,20 +807,22 @@ goes here'
      * @param boolean $plainText
      * @dataProvider providerJsToBottom
      */
-    public function testJsToBottom($value,$addTag = false,$plainText = false) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:jsToBottom=`'.($plainText ? 1 : 0).'`');
+    public function testJsToBottom($value, $addTag = false, $plainText = false)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:jsToBottom=`' . ($plainText ? 1 : 0) . '`');
         $this->tag->process();
         if ($addTag) {
-            $value = '<script src="'.$value.'"></script>';
+            $value = '<script src="' . $value . '"></script>';
         }
-        $this->assertContains($value,$this->modx->jscripts);
+        $this->assertContains($value, $this->modx->jscripts);
         unset($this->modx->jscripts[$value]);
     }
     /**
      * @return array
      */
-    public function providerJsToBottom() {
+    public function providerJsToBottom()
+    {
         return [
             ['assets/js/script.js',true,false],
             ['<script src="assets/js/script2.js"></script>',false,false],
@@ -778,20 +838,22 @@ goes here'
      * @param boolean $plainText
      * @dataProvider providerJsToHead
      */
-    public function testJsToHead($value,$addTag = false,$plainText = false) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:jsToHead=`'.($plainText ? 1 : 0).'`');
+    public function testJsToHead($value, $addTag = false, $plainText = false)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:jsToHead=`' . ($plainText ? 1 : 0) . '`');
         $this->tag->process();
         if ($addTag) {
-            $value = '<script src="'.$value.'"></script>';
+            $value = '<script src="' . $value . '"></script>';
         }
-        $this->assertContains($value,$this->modx->sjscripts);
+        $this->assertContains($value, $this->modx->sjscripts);
         unset($this->modx->sjscripts[$value]);
     }
     /**
      * @return array
      */
-    public function providerJsToHead() {
+    public function providerJsToHead()
+    {
         return [
             ['assets/js/hscript.js',true,false],
             ['<script src="assets/js/hscript2.js"></script>',false,false],
@@ -802,7 +864,8 @@ goes here'
     /**
      * Test :jsToBottom with async loading attribute
      */
-    public function testJsToBottomAsync() {
+    public function testJsToBottomAsync()
+    {
         $url = 'assets/js/async-script.js';
         $this->modx->setPlaceholder('utp', $url);
         $this->tag->set('name', 'utp:jsToBottom=`0,async`');
@@ -814,7 +877,8 @@ goes here'
     /**
      * Test :jsToHead with defer loading attribute
      */
-    public function testJsToHeadDefer() {
+    public function testJsToHeadDefer()
+    {
         $url = 'assets/js/defer-script.js';
         $this->modx->setPlaceholder('utp', $url);
         $this->tag->set('name', 'utp:jsToHead=`0,defer`');
@@ -955,19 +1019,21 @@ goes here'
      * @param mixed $value
      * @dataProvider providerToPlaceholder
      */
-    public function testToPlaceholder($toPlaceholder,$value) {
-        $this->modx->setPlaceholder('utp',$value);
-        $this->tag->set('name','utp:toPlaceholder=`'.$toPlaceholder.'`');
+    public function testToPlaceholder($toPlaceholder, $value)
+    {
+        $this->modx->setPlaceholder('utp', $value);
+        $this->tag->set('name', 'utp:toPlaceholder=`' . $toPlaceholder . '`');
         $this->tag->process();
-        $this->assertArrayHasKey($toPlaceholder,$this->modx->placeholders);
+        $this->assertArrayHasKey($toPlaceholder, $this->modx->placeholders);
         if (isset($this->modx->placeholders[$toPlaceholder])) {
-            $this->assertEquals($value,$this->modx->placeholders[$toPlaceholder]);
+            $this->assertEquals($value, $this->modx->placeholders[$toPlaceholder]);
         }
     }
     /**
      * @return array
      */
-    public function providerToPlaceholder() {
+    public function providerToPlaceholder()
+    {
         return [
             ['myPlaceholder','Test'],
             ['emptyPlaceholder',''],

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -393,4 +393,26 @@ class modXTest extends MODxTestCase
             [22, 2, ['context' => 'custom'], [23, 24]]
         ];
     }
+
+    /**
+     * Test regClientScript with async loading attribute
+     */
+    public function testRegClientScriptAsync()
+    {
+        $url = 'https://cdn.example.com/widget.js';
+        $this->modx->regClientScript($url, false, 'async');
+        $expected = '<script src="' . $url . '" async></script>';
+        $this->assertContains($expected, $this->modx->jscripts);
+    }
+
+    /**
+     * Test regClientStartupScript with defer loading attribute
+     */
+    public function testRegClientStartupScriptDefer()
+    {
+        $url = 'assets/js/analytics.js';
+        $this->modx->regClientStartupScript($url, false, 'defer');
+        $expected = '<script src="' . $url . '" defer></script>';
+        $this->assertContains($expected, $this->modx->sjscripts);
+    }
 }

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -415,4 +415,28 @@ class modXTest extends MODxTestCase
         $expected = '<script src="' . $url . '" defer></script>';
         $this->assertContains($expected, $this->modx->sjscripts);
     }
+
+    /**
+     * Script URLs remain unique when loading attributes differ.
+     */
+    public function testClientScriptsDeduplicateByUrl()
+    {
+        $bodyUrl = 'assets/js/deduplicated-body.js';
+        $this->modx->regClientScript($bodyUrl, false, 'async');
+        $this->modx->regClientScript($bodyUrl, false, 'defer');
+
+        $headUrl = 'assets/js/deduplicated-head.js';
+        $this->modx->regClientStartupScript($headUrl, false, 'defer');
+        $this->modx->regClientStartupScript($headUrl, false, 'async');
+
+        $bodyScripts = array_filter($this->modx->jscripts, static function ($script) use ($bodyUrl) {
+            return strpos($script, $bodyUrl) !== false;
+        });
+        $headScripts = array_filter($this->modx->sjscripts, static function ($script) use ($headUrl) {
+            return strpos($script, $headUrl) !== false;
+        });
+
+        $this->assertSame(['<script src="' . $bodyUrl . '" async></script>'], array_values($bodyScripts));
+        $this->assertSame(['<script src="' . $headUrl . '" defer></script>'], array_values($headScripts));
+    }
 }

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -467,4 +467,26 @@ class modXTest extends MODxTestCase
         $this->assertSame(['<script src="' . $bodyUrl . '" async></script>'], array_values($bodyScripts));
         $this->assertSame(['<script src="' . $headUrl . '" defer></script>'], array_values($headScripts));
     }
+
+    /**
+     * Invalid loading values must be ignored (no attribute on the tag).
+     */
+    public function testRegClientScriptIgnoresInvalidLoading()
+    {
+        $url = 'assets/js/invalid-loading.js';
+        $this->modx->regClientScript($url, false, 'module');
+        $expected = '<script src="' . $url . '"></script>';
+        $this->assertContains($expected, $this->modx->jscripts);
+    }
+
+    /**
+     * Declared signatures stay two-parameter so existing modX subclasses remain compatible.
+     */
+    public function testRegClientScriptDeclaredSignatureStaysTwoParameters()
+    {
+        $body = new \ReflectionMethod(\MODX\Revolution\modX::class, 'regClientScript');
+        $head = new \ReflectionMethod(\MODX\Revolution\modX::class, 'regClientStartupScript');
+        $this->assertSame(2, $body->getNumberOfParameters());
+        $this->assertSame(2, $head->getNumberOfParameters());
+    }
 }

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -104,7 +105,8 @@ class modXTest extends MODxTestCase
      *
      * @after
      */
-    public function tearDownFixtures() {
+    public function tearDownFixtures()
+    {
         parent::tearDownFixtures();
         $this->modx->placeholders = [];
         $this->modx->resourceMap = [[1]];
@@ -113,9 +115,10 @@ class modXTest extends MODxTestCase
     /**
      * Test getting the modCacheManager instance.
      */
-    public function testGetCacheManager() {
+    public function testGetCacheManager()
+    {
         $this->modx->getCacheManager();
-        $this->assertInstanceOf(modCacheManager::class,$this->modx->cacheManager, "Failed to load a modCacheManager instance");
+        $this->assertInstanceOf(modCacheManager::class, $this->modx->cacheManager, "Failed to load a modCacheManager instance");
     }
 
     /**
@@ -125,17 +128,23 @@ class modXTest extends MODxTestCase
      * @param string $allowedTags
      * @dataProvider providerSanitizeString
      */
-    public function testSanitizeString($expected,$string,$chars = ['/',"'",'"','(',')',';','>','<'],$allowedTags = '') {
-        if ($chars == null) $chars = ['/',"'",'"','(',')',';','>','<'];
-        if ($allowedTags == null) $allowedTags = '';
+    public function testSanitizeString($expected, $string, $chars = ['/',"'",'"','(',')',';','>','<'], $allowedTags = '')
+    {
+        if ($chars == null) {
+            $chars = ['/',"'",'"','(',')',';','>','<'];
+        }
+        if ($allowedTags == null) {
+            $allowedTags = '';
+        }
 
-        $result = $this->modx->sanitizeString($string,$chars,$allowedTags);
-        $this->assertEquals($expected,$result);
+        $result = $this->modx->sanitizeString($string, $chars, $allowedTags);
+        $this->assertEquals($expected, $result);
     }
     /**
      * @return array
      */
-    public function providerSanitizeString() {
+    public function providerSanitizeString()
+    {
         return [
             ['test','test'],
             ['Get this','Get (this)'],
@@ -147,14 +156,16 @@ class modXTest extends MODxTestCase
      * @param string $expected
      * @dataProvider providerToQueryString
      */
-    public function testToQueryString(array $parameters,$expected) {
+    public function testToQueryString(array $parameters, $expected)
+    {
         $result = modX::toQueryString($parameters);
-        $this->assertEquals($expected,$result);
+        $this->assertEquals($expected, $result);
     }
     /**
      * @return array
      */
-    public function providerToQueryString() {
+    public function providerToQueryString()
+    {
         return [
             [['r' => 1],'r=1'],
             [['r' => 1,'s' => 2],'r=1&s=2'],
@@ -168,7 +179,8 @@ class modXTest extends MODxTestCase
      * @param boolean $stopOnNotice
      * @dataProvider providerSetDebug
      */
-    public function testSetDebug($stopOnNotice) {
+    public function testSetDebug($stopOnNotice)
+    {
         //$oldValue = $this->modx->setDebug(true,$stopOnNotice);
         $oldValue = $this->modx->getDebug();
         $this->modx->setDebug($stopOnNotice);
@@ -179,7 +191,8 @@ class modXTest extends MODxTestCase
     /**
      * @return array
      */
-    public function providerSetDebug() {
+    public function providerSetDebug()
+    {
         return [
             [true],
             [false],
@@ -189,7 +202,8 @@ class modXTest extends MODxTestCase
     /**
      * Test the getParser method
      */
-    public function testGetParser() {
+    public function testGetParser()
+    {
         $this->modx->getParser();
         $this->assertInstanceOf(modParser::class, $this->modx->parser, "Failed to load a modParser instance");
         $this->modx->parser = null;
@@ -200,14 +214,16 @@ class modXTest extends MODxTestCase
      * @param mixed $v
      * @dataProvider providerSetPlaceholder
      */
-    public function testSetPlaceholder($k,$v) {
-        $this->modx->setPlaceholder($k,$v);
-        $this->assertEquals($v,$this->modx->placeholders[$k]);
+    public function testSetPlaceholder($k, $v)
+    {
+        $this->modx->setPlaceholder($k, $v);
+        $this->assertEquals($v, $this->modx->placeholders[$k]);
     }
     /**
      * @return array
      */
-    public function providerSetPlaceholder() {
+    public function providerSetPlaceholder()
+    {
         return [
             ['name', 'Joe'],
             ['testArray', ['one' => 1,'two' => 2]],
@@ -221,14 +237,16 @@ class modXTest extends MODxTestCase
      * @param string $namespace
      * @dataProvider providerSetPlaceholders
      */
-    public function testSetPlaceholders(array $placeholders,$key,$value,$namespace = '') {
-        $this->modx->setPlaceholders($placeholders,$namespace);
-        $this->assertEquals($value,$this->modx->placeholders[$key]);
+    public function testSetPlaceholders(array $placeholders, $key, $value, $namespace = '')
+    {
+        $this->modx->setPlaceholders($placeholders, $namespace);
+        $this->assertEquals($value, $this->modx->placeholders[$key]);
     }
     /**
      * @return array
      */
-    public function providerSetPlaceholders() {
+    public function providerSetPlaceholders()
+    {
         return [
             [['one' => 1,'two' => 2],'two',2],
             [['one' => 1,'two' => 2],'test.two',2,'test.'],
@@ -244,14 +262,16 @@ class modXTest extends MODxTestCase
      * @param bool $restore
      * @dataProvider providerToPlaceholders
      */
-    public function testToPlaceholders($placeholders,$key,$value,$prefix = '',$separator = '.',$restore = false) {
-        $this->modx->toPlaceholders($placeholders,$prefix,$separator,$restore);
-        $this->assertEquals($value,$this->modx->placeholders[$key]);
+    public function testToPlaceholders($placeholders, $key, $value, $prefix = '', $separator = '.', $restore = false)
+    {
+        $this->modx->toPlaceholders($placeholders, $prefix, $separator, $restore);
+        $this->assertEquals($value, $this->modx->placeholders[$key]);
     }
     /**
      * @return array
      */
-    public function providerToPlaceholders() {
+    public function providerToPlaceholders()
+    {
         return [
             [['one' => 1,'two' => 2],'two',2],
             [['one' => 1,'two' => 2],'test.two',2,'test'],
@@ -268,14 +288,16 @@ class modXTest extends MODxTestCase
      * @param bool $restore
      * @dataProvider providerToPlaceholder
      */
-    public function testToPlaceholder($key,$value,$expectedKey,$prefix = '',$separator = '.',$restore = false) {
-        $this->modx->toPlaceholder($key,$value,$prefix,$separator,$restore);
-        $this->assertEquals($value,$this->modx->placeholders[$expectedKey]);
+    public function testToPlaceholder($key, $value, $expectedKey, $prefix = '', $separator = '.', $restore = false)
+    {
+        $this->modx->toPlaceholder($key, $value, $prefix, $separator, $restore);
+        $this->assertEquals($value, $this->modx->placeholders[$expectedKey]);
     }
     /**
      * @return array
      */
-    public function providerToPlaceholder() {
+    public function providerToPlaceholder()
+    {
         return [
             ['two',2,'two'],
             ['two',2,'test.two','test'],
@@ -288,15 +310,17 @@ class modXTest extends MODxTestCase
      * @param mixed $value
      * @dataProvider providerGetPlaceholder
      */
-    public function testGetPlaceholder($key,$value) {
-        $this->modx->setPlaceholder($key,$value);
+    public function testGetPlaceholder($key, $value)
+    {
+        $this->modx->setPlaceholder($key, $value);
         $result = $this->modx->getPlaceholder($key);
-        $this->assertEquals($value,$result);
+        $this->assertEquals($value, $result);
     }
     /**
      * @return array
      */
-    public function providerGetPlaceholder() {
+    public function providerGetPlaceholder()
+    {
         return [
             ['test','one'],
             ['one', ['two' => 2]],
@@ -309,15 +333,17 @@ class modXTest extends MODxTestCase
      * @param mixed $value
      * @dataProvider providerUnsetPlaceholder
      */
-    public function testUnsetPlaceholder($key,$value) {
-        $this->modx->setPlaceholder($key,$value);
+    public function testUnsetPlaceholder($key, $value)
+    {
+        $this->modx->setPlaceholder($key, $value);
         $this->modx->unsetPlaceholder($key);
-        $this->assertArrayNotHasKey($key,$this->modx->placeholders);
+        $this->assertArrayNotHasKey($key, $this->modx->placeholders);
     }
     /**
      * @return array
      */
-    public function providerUnsetPlaceholder() {
+    public function providerUnsetPlaceholder()
+    {
         return [
             ['test','one'],
             ['one', ['two' => 2]],
@@ -331,15 +357,17 @@ class modXTest extends MODxTestCase
      * @param string $keyToCheck
      * @dataProvider providerUnsetPlaceholders
      */
-    public function testUnsetPlaceholders(array $placeholders,array $placeholdersToUnset,$keyToCheck) {
+    public function testUnsetPlaceholders(array $placeholders, array $placeholdersToUnset, $keyToCheck)
+    {
         $this->modx->setPlaceholders($placeholders);
         $this->modx->unsetPlaceholders($placeholdersToUnset);
-        $this->assertArrayNotHasKey($keyToCheck,$this->modx->placeholders);
+        $this->assertArrayNotHasKey($keyToCheck, $this->modx->placeholders);
     }
     /**
      * @return array
      */
-    public function providerUnsetPlaceholders() {
+    public function providerUnsetPlaceholders()
+    {
         return [
             [['test' => 'testing'], ['test'],'test'],
             [['test' => 'testing','one' => 1], ['one'],'one'],

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -684,17 +684,13 @@ class modOutputFilter
                             $output = '';
                             break;
                         case 'jsToHead':
-                            if (empty($m_val)) {
-                                $m_val = false;
-                            }
-                            $this->modx->regClientStartupScript($output, $m_val);
+                            list($plaintext, $loading) = $this->parseJsModifierValue($m_val);
+                            $this->modx->regClientStartupScript($output, $plaintext, $loading);
                             $output = '';
                             break;
                         case 'jsToBottom':
-                            if (empty($m_val)) {
-                                $m_val = false;
-                            }
-                            $this->modx->regClientScript($output, $m_val);
+                            list($plaintext, $loading) = $this->parseJsModifierValue($m_val);
+                            $this->modx->regClientScript($output, $plaintext, $loading);
                             $output = '';
                             break;
                         case 'in':
@@ -886,5 +882,25 @@ class modOutputFilter
         if ($this->modx->getDebug() === true) {
             $this->modx->log(modX::LOG_LEVEL_DEBUG, $msg);
         }
+    }
+
+    /**
+     * Parse jsToHead/jsToBottom modifier value into plaintext and loading (async/defer).
+     *
+     * @param mixed $m_val Modifier value e.g. "0", "1", "0,async", "0,defer"
+     * @return array{0: bool, 1: string} [plaintext, loading]
+     */
+    private function parseJsModifierValue($m_val)
+    {
+        $plaintext = false;
+        $loading = '';
+        if (strpos((string)$m_val, ',') !== false) {
+            $parts = explode(',', (string)$m_val, 2);
+            $plaintext = !empty(trim($parts[0])) && trim($parts[0]) !== '0';
+            $loading = isset($parts[1]) ? trim($parts[1]) : '';
+        } else {
+            $plaintext = !empty($m_val) && $m_val !== '0';
+        }
+        return [$plaintext, $loading];
     }
 }

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1597,16 +1597,24 @@ class modX extends xPDO {
     /**
      * Register JavaScript to be injected inside the HEAD tag of a resource.
      *
+     * An optional third argument may be passed as the loading attribute:
+     * 'async' or 'defer' for URL scripts. It is read via func_get_arg() so the
+     * declared signature stays compatible with subclasses that override the
+     * historical two-parameter form.
+     *
      * @param string $src The JavaScript to be injected before the closing HEAD
      * tag of an HTML response.
      * @param boolean $plaintext Optional param to treat the $src as plaintext
      * rather than assuming it is JavaScript.
-     * @param string $loading Optional loading attribute: 'async' or 'defer' for URL scripts.
      * @return void
      */
-    public function regClientStartupScript($src, $plaintext = false, $loading = '')
+    public function regClientStartupScript($src, $plaintext = false)
     {
-        $loading = $loading ? strtolower(trim($loading)) : '';
+        $loading = '';
+        if (func_num_args() > 2) {
+            $loading = func_get_arg(2);
+        }
+        $loading = is_string($loading) ? strtolower(trim($loading)) : '';
         if ($loading && $loading !== 'async' && $loading !== 'defer') {
             $loading = '';
         }
@@ -1627,16 +1635,24 @@ class modX extends xPDO {
     /**
      * Register JavaScript to be injected before the closing BODY tag.
      *
+     * An optional third argument may be passed as the loading attribute:
+     * 'async' or 'defer' for URL scripts. It is read via func_get_arg() so the
+     * declared signature stays compatible with subclasses that override the
+     * historical two-parameter form.
+     *
      * @param string $src The JavaScript to be injected before the closing BODY
      * tag in an HTML response.
      * @param boolean $plaintext Optional param to treat the $src as plaintext
      * rather than assuming it is JavaScript.
-     * @param string $loading Optional loading attribute: 'async' or 'defer' for URL scripts.
      * @return void
      */
-    public function regClientScript($src, $plaintext = false, $loading = '')
+    public function regClientScript($src, $plaintext = false)
     {
-        $loading = $loading ? strtolower(trim($loading)) : '';
+        $loading = '';
+        if (func_num_args() > 2) {
+            $loading = func_get_arg(2);
+        }
+        $loading = is_string($loading) ? strtolower(trim($loading)) : '';
         if ($loading && $loading !== 'async' && $loading !== 'defer') {
             $loading = '';
         }

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1610,11 +1610,10 @@ class modX extends xPDO {
         if ($loading && $loading !== 'async' && $loading !== 'defer') {
             $loading = '';
         }
-        $key = $src . ($loading ? '|' . $loading : '');
-        if (empty($src) || array_key_exists($key, $this->loadedjscripts)) {
+        if (empty($src) || array_key_exists($src, $this->loadedjscripts)) {
             return;
         }
-        $this->loadedjscripts[$key] = true;
+        $this->loadedjscripts[$src] = true;
         if ($plaintext == true) {
             $this->sjscripts[count($this->sjscripts)] = $src;
         } elseif (strpos(strtolower($src), "<script") !== false) {
@@ -1641,11 +1640,10 @@ class modX extends xPDO {
         if ($loading && $loading !== 'async' && $loading !== 'defer') {
             $loading = '';
         }
-        $key = $src . ($loading ? '|' . $loading : '');
-        if (isset($this->loadedjscripts[$key])) {
+        if (isset($this->loadedjscripts[$src])) {
             return;
         }
-        $this->loadedjscripts[$key] = true;
+        $this->loadedjscripts[$src] = true;
         if ($plaintext == true) {
             $this->jscripts[count($this->jscripts)] = $src;
         } elseif (strpos(strtolower($src), "<script") !== false) {

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1601,20 +1601,27 @@ class modX extends xPDO {
      * tag of an HTML response.
      * @param boolean $plaintext Optional param to treat the $src as plaintext
      * rather than assuming it is JavaScript.
+     * @param string $loading Optional loading attribute: 'async' or 'defer' for URL scripts.
      * @return void
      */
-    public function regClientStartupScript($src, $plaintext= false) {
-        if (!empty ($src) && !array_key_exists($src, $this->loadedjscripts)) {
-            if (isset ($this->loadedjscripts[$src]))
-                return;
-            $this->loadedjscripts[$src]= true;
-            if ($plaintext == true) {
-                $this->sjscripts[count($this->sjscripts)]= $src;
-            } elseif (strpos(strtolower($src), "<script") !== false) {
-                $this->sjscripts[count($this->sjscripts)]= $src;
-            } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
-            }
+    public function regClientStartupScript($src, $plaintext = false, $loading = '')
+    {
+        $loading = $loading ? strtolower(trim($loading)) : '';
+        if ($loading && $loading !== 'async' && $loading !== 'defer') {
+            $loading = '';
+        }
+        $key = $src . ($loading ? '|' . $loading : '');
+        if (empty($src) || array_key_exists($key, $this->loadedjscripts)) {
+            return;
+        }
+        $this->loadedjscripts[$key] = true;
+        if ($plaintext == true) {
+            $this->sjscripts[count($this->sjscripts)] = $src;
+        } elseif (strpos(strtolower($src), "<script") !== false) {
+            $this->sjscripts[count($this->sjscripts)] = $src;
+        } else {
+            $attr = $loading ? ' ' . $loading : '';
+            $this->sjscripts[count($this->sjscripts)] = '<script src="' . $src . '"' . $attr . '></script>';
         }
     }
 
@@ -1625,18 +1632,27 @@ class modX extends xPDO {
      * tag in an HTML response.
      * @param boolean $plaintext Optional param to treat the $src as plaintext
      * rather than assuming it is JavaScript.
+     * @param string $loading Optional loading attribute: 'async' or 'defer' for URL scripts.
      * @return void
      */
-    public function regClientScript($src, $plaintext= false) {
-        if (isset ($this->loadedjscripts[$src]))
+    public function regClientScript($src, $plaintext = false, $loading = '')
+    {
+        $loading = $loading ? strtolower(trim($loading)) : '';
+        if ($loading && $loading !== 'async' && $loading !== 'defer') {
+            $loading = '';
+        }
+        $key = $src . ($loading ? '|' . $loading : '');
+        if (isset($this->loadedjscripts[$key])) {
             return;
-        $this->loadedjscripts[$src]= true;
+        }
+        $this->loadedjscripts[$key] = true;
         if ($plaintext == true) {
-            $this->jscripts[count($this->jscripts)]= $src;
+            $this->jscripts[count($this->jscripts)] = $src;
         } elseif (strpos(strtolower($src), "<script") !== false) {
-            $this->jscripts[count($this->jscripts)]= $src;
+            $this->jscripts[count($this->jscripts)] = $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
+            $attr = $loading ? ' ' . $loading : '';
+            $this->jscripts[count($this->jscripts)] = '<script src="' . $src . '"' . $attr . '></script>';
         }
     }
 


### PR DESCRIPTION
### What does it do?
Optional `async` / `defer` for `regClientScript` and `regClientStartupScript`, plus `:jsToBottom=`0,async`` / `:jsToHead=`0,defer``. Loading is passed as a third call argument and read with `func_get_arg()` so the declared two-parameter signatures stay compatible with existing `modX` subclasses. Script URLs still dedupe; the first registration wins.

### Why is it needed?
Callers need non-blocking script tags without hand-writing HTML (#14520).

### How to test
```
core/vendor/bin/phpunit -c _build/test/phpunit.xml --filter 'testRegClientScriptAsync|testRegClientStartupScriptDefer|testClientScriptsDeduplicateByUrl|testRegClientScriptIgnoresInvalidLoading|testRegClientScriptDeclaredSignatureStaysTwoParameters|testJsToBottomAsync|testJsToHeadDefer'
```

### Related issue(s)/PR(s)
Resolves #14520