### PR TITLE
feat(core): add chunk debug placeholders (this.name, this.id, this.placeholders)

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -308,6 +308,15 @@ $settings['cache_scripts']->fromArray([
   'area' => 'caching',
   'editedon' => null,
 ], '', true, true);
+$settings['chunk_debug_placeholders'] = $xpdo->newObject(modSystemSetting::class);
+$settings['chunk_debug_placeholders']->fromArray([
+  'key' => 'chunk_debug_placeholders',
+  'value' => false,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'system',
+  'editedon' => null,
+], '', true, true);
 $settings['clear_cache_refresh_trees'] = $xpdo->newObject(modSystemSetting::class);
 $settings['clear_cache_refresh_trees']->fromArray([
   'key' => 'clear_cache_refresh_trees',

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -182,6 +182,9 @@ $_lang['setting_cache_resource_expires_desc'] = 'This value (in seconds) sets th
 $_lang['setting_cache_scripts'] = 'Enable Script Cache';
 $_lang['setting_cache_scripts_desc'] = 'When enabled, MODX will cache all Scripts (Snippets and Plugins) to file to reduce load times. MODX recommends leaving this set to \'Yes\'.';
 
+$_lang['setting_chunk_debug_placeholders'] = 'Chunk Debug Placeholders';
+$_lang['setting_chunk_debug_placeholders_desc'] = 'When enabled, chunks receive [[+this.name]], [[+this.id]], and [[+this.placeholders]] for debugging. Use in development only.';
+
 $_lang['setting_cache_system_settings'] = 'Enable System Setting Cache';
 $_lang['setting_cache_system_settings_desc'] = 'When enabled, system settings will be cached to reduce load times. MODX recommends leaving this on.';
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -296,6 +296,13 @@ class modX extends xPDO {
     private $_deprecations = [];
 
     /**
+     * When true, getChunk() skips chunk_debug_placeholders injection (used by parseChunk).
+     *
+     * @var bool
+     */
+    private $suppressChunkDebugPlaceholders = false;
+
+    /**
      * Harden the environment against common security flaws.
      *
      * @static
@@ -1970,7 +1977,10 @@ class modX extends xPDO {
             $chunk= $this->parser->getElement(modChunk::class, $chunkName);
             if ($chunk instanceof modChunk) {
                 $chunk->setCacheable(false);
-                if ((bool) $this->getOption('chunk_debug_placeholders', null, false)) {
+                if (
+                    !$this->suppressChunkDebugPlaceholders
+                    && (bool) $this->getOption('chunk_debug_placeholders', null, false)
+                ) {
                     $debug = $this->buildChunkDebugPlaceholders($chunkName, $chunk, $properties);
                     $properties['this.name'] = $debug['name'];
                     $properties['this.id'] = $debug['id'];
@@ -1994,10 +2004,18 @@ class modX extends xPDO {
      */
     public function parseChunk($chunkName, $chunkArr, $prefix='[[+', $suffix=']]') {
         $this->deprecated('3.0.0', 'Use $modx->getChunk instead');
-        $chunk= $this->getChunk($chunkName);
+        $debugEnabled = (bool) $this->getOption('chunk_debug_placeholders', null, false);
+        // Suppress debug injection in getChunk(): it would resolve [[+this.*]]
+        // against an empty property bag before $chunkArr is applied below.
+        $this->suppressChunkDebugPlaceholders = true;
+        try {
+            $chunk = $this->getChunk($chunkName);
+        } finally {
+            $this->suppressChunkDebugPlaceholders = false;
+        }
         if (!empty($chunk) || $chunk === '0') {
             if (is_array($chunkArr)) {
-                if ((bool) $this->getOption('chunk_debug_placeholders', null, false)) {
+                if ($debugEnabled) {
                     $chunkObj = $this->getParser() ? $this->parser->getElement(modChunk::class, $chunkName) : null;
                     $debug = $this->buildChunkDebugPlaceholders($chunkName, $chunkObj, $chunkArr);
                     $chunkArr['this.name'] = $debug['name'];
@@ -2005,7 +2023,7 @@ class modX extends xPDO {
                     $chunkArr['this.placeholders'] = $debug['placeholders'];
                 }
                 foreach ($chunkArr as $key => $value) {
-                    $chunk= str_replace($prefix.$key.$suffix, $value, $chunk);
+                    $chunk = str_replace($prefix.$key.$suffix, $value, $chunk);
                 }
             }
         }

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2025,7 +2025,8 @@ class modX extends xPDO {
         return [
             'name' => $chunkName,
             'id' => ($chunk instanceof modChunk) ? $chunk->get('id') : '',
-            'placeholders' => print_r($source, true),
+            // Escape so debug dumps do not inject markup when rendered in HTML.
+            'placeholders' => htmlspecialchars(print_r($source, true), ENT_QUOTES, 'UTF-8'),
         ];
     }
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1970,8 +1970,11 @@ class modX extends xPDO {
             $chunk= $this->parser->getElement(modChunk::class, $chunkName);
             if ($chunk instanceof modChunk) {
                 $chunk->setCacheable(false);
-                if ((bool) $this->getOption('chunk_debug_placeholders', null, false) && !empty($properties)) {
-                    $properties['this'] = $this->buildChunkDebugPlaceholders($chunkName, $chunk, $properties);
+                if ((bool) $this->getOption('chunk_debug_placeholders', null, false)) {
+                    $debug = $this->buildChunkDebugPlaceholders($chunkName, $chunk, $properties);
+                    $properties['this.name'] = $debug['name'];
+                    $properties['this.id'] = $debug['id'];
+                    $properties['this.placeholders'] = $debug['placeholders'];
                 }
                 $output= $chunk->process($properties);
             }

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1970,6 +1970,9 @@ class modX extends xPDO {
             $chunk= $this->parser->getElement(modChunk::class, $chunkName);
             if ($chunk instanceof modChunk) {
                 $chunk->setCacheable(false);
+                if ((bool) $this->getOption('chunk_debug_placeholders', null, false) && !empty($properties)) {
+                    $properties['this'] = $this->buildChunkDebugPlaceholders($chunkName, $chunk, $properties);
+                }
                 $output= $chunk->process($properties);
             }
         }
@@ -1990,13 +1993,37 @@ class modX extends xPDO {
         $this->deprecated('3.0.0', 'Use $modx->getChunk instead');
         $chunk= $this->getChunk($chunkName);
         if (!empty($chunk) || $chunk === '0') {
-            if(is_array($chunkArr)) {
+            if (is_array($chunkArr)) {
+                if ((bool) $this->getOption('chunk_debug_placeholders', null, false)) {
+                    $chunkObj = $this->getParser() ? $this->parser->getElement(modChunk::class, $chunkName) : null;
+                    $debug = $this->buildChunkDebugPlaceholders($chunkName, $chunkObj, $chunkArr);
+                    $chunkArr['this.name'] = $debug['name'];
+                    $chunkArr['this.id'] = $debug['id'];
+                    $chunkArr['this.placeholders'] = $debug['placeholders'];
+                }
                 foreach ($chunkArr as $key => $value) {
                     $chunk= str_replace($prefix.$key.$suffix, $value, $chunk);
                 }
             }
         }
         return $chunk;
+    }
+
+    /**
+     * Build debug placeholders for chunks (this.name, this.id, this.placeholders).
+     *
+     * @param string $chunkName Chunk name.
+     * @param modChunk|null $chunk Chunk instance or null.
+     * @param array $source Properties array to dump (before adding debug keys).
+     * @return array{name: string, id: string|int, placeholders: string}
+     */
+    private function buildChunkDebugPlaceholders(string $chunkName, ?modChunk $chunk, array $source): array
+    {
+        return [
+            'name' => $chunkName,
+            'id' => ($chunk instanceof modChunk) ? $chunk->get('id') : '',
+            'placeholders' => print_r($source, true),
+        ];
     }
 
     /**

--- a/setup/includes/upgrades/common/3.2.1-chunk-debug-placeholders.php
+++ b/setup/includes/upgrades/common/3.2.1-chunk-debug-placeholders.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Add chunk_debug_placeholders system setting (default off).
  *
@@ -6,7 +7,6 @@
  */
 
 use MODX\Revolution\modSystemSetting;
-use MODX\Revolution\modX;
 
 $messageTemplate = '<p class="%s">%s</p>';
 $key = 'chunk_debug_placeholders';

--- a/setup/includes/upgrades/common/3.2.1-chunk-debug-placeholders.php
+++ b/setup/includes/upgrades/common/3.2.1-chunk-debug-placeholders.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Add chunk_debug_placeholders system setting (default off).
+ *
+ * @var modX $modx
+ */
+
+use MODX\Revolution\modSystemSetting;
+use MODX\Revolution\modX;
+
+$messageTemplate = '<p class="%s">%s</p>';
+$key = 'chunk_debug_placeholders';
+
+/** @var modSystemSetting|null $setting */
+$setting = $modx->getObject(modSystemSetting::class, ['key' => $key]);
+if ($setting instanceof modSystemSetting) {
+    return;
+}
+
+$setting = $modx->newObject(modSystemSetting::class);
+$setting->fromArray([
+    'key' => $key,
+    'value' => '0',
+    'xtype' => 'combo-boolean',
+    'namespace' => 'core',
+    'area' => 'system',
+], '', true, true);
+
+if ($setting->save()) {
+    $this->runner->addResult(
+        modInstallRunner::RESULT_SUCCESS,
+        sprintf($messageTemplate, 'ok', $this->install->lexicon('system_setting_update_success', ['key' => $key]))
+    );
+} else {
+    $this->runner->addResult(
+        modInstallRunner::RESULT_WARNING,
+        sprintf($messageTemplate, 'warning', $this->install->lexicon('system_setting_update_failed', ['key' => $key]))
+    );
+}

--- a/setup/includes/upgrades/mysql/3.2.1-pl.php
+++ b/setup/includes/upgrades/mysql/3.2.1-pl.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Specific upgrades for Revolution 3.2.1-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+include dirname(__DIR__) . '/common/3.2.1-chunk-debug-placeholders.php';


### PR DESCRIPTION
### What does it do?
Optional `chunk_debug_placeholders` setting. When on, `getChunk` injects `[[+this.name]]`, `[[+this.id]]`, and `[[+this.placeholders]]` (escaped dump). `parseChunk` applies the same after load so debug keys match the caller property bag. New installs get the setting from transport; upgrades from `3.2.1-pl`.

### Why is it needed?
Chunk debugging without editing every template. Off by default.

### How to test
1. Enable `chunk_debug_placeholders`
2. `getChunk` / `parseChunk` with a chunk that prints `[[+this.name]]` / `[[+this.placeholders]]`
3. Disable the setting and confirm those placeholders stay empty

### Related issue(s)/PR(s)
Chunk debug placeholders feature.