### PR TITLE
feat(ci): add PHP-CS-Fixer and auto-fix workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ on:
       paths-ignore:
           - "_build/templates/**"
 
-          # Allows you to run this workflow manually from the Actions tab
+  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/php-cs-fixer-auto.yml
+++ b/.github/workflows/php-cs-fixer-auto.yml
@@ -12,15 +12,18 @@ on:
 
 permissions:
     contents: write
+    pull-requests: read
 
 jobs:
     auto-fix:
+        # Same-repo PRs only: never checkout or push fork branches with write token.
+        if: github.event.pull_request.head.repo.full_name == github.repository
         runs-on: ubuntu-latest
         steps:
             - name: Checkout PR
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
-                  ref: refs/pull/${{ github.event.pull_request.number }}/head
+                  ref: ${{ github.head_ref }}
                   token: ${{ secrets.GITHUB_TOKEN }}
                   fetch-depth: 0
 
@@ -31,10 +34,10 @@ jobs:
 
             - name: Get composer cache directory
               id: composer-cache
-              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+              run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
             - name: Cache composer dependencies
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -45,25 +48,37 @@ jobs:
 
             - name: Get changed PHP files
               id: changed
+              env:
+                  BASE_REF: ${{ github.base_ref }}
               run: |
-                git fetch origin ${{ github.base_ref }}
-                FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'core/*.php' 'manager/*.php' 'connectors/*.php' 2>/dev/null || true)
-                echo "files<<EOF" >> $GITHUB_OUTPUT
-                echo "$FILES" >> $GITHUB_OUTPUT
-                echo "EOF" >> $GITHUB_OUTPUT
+                  git fetch origin "$BASE_REF"
+                  git diff --name-only --diff-filter=ACMR "origin/${BASE_REF}...HEAD" -- \
+                    'core/**/*.php' 'manager/**/*.php' 'connectors/**/*.php' \
+                    > /tmp/php-cs-fixer-files.txt || true
+                  if [ ! -s /tmp/php-cs-fixer-files.txt ]; then
+                    echo "has_files=false" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "has_files=true" >> "$GITHUB_OUTPUT"
+                  fi
 
             - name: Run PHP-CS-Fixer
+              if: steps.changed.outputs.has_files == 'true'
               run: |
-                FILES="${{ steps.changed.outputs.files }}"
-                if [ -n "$FILES" ]; then
-                  echo "$FILES" | xargs -r core/vendor/bin/php-cs-fixer fix --verbose --
-                fi
+                  mapfile -t files < /tmp/php-cs-fixer-files.txt
+                  core/vendor/bin/php-cs-fixer fix --verbose -- "${files[@]}"
 
             - name: Commit and Push Changes
-              if: github.repository == github.event.pull_request.head.repo.full_name
+              if: steps.changed.outputs.has_files == 'true'
+              env:
+                  HEAD_REF: ${{ github.head_ref }}
               run: |
+                  mapfile -t files < /tmp/php-cs-fixer-files.txt
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git add -A
-                  git diff --cached --quiet || git commit -m "style: auto-fix PHP code with PHP-CS-Fixer"
-                  git push origin HEAD:${{ github.head_ref }}
+                  git add -- "${files[@]}"
+                  if git diff --cached --quiet; then
+                    echo "No CS Fixer changes to commit"
+                    exit 0
+                  fi
+                  git commit -m "style: auto-fix PHP code with PHP-CS-Fixer"
+                  git push origin "HEAD:${HEAD_REF}"

--- a/.github/workflows/php-cs-fixer-auto.yml
+++ b/.github/workflows/php-cs-fixer-auto.yml
@@ -43,8 +43,21 @@ jobs:
             - name: Install dependencies
               run: composer install --no-interaction --no-progress --prefer-dist --optimize-autoloader
 
+            - name: Get changed PHP files
+              id: changed
+              run: |
+                git fetch origin ${{ github.base_ref }}
+                FILES=$(git diff --name-only origin/${{ github.base_ref }}...HEAD -- 'core/*.php' 'manager/*.php' 'connectors/*.php' 2>/dev/null || true)
+                echo "files<<EOF" >> $GITHUB_OUTPUT
+                echo "$FILES" >> $GITHUB_OUTPUT
+                echo "EOF" >> $GITHUB_OUTPUT
+
             - name: Run PHP-CS-Fixer
