### PR TITLE
fix(setup): remove upload_check_exists legacy system settings

### DIFF
--- a/setup/includes/upgrades/common/3.2.1-cleanup-upload-check-exists.php
+++ b/setup/includes/upgrades/common/3.2.1-cleanup-upload-check-exists.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Remove legacy MODX 2.x system settings replaced by upload_file_exists in MODX 3.
+ * After a normal 2.x→3.x upgrade the MODX 3 setting already exists; these orphans
+ * only linger without lexicon descriptions (#15877).
+ *
+ * @var modX $modx
+ */
+
+use MODX\Revolution\modSystemSetting;
+
+$settings = [
+    'upload_check_exists',
+    'upload_check_exist',
+];
+
+$messageTemplate = '<p class="%s">%s</p>';
+
+foreach ($settings as $key) {
+    /** @var modSystemSetting|null $setting */
+    $setting = $modx->getObject(modSystemSetting::class, ['key' => $key]);
+    if (!($setting instanceof modSystemSetting)) {
+        continue;
+    }
+
+    if ($setting->remove()) {
+        $this->runner->addResult(
+            modInstallRunner::RESULT_SUCCESS,
+            sprintf(
+                $messageTemplate,
+                'ok',
+                $this->install->lexicon('system_setting_cleanup_success', ['key' => $key])
+            )
+        );
+    } else {
+        $this->runner->addResult(
+            modInstallRunner::RESULT_WARNING,
+            sprintf(
+                $messageTemplate,
+                'warning',
+                $this->install->lexicon('system_setting_cleanup_failed', ['key' => $key])
+            )
+        );
+    }
+}

--- a/setup/includes/upgrades/common/3.2.1-password-cachepwd-255.php
+++ b/setup/includes/upgrades/common/3.2.1-password-cachepwd-255.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Ensure modUser.password and modUser.cachepwd support 255 chars (PHP recommendation for future hash algorithms).
+ * Idempotent: safe to run on 2.7→3.2.1 upgrades where 2.7-native-password-hash may not have run.
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+use MODX\Revolution\modUser;
+
+$class = modUser::class;
+$table = $modx->getTableName($class);
+
+$password = $this->install->lexicon('alter_column', ['column' => 'password', 'table' => $table]);
+$this->processResults($class, $password, [$modx->manager, 'alterField'], [$class, 'password']);
+
+$cachepwd = $this->install->lexicon('alter_column', ['column' => 'cachepwd', 'table' => $table]);
+$this->processResults($class, $cachepwd, [$modx->manager, 'alterField'], [$class, 'cachepwd']);

--- a/setup/includes/upgrades/mysql/3.2.1-pl.php
+++ b/setup/includes/upgrades/mysql/3.2.1-pl.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Specific upgrades for Revolution 3.2.1-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(__DIR__) . '/common/3.2.1-password-cachepwd-255.php';
+include dirname(__DIR__) . '/common/3.2.1-cleanup-upload-check-exists.php';


### PR DESCRIPTION
### What changed and why

After upgrading from MODX 2.x, orphan system settings `upload_check_exists` / `upload_check_exist` can remain in the DB. They have no lexicon descriptions in MODX 3 (which uses `upload_file_exists`), so they show up blank in System Settings (#15877).

This PR adds a 3.2.1 upgrade step that deletes those legacy keys, following the same pattern as `3.0.0-cleanup-system-settings.php`.

`mysql/3.2.1-pl.php` also includes the password/cachepwd widen step from #16886 so both PRs share one version entry point and merge cleanly in either order.

### How to test

1. On a DB that still has `upload_check_exists` and/or `upload_check_exist`, run the 3.2.1 upgrade (or include the common script in a test upgrade run).
2. Confirm both legacy keys are gone.
3. Confirm `upload_file_exists` is unchanged.
4. Re-run the step: no errors when the keys are already absent.
5. Gate E:
   - `php -l setup/includes/upgrades/common/3.2.1-cleanup-upload-check-exists.php` → exit 0
   - `php -l setup/includes/upgrades/mysql/3.2.1-pl.php` → exit 0
   - `core/vendor/bin/phpcs --standard=phpcs.xml setup/includes/upgrades/common/3.2.1-cleanup-upload-check-exists.php setup/includes/upgrades/common/3.2.1-password-cachepwd-255.php setup/includes/upgrades/mysql/3.2.1-pl.php` → exit 0

### Related issue(s)/PR(s)

Resolves #15877  
Coordinates with #16886 (shared `mysql/3.2.1-pl.php`)

### Compatibility notes

Runs only during setup upgrade to 3.2.1+. Fresh 3.x installs never create the legacy keys. Safe for sites that already deleted them (idempotent remove).

### Breaking change assessment

No public API changes. Removes obsolete system setting rows that MODX 3 does not use. Runtime already reads `upload_file_exists` only.

### Test coverage

No PHPUnit for installer upgrade scripts in this repo (same as other `setup/includes/upgrades/common/*` steps). Verification is syntax/phpcs plus the manual upgrade checklist above.

Lexicon keys used (`system_setting_cleanup_success`, `system_setting_cleanup_failed`) already exist in `setup/lang/*/upgrades.inc.php`.

### Contributors

Thanks @JoshuaLuckers for pointing at the cleanup-upgrade approach, and @Ruslan-Aleev for confirming the 2.x→3.x leftover.

### AI tool use

Cursor agent assisted review, simplification of the cleanup script, and PR description rewrite. Human review still required before merge.