### PR TITLE
fix(propertyset): refresh cache after UpdateFromElement so plugin properties stay in sync

### DIFF
--- a/core/src/Revolution/Processors/Element/PropertySet/UpdateFromElement.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/UpdateFromElement.php
@@ -114,7 +114,9 @@ class UpdateFromElement extends Update
      */
     public function afterSave()
     {
-        if ($this->getProperty('clearCache', true)) {
+        $requestProps = $this->getProperties();
+        $clearCache = !array_key_exists('clearCache', $requestProps) || $this->modx->paramValueIsTrue($requestProps, 'clearCache');
+        if ($clearCache) {
             $this->modx->cacheManager->refresh();
         }
     }

--- a/core/src/Revolution/Processors/Element/PropertySet/UpdateFromElement.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/UpdateFromElement.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -9,7 +10,6 @@
  */
 
 namespace MODX\Revolution\Processors\Element\PropertySet;
-
 
 use MODX\Revolution\modElement;
 use MODX\Revolution\modPropertySet;
@@ -109,6 +109,18 @@ class UpdateFromElement extends Update
     }
 
     /**
+     * Refresh context cache so plugin/element properties in cache match the database.
+     *
+     * @return void
+     */
+    public function afterSave()
+    {
+        if ($this->getProperty('clearCache', true)) {
+            $this->modx->cacheManager->refresh();
+        }
+    }
+
+    /**
      * {@inheritDoc}
      * @return mixed
      */
@@ -116,7 +128,9 @@ class UpdateFromElement extends Update
     {
         if (!$this->object) {
             $this->element->setProperties($this->getData());
-            $this->element->save();
+            if ($this->element->save() === false) {
+                return $this->failure($this->modx->lexicon($this->objectType . '_err_save'));
+            }
         } else {
             /* Run the beforeSave method and allow stoppage */
             $canSave = $this->beforeSave();
@@ -131,6 +145,7 @@ class UpdateFromElement extends Update
             }
         }
 
+        $this->afterSave();
         $this->logManagerAction();
 
         return $this->success();

--- a/core/src/Revolution/Processors/Element/PropertySet/UpdateFromElement.php
+++ b/core/src/Revolution/Processors/Element/PropertySet/UpdateFromElement.php
@@ -109,8 +109,7 @@ class UpdateFromElement extends Update
     }
 
     /**
-     * Refresh context cache so plugin/element properties in cache match the database.
-     *
+     * {@inheritdoc}
      * @return void
      */
     public function afterSave()

--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -284,7 +284,10 @@ Ext.extend(MODx.grid.ElementProperties, MODx.grid.LocalProperty, {
     save: function() {
         const
             data = this.encode(),
-            propSetCombo = Ext.getCmp('modx-combo-property-set')
+            propSetCombo = Ext.getCmp('modx-combo-property-set'),
+            elementId = this.panel?.split('-').pop(),
+            isElementPanel = typeof elementId === 'string' && ['chunk', 'plugin', 'snippet', 'template', 'tv'].includes(elementId),
+            clearCache = !isElementPanel || Ext.getCmp(this.panel)?.form.items.get(`modx-${elementId}-clear-cache`)?.getValue()
         ;
         if (!propSetCombo) {
             this.getStore().commitChanges();
@@ -294,7 +297,8 @@ Ext.extend(MODx.grid.ElementProperties, MODx.grid.LocalProperty, {
         const params = {
             action: 'Element/PropertySet/UpdateFromElement',
             id: propSetCombo.getValue(),
-            data: data
+            data: data,
+            clearCache: clearCache
         };
         if (this.config.elementId) {
             Ext.apply(params, {


### PR DESCRIPTION
### What does it do?
After a successful Property Set save from an element (`UpdateFromElement`), refreshes the cache when `clearCache` is not false so `pluginCache` picks up new properties.

### Why is it needed?
Saving plugin properties in the manager could leave stale plugin cache until a manual refresh (#16023).

### How to test
1. Edit a plugin property set and save
2. Confirm plugin behavior / cache reflects the new values without a separate Clear Cache

### Related issue(s)/PR(s)
Resolves #16023