### PR TITLE
test(security): regression for principal 0 in UserGroup ACL processors

### DIFF
--- a/_build/test/Tests/Processors/Security/Access/UserGroupPrincipalZeroTest.php
+++ b/_build/test/Tests/Processors/Security/Access/UserGroupPrincipalZeroTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *

--- a/_build/test/Tests/Processors/Security/Access/UserGroupPrincipalZeroTest.php
+++ b/_build/test/Tests/Processors/Security/Access/UserGroupPrincipalZeroTest.php
@@ -1,0 +1,83 @@
+<?php
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+namespace MODX\Revolution\Tests\Processors\Security\Access;
+
+use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Processors\Security\Access\UserGroup\Context\Create as ContextCreate;
+use MODX\Revolution\Processors\Security\Access\UserGroup\Context\Update as ContextUpdate;
+use MODX\Revolution\Processors\Security\Access\UserGroup\ResourceGroup\Create as ResourceGroupCreate;
+use MODX\Revolution\Processors\Security\Access\UserGroup\ResourceGroup\Update as ResourceGroupUpdate;
+use MODX\Revolution\Processors\Processor;
+
+/**
+ * Regression for #15062: principal ID 0 must not be treated as missing (== null).
+ *
+ * @package modx-test
+ * @group Processors
+ * @group Security
+ * @group Access
+ */
+class UserGroupPrincipalZeroTest extends MODxTestCase
+{
+    /**
+     * @param class-string<Processor> $processorClass
+     * @dataProvider providerUserGroupAclProcessors
+     */
+    public function testPrincipalZeroIsNotRejectedAsMissing($processorClass)
+    {
+        $this->modx->lexicon->load('access', 'user', 'context');
+
+        /** @var Processor $processor */
+        $processor = new $processorClass($this->modx, [
+            'principal' => 0,
+            'target' => 1,
+            'policy' => 1,
+            'authority' => 0,
+        ]);
+
+        $processor->beforeSet();
+
+        $this->assertFalse(
+            $this->hasFieldError($processor, 'principal'),
+            $processorClass . ' must accept principal 0 without usergroup_err_ns'
+        );
+    }
+
+    /**
+     * @return array<string, array{0: class-string<Processor>}>
+     */
+    public function providerUserGroupAclProcessors()
+    {
+        return [
+            'context create' => [ContextCreate::class],
+            'context update' => [ContextUpdate::class],
+            'resource group create' => [ResourceGroupCreate::class],
+            'resource group update' => [ResourceGroupUpdate::class],
+        ];
+    }
+
+    /**
+     * @param Processor $processor
+     * @param string $field
+     * @return bool
+     */
+    private function hasFieldError(Processor $processor, $field)
+    {
+        foreach ($this->modx->error->getErrors(true) as $error) {
+            if (is_array($error) && isset($error['id']) && $error['id'] === $field) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/_build/test/phpunit.xml
+++ b/_build/test/phpunit.xml
@@ -46,6 +46,7 @@
             <directory>Tests/Processors/Context</directory>
             <directory>Tests/Processors/Element</directory>
             <directory>Tests/Processors/Resource</directory>
+            <directory>Tests/Processors/Security</directory>
         </testsuite>
         <testsuite name="Transport">
             <directory>Tests/Transport</directory>


### PR DESCRIPTION
### What does it do?
Adds a regression test that UserGroup ACL processors accept `principal=0` (Anonymous) under strict `=== null` checks.

### Why is it needed?
#15062: loose `== null` treated principal `0` as missing. Production processors on `3.x` already use `=== null`; this test locks that behavior.

### How to test
```
core/vendor/bin/phpunit -c _build/test/phpunit.xml --filter UserGroupPrincipalZeroTest
```

### Related issue(s)/PR(s)
Related: #15062