-              run: composer fix
+              run: |
+                FILES="${{ steps.changed.outputs.files }}"
+                if [ -n "$FILES" ]; then
+                  echo "$FILES" | xargs -r core/vendor/bin/php-cs-fixer fix --verbose --
+                fi
 
             - name: Commit and Push Changes
               if: github.repository == github.event.pull_request.head.repo.full_name

--- a/.github/workflows/php-cs-fixer-auto.yml
+++ b/.github/workflows/php-cs-fixer-auto.yml
@@ -1,4 +1,4 @@
-name: "Auto Fix PHP Code Style"
+name: "PHP-CS-Fixer"
 
 on:
     pull_request:
@@ -10,41 +10,39 @@ on:
             - ".php-cs-fixer.dist.php"
             - ".github/workflows/php-cs-fixer-auto.yml"
 
+# Read-only: never give a write token to a job that installs Composer deps from the PR.
 permissions:
-    contents: write
-    pull-requests: read
+    contents: read
 
 jobs:
-    auto-fix:
-        # Same-repo PRs only: never checkout or push fork branches with write token.
-        if: github.event.pull_request.head.repo.full_name == github.repository
+    cs-check:
         runs-on: ubuntu-latest
         steps:
             - name: Checkout PR
-              uses: actions/checkout@v4
+              uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
               with:
-                  ref: ${{ github.head_ref }}
-                  token: ${{ secrets.GITHUB_TOKEN }}
                   fetch-depth: 0
 
             - name: Setup PHP
-              uses: shivammathur/setup-php@v2
+              uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # 2.32.0
               with:
                   php-version: "8.2"
+                  coverage: none
+                  tools: none
 
             - name: Get composer cache directory
               id: composer-cache
               run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
             - name: Cache composer dependencies
-              uses: actions/cache@v4
+              uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
                   restore-keys: ${{ runner.os }}-composer-
 
             - name: Install dependencies
-              run: composer install --no-interaction --no-progress --prefer-dist --optimize-autoloader
+              run: composer install --no-interaction --no-progress --prefer-dist --optimize-autoloader --no-scripts
 
             - name: Get changed PHP files
               id: changed
@@ -61,24 +59,8 @@ jobs:
                     echo "has_files=true" >> "$GITHUB_OUTPUT"
                   fi
 
-            - name: Run PHP-CS-Fixer
+            - name: PHP-CS-Fixer dry-run
               if: steps.changed.outputs.has_files == 'true'
               run: |
                   mapfile -t files < /tmp/php-cs-fixer-files.txt
-                  core/vendor/bin/php-cs-fixer fix --verbose -- "${files[@]}"
-
-            - name: Commit and Push Changes
-              if: steps.changed.outputs.has_files == 'true'
-              env:
-                  HEAD_REF: ${{ github.head_ref }}
-              run: |
-                  mapfile -t files < /tmp/php-cs-fixer-files.txt
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
-                  git add -- "${files[@]}"
-                  if git diff --cached --quiet; then
-                    echo "No CS Fixer changes to commit"
-                    exit 0
-                  fi
-                  git commit -m "style: auto-fix PHP code with PHP-CS-Fixer"
-                  git push origin "HEAD:${HEAD_REF}"
+                  core/vendor/bin/php-cs-fixer fix --dry-run --diff --verbose -- "${files[@]}"

--- a/.github/workflows/php-cs-fixer-auto.yml
+++ b/.github/workflows/php-cs-fixer-auto.yml
@@ -20,8 +20,9 @@ jobs:
             - name: Checkout PR
               uses: actions/checkout@v3
               with:
-                  ref: ${{ github.head_ref }}
+                  ref: refs/pull/${{ github.event.pull_request.number }}/head
                   token: ${{ secrets.GITHUB_TOKEN }}
+                  fetch-depth: 0
 
             - name: Setup PHP
               uses: shivammathur/setup-php@v2
@@ -39,16 +40,17 @@ jobs:
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
                   restore-keys: ${{ runner.os }}-composer-
 
-            - name: Install Composer Dependencies
-              run: composer install --no-interaction --prefer-dist --optimize-autoloader
+            - name: Install dependencies
+              run: composer install --no-interaction --no-progress --prefer-dist --optimize-autoloader
 
             - name: Run PHP-CS-Fixer
               run: composer fix
 
             - name: Commit and Push Changes
+              if: github.repository == github.event.pull_request.head.repo.full_name
               run: |
                   git config user.name "github-actions[bot]"
                   git config user.email "github-actions[bot]@users.noreply.github.com"
                   git add -A
                   git diff --cached --quiet || git commit -m "style: auto-fix PHP code with PHP-CS-Fixer"
