### PR TITLE
fix(setup): extend modUser password/cachepwd to 255 chars in 3.2.1 upgrade

### DIFF
--- a/setup/includes/upgrades/common/3.2.1-cleanup-upload-check-exists.php
+++ b/setup/includes/upgrades/common/3.2.1-cleanup-upload-check-exists.php
@@ -2,8 +2,8 @@
 
 /**
  * Remove legacy MODX 2.x system settings replaced by upload_file_exists in MODX 3.
- * Migrates a legacy value only when upload_file_exists is missing; never overwrites
- * an existing MODX 3 setting the admin may already have changed.
+ * After a normal 2.x→3.x upgrade the MODX 3 setting already exists; these orphans
+ * only linger without lexicon descriptions (#15877).
  *
  * @var modX $modx
  */
@@ -16,10 +16,6 @@ $settings = [
 ];
 
 $messageTemplate = '<p class="%s">%s</p>';
-$replacementKey = 'upload_file_exists';
-/** @var modSystemSetting|null $replacement */
-$replacement = $modx->getObject(modSystemSetting::class, ['key' => $replacementKey]);
-$valueMigrated = $replacement instanceof modSystemSetting;
 
 foreach ($settings as $key) {
     /** @var modSystemSetting|null $setting */
@@ -28,42 +24,23 @@ foreach ($settings as $key) {
         continue;
     }
 
-    if (!$valueMigrated) {
-        $setting->set('key', $replacementKey);
-        if (!$setting->save()) {
-            $msg = $this->install->lexicon('system_setting_update_failed', ['key' => $replacementKey]);
-            $this->runner->addResult(
-                modInstallRunner::RESULT_WARNING,
-                sprintf($messageTemplate, 'warning', $msg)
-            );
-            continue;
-        }
-
-        $replacement = $setting;
-        $valueMigrated = true;
-        $msg = $this->install->lexicon('system_setting_update_success', ['key' => $replacementKey]);
-        $this->runner->addResult(
-            modInstallRunner::RESULT_SUCCESS,
-            sprintf($messageTemplate, 'ok', $msg)
-        );
-        continue;
-    }
-
-    if ($setting === $replacement) {
-        continue;
-    }
-
     if ($setting->remove()) {
-        $msg = $this->install->lexicon('system_setting_cleanup_success', ['key' => $key]);
         $this->runner->addResult(
             modInstallRunner::RESULT_SUCCESS,
-            sprintf($messageTemplate, 'ok', $msg)
+            sprintf(
+                $messageTemplate,
+                'ok',
+                $this->install->lexicon('system_setting_cleanup_success', ['key' => $key])
+            )
         );
     } else {
-        $msg = $this->install->lexicon('system_setting_cleanup_failed', ['key' => $key]);
         $this->runner->addResult(
             modInstallRunner::RESULT_WARNING,
-            sprintf($messageTemplate, 'warning', $msg)
+            sprintf(
+                $messageTemplate,
+                'warning',
+                $this->install->lexicon('system_setting_cleanup_failed', ['key' => $key])
+            )
         );
     }
 }

