### PR TITLE
fix(manager): add checkbox style to Add Property Set window

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -1083,6 +1083,7 @@ MODx.window.AddPropertySet = function(config = {}) {
         }, {
             xtype: 'fieldset',
             title: _('propertyset_create_new'),
+            cls: 'x-fieldset-checkbox-toggle',
             autoHeight: true,
             checkboxToggle: true,
             collapsed: true,


### PR DESCRIPTION
### What does it do?
Adds `cls: 'x-fieldset-checkbox-toggle'` to the "Create new" fieldset in the Add Property Set window (`MODx.window.AddPropertySet`). This reuses the same ExtJS fieldset class used elsewhere in the manager so the toggle checkbox is styled with Font Awesome icons (square/check-square).

### Why is it needed?
In the Add Property Set dialog, the "Create new" block showed a plain native checkbox without icons. Other manager fieldsets that use `checkboxToggle: true` apply `x-fieldset-checkbox-toggle`, which is styled in `index.css` with Font Awesome. Without this class, the Add Property Set fieldset looked inconsistent and less clear.

### How to test
1. In the manager, go to Elements (or any element type) and open the Properties tab.
2. Click "Add Property Set".
3. In the "Create new" section, confirm the toggle checkbox shows Font Awesome icons (empty square / checked square) instead of a native checkbox.

### Related issue(s)/PR(s)
Resolves #14536