### PR TITLE
fix(setup): preserve Windows paths in cli-install.php

### DIFF
--- a/_build/test/Tests/Cases/Setup/CliInstallPathNormalizeTest.php
+++ b/_build/test/Tests/Cases/Setup/CliInstallPathNormalizeTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -9,8 +10,10 @@
  *
  * @package modx-test
  */
+
 namespace MODX\Revolution\Tests\Cases\Setup;
 
+use MODX\Setup\modInstallPathUtil;
 use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
 
 /**
@@ -34,7 +37,7 @@ class CliInstallPathNormalizeTest extends XTestCase
      */
     public function testNormalizePathOrUrl($input, $expected)
     {
-        $this->assertSame($expected, \modInstallPathUtil::normalizePathOrUrl($input));
+        $this->assertSame($expected, modInstallPathUtil::normalizePathOrUrl($input));
     }
 
     /**

--- a/_build/test/Tests/Cases/Setup/CliInstallPathNormalizeTest.php
+++ b/_build/test/Tests/Cases/Setup/CliInstallPathNormalizeTest.php
@@ -1,0 +1,55 @@
+<?php
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+namespace MODX\Revolution\Tests\Cases\Setup;
+
+use Yoast\PHPUnitPolyfills\TestCases\XTestCase;
+
+/**
+ * @package modx-test
+ * @subpackage setup
+ * @group Cases
+ * @group Setup
+ */
+class CliInstallPathNormalizeTest extends XTestCase
+{
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+        require_once dirname(__DIR__, 5) . '/setup/includes/modinstallpathutil.class.php';
+    }
+
+    /**
+     * @param string $input
+     * @param string $expected
+     * @dataProvider providerNormalizePathOrUrl
+     */
+    public function testNormalizePathOrUrl($input, $expected)
+    {
+        $this->assertSame($expected, \modInstallPathUtil::normalizePathOrUrl($input));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerNormalizePathOrUrl()
+    {
+        return [
+            ['D:/laragon/www/site/core', 'D:/laragon/www/site/core/'],
+            ['D:\\laragon\\www\\site\\core', 'D:/laragon/www/site/core/'],
+            ['\\\\server\\share\\site\\core', '//server/share/site/core/'],
+            ['//server/share/site/core', '//server/share/site/core/'],
+            ['/var/www/site/core', '/var/www/site/core/'],
+            ['var/www/site/core', '/var/www/site/core/'],
+            ['/manager/', '/manager/'],
+        ];
+    }
+}

--- a/setup/cli-install.php
+++ b/setup/cli-install.php
@@ -19,6 +19,7 @@ if (PHP_SAPI != 'cli') {
     exit('This file should be run through the command line interface!');
 }
 $path = dirname(__FILE__) . '/';
+require_once $path . 'includes/modinstallpathutil.class.php';
 $config = $path . 'config.xml';
 $mode = 'new';
 $languages = array_slice(scandir($path . 'lang/'), 2);
@@ -154,11 +155,7 @@ foreach ($variables as $key => $params) {
         $data[$key] = trim($res);
     }
     if (strpos($key, '_path') !== false || strpos($key, '_url') !== false) {
-        $value = str_replace('\\', '/', trim($data[$key], "/\\"));
-        if (!preg_match('#^[A-Za-z]:#', $value)) {
-            $value = '/' . ltrim($value, '/');
-        }
-        $data[$key] = preg_replace('#/+#', '/', $value . '/');
+        $data[$key] = modInstallPathUtil::normalizePathOrUrl($data[$key]);
     }
 }
 

--- a/setup/cli-install.php
+++ b/setup/cli-install.php
@@ -154,7 +154,11 @@ foreach ($variables as $key => $params) {
         $data[$key] = trim($res);
     }
     if (strpos($key, '_path') !== false || strpos($key, '_url') !== false) {
-        $data[$key] = preg_replace('#/+#', '/', ('/' . trim($data[$key], '/') . '/'));
+        $value = trim($data[$key], '/');
+        if (!preg_match('#^[A-Za-z]:#', $value)) {
+            $value = '/' . $value;
+        }
+        $data[$key] = preg_replace('#/+#', '/', $value . '/');
     }
 }
 

