### PR TITLE
fix(core): resolve SQL error when removing user or user group

### DIFF
--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -799,7 +799,6 @@
     </object>
 
     <object class="modPrincipal" extends="xPDO\Om\xPDOSimpleObject">
-        <composite alias="Acls" class="modAccess" local="id" foreign="principal" cardinality="many" owner="local" />
     </object>
 
     <object class="modPropertySet" table="property_set" extends="xPDO\Om\xPDOSimpleObject">

--- a/core/src/Revolution/modPrincipal.php
+++ b/core/src/Revolution/modPrincipal.php
@@ -45,8 +45,7 @@ abstract class modPrincipal extends xPDOSimpleObject
             \MODX\Revolution\Sources\modAccessMediaSource::class,
             modAccessNamespace::class,
         ]);
-        $targets = explode(',', $this->xpdo->getOption('principal_targets', null, $defaultTargets));
-        array_walk($targets, 'trim');
+        $targets = array_map('trim', explode(',', $this->xpdo->getOption('principal_targets', null, $defaultTargets)));
 
         foreach ($targets as $target) {
             $fields = $this->xpdo->getFields($target);
@@ -106,8 +105,7 @@ abstract class modPrincipal extends xPDOSimpleObject
             $defaultPrincipalTargets = 'MODX\\Revolution\\modAccessContext,'
                 . 'MODX\\Revolution\\modAccessResourceGroup,MODX\\Revolution\\modAccessCategory,'
                 . 'MODX\\Revolution\\Sources\\modAccessMediaSource,MODX\\Revolution\\modAccessNamespace';
-            $targets = explode(',', $this->xpdo->getOption('principal_targets', null, $defaultPrincipalTargets));
-            array_walk($targets, 'trim');
+            $targets = array_map('trim', explode(',', $this->xpdo->getOption('principal_targets', null, $defaultPrincipalTargets)));
         }
         $this->loadAttributes($targets, $context, $reload);
 

--- a/core/src/Revolution/modPrincipal.php
+++ b/core/src/Revolution/modPrincipal.php
@@ -11,8 +11,6 @@ use xPDO\xPDO;
  * {@internal Implement a derivative to define the behavior and attributes of
  * an actual user or system that is intended to access modX or a modX service.}
  *
- * @property modAccess[] $Acls
- *
  * @abstract
  * @package MODX\Revolution
  */
@@ -28,6 +26,51 @@ abstract class modPrincipal extends xPDOSimpleObject
      * @access protected
      */
     protected $_attributes = [];
