### PR TITLE
fix(core): preserve plugin returnedValues across invokeEvent loop

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1613,7 +1613,7 @@ class modX extends xPDO {
             } elseif (strpos(strtolower($src), "<script") !== false) {
                 $this->sjscripts[count($this->sjscripts)]= $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)] = '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1636,7 +1636,7 @@ class modX extends xPDO {
         } elseif (strpos(strtolower($src), "<script") !== false) {
             $this->jscripts[count($this->jscripts)]= $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)] = '<script src="' . $src . '"></script>';
         }
     }
 
@@ -1709,7 +1709,7 @@ class modX extends xPDO {
         if (count($this->eventMap[$eventName])) {
             $this->event= new modSystemEvent();
             $this->event->resetEventObject();
-            $this->event->name= $eventName;
+            $this->event->name = $eventName;
             foreach ($this->eventMap[$eventName] as $pluginId => $pluginPropset) {
                 /** @var modPlugin $plugin */
                 $plugin= null;

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1708,12 +1708,13 @@ class modX extends xPDO {
         $results= [];
         if (count($this->eventMap[$eventName])) {
             $this->event= new modSystemEvent();
+            $this->event->resetEventObject();
+            $this->event->name= $eventName;
             foreach ($this->eventMap[$eventName] as $pluginId => $pluginPropset) {
                 /** @var modPlugin $plugin */
                 $plugin= null;
                 $this->Event = clone $this->event;
-                $this->event->resetEventObject();
-                $this->event->name= $eventName;
+                $this->event->_output = '';
                 if (isset ($this->pluginCache[$pluginId])) {
                     $plugin= $this->newObject(modPlugin::class);
                     $plugin->fromArray($this->pluginCache[$pluginId], '', true, true);


### PR DESCRIPTION
### What does it do?
In `modX::invokeEvent()`, the event object is now reset once before the plugin loop (`resetEventObject()` and `name` set), and inside the loop only `_output` is cleared between plugins. `returnedValues` and `_propagate` are no longer reset per plugin, so values set by one plugin remain available to the next and to code after `invokeEvent()`. The `$this->Event = clone $this->event` line is kept for backward compatibility.

### Why is it needed?
Previously, `resetEventObject()` was called at the start of each plugin iteration, which set `returnedValues` to `null`. So when multiple plugins were attached to the same event, any value assigned to `$modx->event->returnedValues` by an earlier plugin was lost before the next plugin ran and was not available after the event. This fix preserves `returnedValues` across plugins while still resetting per-plugin output. Minimal change; no refactor of `modSystemEvent` or event API (unlike closed PR #15577).

### How to test
1. Create two plugins bound to the same event (e.g. OnBeforeDocFormSave).
2. In the first plugin, set e.g. `$modx->event->returnedValues = ['key' => 'from plugin 1'];`.
3. In the second plugin (or in code that runs after `$modx->invokeEvent('OnBeforeDocFormSave', ...)`), read `$modx->event->returnedValues` and confirm it still contains the value set by the first plugin.

### Related issue(s)/PR(s)
Resolves #15056