--- a/setup/cli-install.php
+++ b/setup/cli-install.php
@@ -154,9 +154,9 @@ foreach ($variables as $key => $params) {
         $data[$key] = trim($res);
     }
     if (strpos($key, '_path') !== false || strpos($key, '_url') !== false) {
-        $value = trim($data[$key], '/');
+        $value = str_replace('\\', '/', trim($data[$key], "/\\"));
         if (!preg_match('#^[A-Za-z]:#', $value)) {
-            $value = '/' . $value;
+            $value = '/' . ltrim($value, '/');
         }
         $data[$key] = preg_replace('#/+#', '/', $value . '/');
     }

--- a/setup/cli-install.php
+++ b/setup/cli-install.php
@@ -155,7 +155,7 @@ foreach ($variables as $key => $params) {
         $data[$key] = trim($res);
     }
     if (strpos($key, '_path') !== false || strpos($key, '_url') !== false) {
-        $data[$key] = modInstallPathUtil::normalizePathOrUrl($data[$key]);
+        $data[$key] = \MODX\Setup\modInstallPathUtil::normalizePathOrUrl($data[$key]);
     }
 }
 

--- a/setup/includes/modinstallpathutil.class.php
+++ b/setup/includes/modinstallpathutil.class.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -7,6 +8,8 @@
  * For complete copyright and license information, see the COPYRIGHT and LICENSE
  * files found in the top-level directory of this distribution.
  */
+
+namespace MODX\Setup;
 
 /**
  * Path normalization helpers for the MODX CLI installer.

--- a/setup/includes/modinstallpathutil.class.php
+++ b/setup/includes/modinstallpathutil.class.php
@@ -1,0 +1,44 @@
+<?php
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+/**
+ * Path normalization helpers for the MODX CLI installer.
+ *
+ * @package setup
+ */
+class modInstallPathUtil
+{
+    /**
+     * Normalize a filesystem path or URL fragment entered during CLI installation.
+     *
+     * @param string $value
+     * @return string
+     */
+    public static function normalizePathOrUrl($value)
+    {
+        $raw = trim($value);
+        $isUnc = (bool) preg_match('#^(\\\\|//)#', $raw);
+        $isDrive = (bool) preg_match('#^[A-Za-z]:#', $raw);
+        $normalized = str_replace('\\', '/', $raw);
+
+        if ($isUnc) {
+            $normalized = ltrim($normalized, '/');
+            $normalized = '//' . preg_replace('#/+#', '/', $normalized);
+
+            return rtrim($normalized, '/') . '/';
+        }
+
+        if (!$isDrive) {
+            $normalized = '/' . ltrim($normalized, '/');
+        }
+
+        return preg_replace('#/+#', '/', rtrim($normalized, '/') . '/');
+    }
+}


### PR DESCRIPTION
### What changed and why

`cli-install.php` normalized paths by always prefixing `/`, which broke Windows drive letters (`D:/laragon/...`) and mixed backslash paths (#16890).

This PR preserves drive-letter paths and normalizes backslashes to forward slashes before trim.

### How to test

Run CLI install on Windows with `_path` values using `D:/...` or `D:\...`. Confirm paths in generated config stay valid.

### Related issue(s)/PR(s)

Resolves #16890

### Compatibility notes

Setup CLI on Windows. Unix paths unchanged.

### Breaking change assessment

No API changes. Path normalization fix only. Patch-safe.

### Test coverage

`CliInstallPathNormalizeTest` if present in branch; otherwise manual Windows CLI install.

### Contributors

None beyond author.

### AI tool use

Cursor helped normalize this PR description to the repository template.
