### PR TITLE
fix(core): enforce context load permission and return 404 when denied

### DIFF
--- a/core/src/Revolution/modRequest.php
+++ b/core/src/Revolution/modRequest.php
@@ -73,6 +73,11 @@ class modRequest
     {
         $this->loadErrorHandler();
 
+        if (!$this->modx->context || !$this->modx->context->checkPolicy('load')) {
+            $this->modx->sendErrorPage();
+            return;
+        }
+
         // If enabled, send the X-Powered-By header to identify this site as running MODX, per discussion in #12882
         if ($this->modx->getOption('send_poweredby_header', null, true)) {
             $version = $this->modx->getVersionData();

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1613,7 +1613,7 @@ class modX extends xPDO {
             } elseif (strpos(strtolower($src), "<script") !== false) {
                 $this->sjscripts[count($this->sjscripts)]= $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)] = '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1636,7 +1636,7 @@ class modX extends xPDO {
         } elseif (strpos(strtolower($src), "<script") !== false) {
             $this->jscripts[count($this->jscripts)]= $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)] = '<script src="' . $src . '"></script>';
         }
     }
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2636,6 +2636,7 @@ class modX extends xPDO {
                     $this->context =& $this->contexts[$oldContext];
                 } else {
                     $this->log(modX::LOG_LEVEL_ERROR, 'Could not load context: ' . $contextKey);
+                    $this->context = null;
                 }
             }
         }

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1613,7 +1613,7 @@ class modX extends xPDO {
             } elseif (strpos(strtolower($src), "<script") !== false) {
                 $this->sjscripts[count($this->sjscripts)]= $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)] = '<script src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1636,7 +1636,7 @@ class modX extends xPDO {
         } elseif (strpos(strtolower($src), "<script") !== false) {
             $this->jscripts[count($this->jscripts)]= $src;
         } else {
-            $this->jscripts[count($this->jscripts)] = '<script src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
         }
     }
 
@@ -2636,7 +2636,6 @@ class modX extends xPDO {
                     $this->context =& $this->contexts[$oldContext];
                 } else {
                     $this->log(modX::LOG_LEVEL_ERROR, 'Could not load context: ' . $contextKey);
-                    $this->context = null;
                 }
             }
         }


### PR DESCRIPTION
### What does it do?
After the error handler loads, refuse requests when the current context is missing or the user lacks `load`, and send the site 404 page.

### Why is it needed?
Docs say denying Anonymous `load` on a context should yield 404. Context init ran before that check was enforced on the request, so denied contexts still served content (#15145).

### How to test
1. Remove or deny Anonymous `load` on the `web` context (keep the ACL row).
2. Request a front-end URL in that context.
3. Confirm a 404 (error page / header), not the normal resource.

### Related issue(s)/PR(s)
Fixes #15145