-                  git push origin ${{ github.head_ref }}
+                  git push origin HEAD:${{ github.head_ref }}

--- a/.github/workflows/php-cs-fixer-auto.yml
+++ b/.github/workflows/php-cs-fixer-auto.yml
@@ -1,0 +1,54 @@
+name: "Auto Fix PHP Code Style"
+
+on:
+    pull_request:
+        paths:
+            - "core/**"
+            - "manager/**"
+            - "connectors/**"
+            - "composer.json"
+            - ".php-cs-fixer.dist.php"
+            - ".github/workflows/php-cs-fixer-auto.yml"
+
+permissions:
+    contents: write
+
+jobs:
+    auto-fix:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout PR
+              uses: actions/checkout@v3
+              with:
+                  ref: ${{ github.head_ref }}
+                  token: ${{ secrets.GITHUB_TOKEN }}
+
+            - name: Setup PHP
+              uses: shivammathur/setup-php@v2
+              with:
+                  php-version: "8.2"
+
+            - name: Get composer cache directory
+              id: composer-cache
+              run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+            - name: Cache composer dependencies
+              uses: actions/cache@v3
+              with:
+                  path: ${{ steps.composer-cache.outputs.dir }}
+                  key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+                  restore-keys: ${{ runner.os }}-composer-
+
+            - name: Install Composer Dependencies
+              run: composer install --no-interaction --prefer-dist --optimize-autoloader
+
+            - name: Run PHP-CS-Fixer
+              run: composer fix
+
+            - name: Commit and Push Changes
+              run: |
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+                  git add -A
+                  git diff --cached --quiet || git commit -m "style: auto-fix PHP code with PHP-CS-Fixer"
+                  git push origin ${{ github.head_ref }}

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,22 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/core')
+    ->in(__DIR__ . '/manager')
+    ->in(__DIR__ . '/connectors')
+    ->name('*.php')
+    ->ignoreDotFiles(true)
+    ->ignoreVCS(true);
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+        'ordered_imports' => true,
+        'single_quote' => true,
+        'no_extra_blank_lines' => true,
+        'trailing_comma_in_multiline' => true,
+    ])
+    ->setFinder($finder)
+    ->setUsingCache(true)
+    ->setRiskyAllowed(true);

--- a/composer.json
+++ b/composer.json
@@ -110,11 +110,13 @@
             "core/vendor/bin/xpdo parse-schema --config=core/model/schema/config.php --update=1 --psr4=MODX\\\\ mysql core/model/schema/modx.transport.mysql.schema.xml core/src/"
         ],
         "parse-schema": [
-          "composer run-script parse-schema-mysql"
+            "composer run-script parse-schema-mysql"
         ],
         "phpcs": "core/vendor/bin/phpcs --standard=phpcs.xml",
         "phpcbf": "core/vendor/bin/phpcbf --standard=phpcs.xml",
-        "pre-autoload-dump": "Aws\\Script\\Composer\\Composer::removeUnusedServices"
+        "pre-autoload-dump": "Aws\\Script\\Composer\\Composer::removeUnusedServices",
+        "fix": "php-cs-fixer fix --verbose",
+        "fix:dry": "php-cs-fixer fix --dry-run --verbose"
     },
     "scripts-descriptions": {
         "phpunit": "Run PHPUnit test"
@@ -127,6 +129,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require-dev": {
+        "friendsofphp/php-cs-fixer": "^3.15",
         "yoast/phpunit-polyfills": "^0.2.0",
         "squizlabs/php_codesniffer": "3.*",
         "phpcompatibility/php-compatibility": "^9.3"


### PR DESCRIPTION
### What does it do?
Adds `friendsofphp/php-cs-fixer` plus a pull_request workflow that dry-runs the fixer on changed PHP under `core/`, `manager/`, and `connectors/`. The job uses `contents: read` only (no auto-commit).

### Why is it needed?
Catch style drift in CI without giving a write token to a job that installs Composer dependencies from the PR.

### How to test
1. Open a PR that touches PHP under `core/` with non-compliant style
2. Confirm the PHP-CS-Fixer check fails with a diff
3. Run `composer fix` locally, push, and confirm the check passes

### Notes
Auto-push was removed on purpose. Pin Actions by commit SHA. Local fix: `composer fix` / `composer fix:dry`.

### Related issue(s)/PR(s)
CI / DX.