### PR TITLE
fix(lexicon): each search replaces the previous

### DIFF
--- a/core/src/Revolution/Processors/Workspace/Lexicon/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/GetList.php
@@ -83,7 +83,14 @@ class GetList extends Processor
             'language' => $this->getProperty('language'),
         ];
 
+        // Normalize query to a single string so each search replaces the previous (no stepwise refinement)
         $query = $this->getProperty('query');
+        if (is_array($query)) {
+            $query = end($query);
+        }
+        $query = is_string($query) ? trim($query) : '';
+        $this->setProperty('query', $query);
+
         if (!empty($query)) {
             $where[] = [
                 'name:LIKE' => '%' . $query . '%',


### PR DESCRIPTION
### What does it do?

Normalizes the `query` parameter in `Workspace/Lexicon/GetList` before filtering:

- If `query` arrives as an array (duplicate request params), the last value is used.
- The value is trimmed to a single string; non-strings become an empty string.

Each lexicon search request therefore sends one criterion to the processor. No JavaScript changes in this PR.

### Why is it needed?

In Lexicon Management, repeated searches without clearing the filter could leave duplicate `query` values on the request. The processor then saw stacked criteria instead of a replacement search.

### How to test

1. Open Lexicon Management (`namespace=core`, `topic=default`, `language=en`).
2. Search for `Search` and press Enter. The grid should list entries matching `Search`.
3. Without clearing the filter, search for `Results` and press Enter. The grid should show only entries matching `Results`.
4. Repeat with `More`. Each search should replace the previous result set.

### Related issue(s)/PR(s)

Resolves #14456