### PR TITLE
fix(core): initialize modError in modX::initialize() for use outside …

### DIFF
--- a/_build/test/MODxTestCase.php
+++ b/_build/test/MODxTestCase.php
@@ -40,6 +40,8 @@ abstract class MODxTestCase extends XTestCase {
         $this->modx = MODxTestHarness::getFixture(modX::class, 'modx');
         if ($this->modx->request) {
             $this->modx->request->loadErrorHandler();
+        }
+        if ($this->modx->error !== null) {
             $this->modx->error->reset();
         }
         /* setup some basic test-environment options to allow us to simulate a site */

--- a/_build/test/Tests/Model/Request/modRequestTest.php
+++ b/_build/test/Tests/Model/Request/modRequestTest.php
@@ -152,8 +152,9 @@ class modRequestTest extends MODxTestCase {
      * Test the loadErrorHandler method
      */
     public function testLoadErrorHandler() {
+        $this->modx->error = null;
         $this->request->loadErrorHandler();
-        $this->assertInstanceOf(modError::class, $this->modx->error,'modRequest.loadErrorHandler did not load a modError-derivative class!');
+        $this->assertInstanceOf(modError::class, $this->modx->error, 'modRequest.loadErrorHandler did not load a modError-derivative class!');
     }
 
     /**

--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -114,8 +114,8 @@ class modPHPMailer extends modMail
             case modMail::MAIL_SMTP_SECURE :
                 $this->mailer->SMTPSecure = $this->attributes[$key];
                 break;
-            case modMail::MAIL_SMTP_AUTOTLS :
-                $this->mailer->SMTPAutoTLS= $this->attributes[$key];
+            case modMail::MAIL_SMTP_AUTOTLS:
+                $this->mailer->SMTPAutoTLS = $this->attributes[$key];
                 break;
             case modMail::MAIL_SMTP_SINGLE_TO :
                 $this->mailer->SingleTo = $this->attributes[$key];

--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -12,6 +12,7 @@ namespace MODX\Revolution\Mail;
 
 
 use Exception;
+use MODX\Revolution\Error\modError;
 use MODX\Revolution\modX;
 use InlineStyle\InlineStyle;
 use PHPMailer\PHPMailer\PHPMailer;
@@ -241,7 +242,10 @@ class modPHPMailer extends modMail
             }
             $sent = $this->mailer->send();
         } catch (Exception $e) {
-            $this->error = $this->modx->getService('error.modError');
+            if (!$this->modx->services->has('error')) {
+                $this->modx->services->add('error', new modError($this->modx));
+            }
+            $this->error = $this->modx->services->get('error');
             $this->error->addError($e->getMessage());
         }
 
@@ -302,7 +306,10 @@ class modPHPMailer extends modMail
         try {
             $this->mailer->addAttachment($file, $name, $encoding, $type);
         } catch (Exception $e) {
-            $this->error = $this->modx->getService('error.modError');
+            if (!$this->modx->services->has('error')) {
+                $this->modx->services->add('error', new modError($this->modx));
+            }
+            $this->error = $this->modx->services->get('error');
             $this->error->addError($e->getMessage());
         }
     }

--- a/core/src/Revolution/modRequest.php
+++ b/core/src/Revolution/modRequest.php
@@ -444,18 +444,19 @@ class modRequest
      */
     public function loadErrorHandler($class = modError::class)
     {
+        $error = null;
         if ($this->modx->services !== null && $this->modx->services->has('error')) {
-            $this->modx->error = $this->modx->services->get('error');
-            return;
-        }
-        if (class_exists($class)) {
+            $error = $this->modx->services->get('error');
+        } elseif (class_exists($class)) {
             $error = new $class($this->modx);
             if ($this->modx->services !== null) {
                 $this->modx->services->add('error', $error);
             }
-            $this->modx->error = $error;
         } else {
             $this->modx->log(modX::LOG_LEVEL_FATAL, 'Error handling class could not be loaded: ' . $class);
+        }
+        if ($error !== null) {
+            $this->modx->error = $error;
         }
     }
 

--- a/core/src/Revolution/modRequest.php
+++ b/core/src/Revolution/modRequest.php
@@ -444,15 +444,19 @@ class modRequest
      */
     public function loadErrorHandler($class = modError::class)
     {
-        if (!$this->modx->services->has('error')) {
-            if (class_exists($class)) {
-                $this->modx->services->add('error', new $class($this->modx));
-            } else {
-                $this->modx->log(modX::LOG_LEVEL_FATAL, 'Error handling class could not be loaded: ' . $class);
-                return;
-            }
+        if ($this->modx->services !== null && $this->modx->services->has('error')) {
+            $this->modx->error = $this->modx->services->get('error');
+            return;
         }
-        $this->modx->error = $this->modx->services->get('error');
+        if (class_exists($class)) {
+            $error = new $class($this->modx);
+            if ($this->modx->services !== null) {
+                $this->modx->services->add('error', $error);
+            }
+            $this->modx->error = $error;
+        } else {
+            $this->modx->log(modX::LOG_LEVEL_FATAL, 'Error handling class could not be loaded: ' . $class);
+        }
     }
 
     /**

--- a/core/src/Revolution/modRequest.php
+++ b/core/src/Revolution/modRequest.php
@@ -444,20 +444,18 @@ class modRequest
      */
     public function loadErrorHandler($class = modError::class)
     {
-        $error = null;
-        if ($this->modx->services !== null && $this->modx->services->has('error')) {
-            $error = $this->modx->services->get('error');
-        } elseif (class_exists($class)) {
-            $error = new $class($this->modx);
-            if ($this->modx->services !== null) {
-                $this->modx->services->add('error', $error);
-            }
-        } else {
+        if ($this->modx->error instanceof modError) {
+            return;
+        }
+        if (!class_exists($class)) {
             $this->modx->log(modX::LOG_LEVEL_FATAL, 'Error handling class could not be loaded: ' . $class);
+            return;
         }
-        if ($error !== null) {
-            $this->modx->error = $error;
+        $error = new $class($this->modx);
+        if ($this->modx->services !== null && !$this->modx->services->has('error')) {
+            $this->modx->services->add('error', $error);
         }
+        $this->modx->error = $error;
     }
 
     /**

--- a/core/src/Revolution/modRequest.php
+++ b/core/src/Revolution/modRequest.php
@@ -444,11 +444,15 @@ class modRequest
      */
     public function loadErrorHandler($class = modError::class)
     {
-        if (class_exists($class)) {
-            $this->modx->error = new $class($this->modx);
-        } else {
-            $this->modx->log(modX::LOG_LEVEL_FATAL, 'Error handling class could not be loaded: ' . $class);
+        if (!$this->modx->services->has('error')) {
+            if (class_exists($class)) {
+                $this->modx->services->add('error', new $class($this->modx));
+            } else {
+                $this->modx->log(modX::LOG_LEVEL_FATAL, 'Error handling class could not be loaded: ' . $class);
+                return;
+            }
         }
+        $this->modx->error = $this->modx->services->get('error');
     }
 
     /**

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1584,14 +1584,14 @@ class modX extends xPDO {
         if (isset ($this->loadedjscripts[$src]) && $this->loadedjscripts[$src]) {
             return;
         }
-        $this->loadedjscripts[$src]= true;
+        $this->loadedjscripts[$src] = true;
         if (strpos(strtolower($src), "<style") !== false || strpos(strtolower($src), "<link") !== false) {
-            $this->sjscripts[count($this->sjscripts)]= $src;
+            $this->sjscripts[count($this->sjscripts)] = $src;
         } else {
             if (!empty($media)) {
                 $media = ' media="' . $media .'"';
             }
-            $this->sjscripts[count($this->sjscripts)]= '<link rel="stylesheet" href="' . $src . '" type="text/css"' . $media . ' />';
+            $this->sjscripts[count($this->sjscripts)] = '<link rel="stylesheet" href="' . $src . '" type="text/css"' . $media . ' />';
         }
     }
 
@@ -1608,13 +1608,13 @@ class modX extends xPDO {
         if (!empty ($src) && !array_key_exists($src, $this->loadedjscripts)) {
             if (isset ($this->loadedjscripts[$src]))
                 return;
-            $this->loadedjscripts[$src]= true;
+            $this->loadedjscripts[$src] = true;
             if ($plaintext == true) {
-                $this->sjscripts[count($this->sjscripts)]= $src;
+                $this->sjscripts[count($this->sjscripts)] = $src;
             } elseif (strpos(strtolower($src), "<script") !== false) {
-                $this->sjscripts[count($this->sjscripts)]= $src;
+                $this->sjscripts[count($this->sjscripts)] = $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)] = '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1631,13 +1631,13 @@ class modX extends xPDO {
     public function regClientScript($src, $plaintext= false) {
         if (isset ($this->loadedjscripts[$src]))
             return;
-        $this->loadedjscripts[$src]= true;
+        $this->loadedjscripts[$src] = true;
         if ($plaintext == true) {
-            $this->jscripts[count($this->jscripts)]= $src;
+            $this->jscripts[count($this->jscripts)] = $src;
         } elseif (strpos(strtolower($src), "<script") !== false) {
-            $this->jscripts[count($this->jscripts)]= $src;
+            $this->jscripts[count($this->jscripts)] = $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)] = '<script src="' . $src . '"></script>';
         }
     }
 
@@ -2748,6 +2748,7 @@ class modX extends xPDO {
      *
      * @param array|null $options Unused; for signature consistency with other _init methods.
      */
+    // phpcs:ignore PSR2.Methods.MethodDeclaration.Underscore -- legacy init method name
     protected function _initError($options = null)
     {
         if (!$this->services->has('error')) {

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1580,18 +1580,19 @@ class modX extends xPDO {
      * @param string $media all, aural, braille, embossed, handheld, print, projection, screen, tty, tv
      * @return void
      */
-    public function regClientCSS($src, $media = null) {
+    public function regClientCSS($src, $media = null)
+    {
         if (isset ($this->loadedjscripts[$src]) && $this->loadedjscripts[$src]) {
             return;
         }
-        $this->loadedjscripts[$src]= true;
+        $this->loadedjscripts[$src] = true;
         if (strpos(strtolower($src), "<style") !== false || strpos(strtolower($src), "<link") !== false) {
-            $this->sjscripts[count($this->sjscripts)]= $src;
+            $this->sjscripts[count($this->sjscripts)] = $src;
         } else {
             if (!empty($media)) {
                 $media = ' media="' . $media .'"';
             }
-            $this->sjscripts[count($this->sjscripts)]= '<link rel="stylesheet" href="' . $src . '" type="text/css"' . $media . ' />';
+            $this->sjscripts[count($this->sjscripts)] = '<link rel="stylesheet" href="' . $src . '" type="text/css"' . $media . ' />';
         }
     }
 
@@ -1604,17 +1605,18 @@ class modX extends xPDO {
      * rather than assuming it is JavaScript.
      * @return void
      */
-    public function regClientStartupScript($src, $plaintext= false) {
+    public function regClientStartupScript($src, $plaintext = false)
+    {
         if (!empty ($src) && !array_key_exists($src, $this->loadedjscripts)) {
             if (isset ($this->loadedjscripts[$src]))
                 return;
-            $this->loadedjscripts[$src]= true;
+            $this->loadedjscripts[$src] = true;
             if ($plaintext == true) {
-                $this->sjscripts[count($this->sjscripts)]= $src;
+                $this->sjscripts[count($this->sjscripts)] = $src;
             } elseif (strpos(strtolower($src), "<script") !== false) {
-                $this->sjscripts[count($this->sjscripts)]= $src;
+                $this->sjscripts[count($this->sjscripts)] = $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)] = '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1628,16 +1630,17 @@ class modX extends xPDO {
      * rather than assuming it is JavaScript.
      * @return void
      */
-    public function regClientScript($src, $plaintext= false) {
+    public function regClientScript($src, $plaintext = false)
+    {
         if (isset ($this->loadedjscripts[$src]))
             return;
-        $this->loadedjscripts[$src]= true;
+        $this->loadedjscripts[$src] = true;
         if ($plaintext == true) {
-            $this->jscripts[count($this->jscripts)]= $src;
+            $this->jscripts[count($this->jscripts)] = $src;
         } elseif (strpos(strtolower($src), "<script") !== false) {
-            $this->jscripts[count($this->jscripts)]= $src;
+            $this->jscripts[count($this->jscripts)] = $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)] = '<script src="' . $src . '"></script>';
         }
     }
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -585,6 +585,7 @@ class modX extends xPDO {
             }
             $this->_initSession($options);
             $this->_initErrorHandler($options);
+            $this->_initError($options);
             $this->_initHttpClient();
             $this->_initCulture($options);
 
@@ -2740,6 +2741,19 @@ class modX extends xPDO {
         } catch (\Exception $exception) {
             $this->log(modX::LOG_LEVEL_ERROR, 'Error handler not found: ' . $exception->getMessage());
         }
+    }
+
+    /**
+     * Loads the modError instance for validation/response errors (e.g. processors).
+     *
+     * @param array|null $options Unused; for signature consistency with other _init methods.
+     */
+    protected function _initError($options = null)
+    {
+        if (!$this->services->has('error')) {
+            $this->services->add('error', new modError($this));
+        }
+        $this->error = $this->services->get('error');
     }
 
     protected function _initHttpClient()

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1584,14 +1584,14 @@ class modX extends xPDO {
         if (isset ($this->loadedjscripts[$src]) && $this->loadedjscripts[$src]) {
             return;
         }
-        $this->loadedjscripts[$src] = true;
+        $this->loadedjscripts[$src]= true;
         if (strpos(strtolower($src), "<style") !== false || strpos(strtolower($src), "<link") !== false) {
-            $this->sjscripts[count($this->sjscripts)] = $src;
+            $this->sjscripts[count($this->sjscripts)]= $src;
         } else {
             if (!empty($media)) {
                 $media = ' media="' . $media .'"';
             }
-            $this->sjscripts[count($this->sjscripts)] = '<link rel="stylesheet" href="' . $src . '" type="text/css"' . $media . ' />';
+            $this->sjscripts[count($this->sjscripts)]= '<link rel="stylesheet" href="' . $src . '" type="text/css"' . $media . ' />';
         }
     }
 
@@ -1608,13 +1608,13 @@ class modX extends xPDO {
         if (!empty ($src) && !array_key_exists($src, $this->loadedjscripts)) {
             if (isset ($this->loadedjscripts[$src]))
                 return;
-            $this->loadedjscripts[$src] = true;
+            $this->loadedjscripts[$src]= true;
             if ($plaintext == true) {
-                $this->sjscripts[count($this->sjscripts)] = $src;
+                $this->sjscripts[count($this->sjscripts)]= $src;
             } elseif (strpos(strtolower($src), "<script") !== false) {
-                $this->sjscripts[count($this->sjscripts)] = $src;
+                $this->sjscripts[count($this->sjscripts)]= $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)] = '<script src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1631,13 +1631,13 @@ class modX extends xPDO {
     public function regClientScript($src, $plaintext= false) {
         if (isset ($this->loadedjscripts[$src]))
             return;
-        $this->loadedjscripts[$src] = true;
+        $this->loadedjscripts[$src]= true;
         if ($plaintext == true) {
-            $this->jscripts[count($this->jscripts)] = $src;
+            $this->jscripts[count($this->jscripts)]= $src;
         } elseif (strpos(strtolower($src), "<script") !== false) {
-            $this->jscripts[count($this->jscripts)] = $src;
+            $this->jscripts[count($this->jscripts)]= $src;
         } else {
-            $this->jscripts[count($this->jscripts)] = '<script src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
         }
     }
 


### PR DESCRIPTION
### What does it do?
Initializes `$modx->error` (modError) during `$modx->initialize()` so it is available when using MODX outside the web context (CLI, unit tests, extras). Adds `_initError()` to register modError in the services container and set `$modx->error`. Updates `modRequest::loadErrorHandler()` to use the container, and replaces deprecated `getService('error.modError')` in modPHPMailer with the services API.

### Why is it needed?
After `$modx->initialize()` outside MODX, `$modx->error` was null because modError was only created in `runProcessor()` and `modRequest::handleRequest()`. Any code calling `$modx->error->addError()` or `$modx->error->hasError()` before those paths caused a fatal error.

### How to test
1. Run: `$modx = new \MODX\Revolution\modX(); $modx->initialize('web');`
2. Assert `$modx->error !== null` and e.g. `$modx->error->addError('test')` does not throw.

### Related issue(s)/PR(s)
Resolves #15807