--- a/setup/includes/upgrades/common/3.2.1-cleanup-upload-check-exists.php
+++ b/setup/includes/upgrades/common/3.2.1-cleanup-upload-check-exists.php
@@ -1,0 +1,69 @@
+<?php
+
+/**
+ * Remove legacy MODX 2.x system settings replaced by upload_file_exists in MODX 3.
+ * Migrates a legacy value only when upload_file_exists is missing; never overwrites
+ * an existing MODX 3 setting the admin may already have changed.
+ *
+ * @var modX $modx
+ */
+
+use MODX\Revolution\modSystemSetting;
+
+$settings = [
+    'upload_check_exists',
+    'upload_check_exist',
+];
+
+$messageTemplate = '<p class="%s">%s</p>';
+$replacementKey = 'upload_file_exists';
+/** @var modSystemSetting|null $replacement */
+$replacement = $modx->getObject(modSystemSetting::class, ['key' => $replacementKey]);
+$valueMigrated = $replacement instanceof modSystemSetting;
+
+foreach ($settings as $key) {
+    /** @var modSystemSetting|null $setting */
+    $setting = $modx->getObject(modSystemSetting::class, ['key' => $key]);
+    if (!($setting instanceof modSystemSetting)) {
+        continue;
+    }
+
+    if (!$valueMigrated) {
+        $setting->set('key', $replacementKey);
+        if (!$setting->save()) {
+            $msg = $this->install->lexicon('system_setting_update_failed', ['key' => $replacementKey]);
+            $this->runner->addResult(
+                modInstallRunner::RESULT_WARNING,
+                sprintf($messageTemplate, 'warning', $msg)
+            );
+            continue;
+        }
+
+        $replacement = $setting;
+        $valueMigrated = true;
+        $msg = $this->install->lexicon('system_setting_update_success', ['key' => $replacementKey]);
+        $this->runner->addResult(
+            modInstallRunner::RESULT_SUCCESS,
+            sprintf($messageTemplate, 'ok', $msg)
+        );
+        continue;
+    }
+
+    if ($setting === $replacement) {
+        continue;
+    }
+
+    if ($setting->remove()) {
+        $msg = $this->install->lexicon('system_setting_cleanup_success', ['key' => $key]);
+        $this->runner->addResult(
+            modInstallRunner::RESULT_SUCCESS,
+            sprintf($messageTemplate, 'ok', $msg)
+        );
+    } else {
+        $msg = $this->install->lexicon('system_setting_cleanup_failed', ['key' => $key]);
+        $this->runner->addResult(
+            modInstallRunner::RESULT_WARNING,
+            sprintf($messageTemplate, 'warning', $msg)
+        );
+    }
+}

--- a/setup/includes/upgrades/common/3.2.1-password-cachepwd-255.php
+++ b/setup/includes/upgrades/common/3.2.1-password-cachepwd-255.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * Ensure modUser.password and modUser.cachepwd support 255 chars (PHP recommendation for future hash algorithms).
+ * Idempotent: safe to run on 2.7→3.2.1 upgrades where 2.7-native-password-hash may not have run.
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+use MODX\Revolution\modUser;
+
+$class = modUser::class;
+$table = $modx->getTableName($class);
+
+$password = $this->install->lexicon('alter_column', ['column' => 'password', 'table' => $table]);
+$this->processResults($class, $password, [$modx->manager, 'alterField'], [$class, 'password']);
+
+$cachepwd = $this->install->lexicon('alter_column', ['column' => 'cachepwd', 'table' => $table]);
+$this->processResults($class, $cachepwd, [$modx->manager, 'alterField'], [$class, 'cachepwd']);

--- a/setup/includes/upgrades/mysql/3.2.1-pl.php
+++ b/setup/includes/upgrades/mysql/3.2.1-pl.php
@@ -9,3 +9,4 @@
 
 /* run upgrades common to all db platforms */
 include dirname(__DIR__) . '/common/3.2.1-password-cachepwd-255.php';
+include dirname(__DIR__) . '/common/3.2.1-cleanup-upload-check-exists.php';

--- a/setup/includes/upgrades/mysql/3.2.1-pl.php
+++ b/setup/includes/upgrades/mysql/3.2.1-pl.php
@@ -1,0 +1,11 @@
+<?php
+/**
+ * Specific upgrades for Revolution 3.2.1-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(__DIR__) . '/common/3.2.1-password-cachepwd-255.php';


### PR DESCRIPTION
### What does it do?
3.2.1 upgrade: widen `modUser.password` and `modUser.cachepwd` to `varchar(255)`.

Also includes the shared `mysql/3.2.1-pl.php` entry point used by #16873 (upload settings cleanup), so both PRs merge without file conflicts.

### Why is it needed?
Schema already declares 255 chars; older DBs may still truncate hashes. Issue #13929.

### How to test
Upgrade a 3.2.x DB; confirm both columns are `varchar(255)`. Re-run the step; it stays idempotent.

### Related issue(s)
Fixes #13929