+
+    /**
+     * Overrides xPDOObject::remove to delete ACL records before removing the principal.
+     * modAccess is abstract and has no table; xPDO cannot cascade-delete it, so we delete
+     * from each concrete principal_target table by principal_class and principal.
+     *
+     * {@inheritDoc}
+     */
+    public function remove(array $ancestors = [])
+    {
+        $principalClass = get_class($this);
+        $principalId = $this->get('id');
+        $defaultTargets = implode(',', [
+            modAccessContext::class,
+            modAccessResourceGroup::class,
+            modAccessCategory::class,
+            \MODX\Revolution\Sources\modAccessMediaSource::class,
+            modAccessNamespace::class,
+        ]);
+        $targets = explode(',', $this->xpdo->getOption('principal_targets', null, $defaultTargets));
+        array_walk($targets, 'trim');
+
+        foreach ($targets as $target) {
+            $fields = $this->xpdo->getFields($target);
+            $hasPrincipalFields = is_array($fields)
+                && array_key_exists('principal_class', $fields)
+                && array_key_exists('principal', $fields);
+            if (!$hasPrincipalFields) {
+                continue;
+            }
+            $tableName = $this->xpdo->getTableName($target);
+            if (empty($tableName)) {
+                continue;
+            }
+            $principalClassField = $this->xpdo->escape('principal_class');
+            $principalField = $this->xpdo->escape('principal');
+            $quotedClass = $this->xpdo->quote($principalClass);
+            $principalIdInt = (int) $principalId;
+            $sql = "DELETE FROM {$tableName} WHERE {$principalClassField} = {$quotedClass} "
+                . "AND {$principalField} = {$principalIdInt}";
+            $this->xpdo->query($sql);
+        }
+
+        return parent::remove($ancestors);
+    }
 
     /**
      * Load attributes of the principal that define access to secured objects.
@@ -60,8 +103,10 @@ abstract class modPrincipal extends xPDOSimpleObject
     {
         $context = !empty($context) ? $context : $this->xpdo->context->get('key');
         if (!is_array($targets) || empty($targets)) {
-            $targets = explode(',', $this->xpdo->getOption('principal_targets', null,
-                'MODX\\Revolution\\modAccessContext,MODX\\Revolution\\modAccessResourceGroup,MODX\\Revolution\\modAccessCategory,MODX\\Revolution\\Sources\\modAccessMediaSource,MODX\\Revolution\\modAccessNamespace'));
+            $defaultPrincipalTargets = 'MODX\\Revolution\\modAccessContext,'
+                . 'MODX\\Revolution\\modAccessResourceGroup,MODX\\Revolution\\modAccessCategory,'
+                . 'MODX\\Revolution\\Sources\\modAccessMediaSource,MODX\\Revolution\\modAccessNamespace';
+            $targets = explode(',', $this->xpdo->getOption('principal_targets', null, $defaultPrincipalTargets));
             array_walk($targets, 'trim');
         }
         $this->loadAttributes($targets, $context, $reload);

--- a/core/src/Revolution/modPrincipal.php
+++ b/core/src/Revolution/modPrincipal.php
@@ -38,14 +38,11 @@ abstract class modPrincipal extends xPDOSimpleObject
     {
         $principalClass = get_class($this);
         $principalId = $this->get('id');
-        $defaultTargets = implode(',', [
-            modAccessContext::class,
-            modAccessResourceGroup::class,
-            modAccessCategory::class,
-            \MODX\Revolution\Sources\modAccessMediaSource::class,
-            modAccessNamespace::class,
-        ]);
-        $targets = array_map('trim', explode(',', $this->xpdo->getOption('principal_targets', null, $defaultTargets)));
+        $targets = $this->getPrincipalRemovalTargets();
+
+        if (!$this->xpdo->beginTransaction()) {
+            return false;
+        }
 
         foreach ($targets as $target) {
             $fields = $this->xpdo->getFields($target);
@@ -65,10 +62,42 @@ abstract class modPrincipal extends xPDOSimpleObject
             $principalIdInt = (int) $principalId;
             $sql = "DELETE FROM {$tableName} WHERE {$principalClassField} = {$quotedClass} "
                 . "AND {$principalField} = {$principalIdInt}";
-            $this->xpdo->query($sql);
+            if ($this->xpdo->query($sql) === false) {
+                $this->xpdo->rollBack();
+
+                return false;
+            }
         }
 
-        return parent::remove($ancestors);
+        if (!parent::remove($ancestors)) {
+            $this->xpdo->rollBack();
+
+            return false;
+        }
+
+        return $this->xpdo->commit();
+    }
+
+    /**
+     * Built-in ACL targets plus any configured in the principal_targets setting.
+     *
+     * @return string[]
+     */
+    protected function getPrincipalRemovalTargets(): array
+    {
+        $defaultTargets = [
+            modAccessContext::class,
+            modAccessResourceGroup::class,
+            modAccessCategory::class,
+            \MODX\Revolution\Sources\modAccessMediaSource::class,
+            modAccessNamespace::class,
+        ];
+        $configuredTargets = array_map('trim', explode(',', (string) $this->xpdo->getOption('principal_targets', null, '')));
+        $configuredTargets = array_filter($configuredTargets, static function ($target) {
+            return $target !== '';
+        });
+
+        return array_values(array_unique(array_merge($defaultTargets, $configuredTargets)));
     }
 
     /**

--- a/core/src/Revolution/modUserGroup.php
+++ b/core/src/Revolution/modUserGroup.php
@@ -62,22 +62,7 @@ class modUserGroup extends modPrincipal
             ]);
         }
 
-        $removed = parent:: remove($ancestors);
-
-        // delete ACLs for this group
-        $targets = explode(',', $this->xpdo->getOption('principal_targets', null, implode(',', [modAccessContext::class,modAccessResourceGroup::class,modAccessCategory::class])));
-        array_walk($targets, 'trim');
-        foreach ($targets as $target) {
-            $fields = $this->xpdo->getFields($target);
-            if (array_key_exists('principal_class', $fields) && array_key_exists('principal', $fields)) {
-                $tablename = $this->xpdo->getTableName($target);
-                $principal_class_field = $this->xpdo->escape('principal_class');
-                $principal_field = $this->xpdo->escape('principal');
-                if (!empty($tablename)) {
-                    $this->xpdo->query("DELETE FROM {$tablename} WHERE {$principal_class_field} = {$this->xpdo->quote(modUserGroup::class)} AND {$principal_field} = {$this->_fields['id']}");
-                }
-            }
-        }
+        $removed = parent::remove($ancestors);
 
         if ($this->xpdo instanceof modX) {
             $this->xpdo->invokeEvent('OnUserGroupRemove', [

--- a/core/src/Revolution/mysql/modPrincipal.php
+++ b/core/src/Revolution/mysql/modPrincipal.php
@@ -20,17 +20,6 @@ class modPrincipal extends \MODX\Revolution\modPrincipal
         'fieldMeta' => 
         array (
         ),
-        'composites' => 
-        array (
-            'Acls' => 
-            array (
-                'class' => 'modAccess',
-                'local' => 'id',
-                'foreign' => 'principal',
-                'cardinality' => 'many',
-                'owner' => 'local',
-            ),
-        ),
     );
 
 }


### PR DESCRIPTION
### What does it do?
Remove the composite `Acls` relation from `modPrincipal` in the schema and mysql map, because `modAccess` is abstract and has no table. xPDO cascade-delete attempted to query a non-existent table, generating invalid SQL (`FROM AS modAccess`). Add manual ACL deletion in `modPrincipal::remove()` before `parent::remove()`, iterating over `principal_targets` tables (Context, ResourceGroup, Category, MediaSource, Namespace). Refactor `modUserGroup::remove()` to remove its duplicate ACL deletion block and rely on `modPrincipal::remove()`.

### Why is it needed?
When deleting a user (or user group) via the Manager, xPDO tried to cascade-delete the composite `Acls` of class `modAccess`. `modAccess` is abstract—real tables are `access_context`, `access_resource_groups`, etc. xPDO could not resolve a table name and produced broken SQL, causing errors in the log even though the user was removed successfully.

### How to test
1. Create a test user in Manager (Security → Users).
2. Delete the user from the grid.
3. Check the error log—there should be no "Could not get table name for class: modAccess" or SQL syntax errors.
4. Verify user removal and User Group removal still work correctly.

### Related issue(s)/PR(s)
Fixes #13725