### PR TITLE
fix(filters): evaluate TV elements bindings in tvLabel output modifier

### DIFF
--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -717,11 +717,15 @@ class modOutputFilter
                                 break;
                             }
                             $o_prop = $tv->get('output_properties');
-                            $options = explode('||', $tv->get('elements'));
+                            $resourceId = ($this->modx->resource && $this->modx->resource->get('id'))
+                                ? (int) $this->modx->resource->get('id')
+                                : 0;
+                            $elementsProcessed = $tv->processBindings($tv->get('elements'), $resourceId);
+                            $options = is_string($elementsProcessed) ? explode('||', $elementsProcessed) : [];
                             $lookup = [];
                             foreach ($options as $o) {
-                                list($name, $value) = explode('==', $o);
-                                $lookup[$value] = $name;
+                                $parts = array_pad(explode('==', $o, 2), 2, '');
+                                $lookup[$parts[1]] = $parts[0];
                             }
                             if (isset($o_prop['delimiter'])) {
                                 $delimiter = $o_prop['delimiter'];
@@ -732,7 +736,7 @@ class modOutputFilter
                             }
                             $return_values = [];
                             foreach ($values as $v) {
-                                $return_values[] = $lookup[$v];
+                                $return_values[] = isset($lookup[$v]) ? $lookup[$v] : $v;
                             }
                             $output = implode($delimiter, $return_values);
                             break;

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -724,8 +724,12 @@ class modOutputFilter
                             $options = is_string($elementsProcessed) ? explode('||', $elementsProcessed) : [];
                             $lookup = [];
                             foreach ($options as $o) {
-                                $parts = array_pad(explode('==', $o, 2), 2, '');
-                                $lookup[$parts[1]] = $parts[0];
+                                if (strpos($o, '==') === false) {
+                                    $lookup[$o] = $o;
+                                } else {
+                                    $parts = explode('==', $o);
+                                    $lookup[$parts[1]] = $parts[0];
+                                }
                             }
                             if (isset($o_prop['delimiter'])) {
                                 $delimiter = $o_prop['delimiter'];


### PR DESCRIPTION
### What does it do?
`tvLabel` resolves TV input option values through `modTemplateVar::processBindings()` before building the label map, so `@SELECT` and other @ bindings work like in the manager.

### Why is it needed?
Front-end `tvLabel` showed raw option keys when Input Option Values used bindings (#13607).

### How to test
1. TV with `@SELECT`-based input options
2. Output `[[*tvName:tvLabel]]` on a resource
3. Confirm the label text appears, not the raw value

### Related issue(s)/PR(s)
Resolves #13607