### PR TITLE
fix(core): restore event context in nested invokeEvent calls

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1705,51 +1705,64 @@ class modX extends xPDO {
             //$this->log(modX::LOG_LEVEL_DEBUG,'System event '.$eventName.' was executed but does not exist.');
             return false;
         }
-        $results= [];
-        if (count($this->eventMap[$eventName])) {
-            $this->event= new modSystemEvent();
-            foreach ($this->eventMap[$eventName] as $pluginId => $pluginPropset) {
-                /** @var modPlugin $plugin */
-                $plugin= null;
-                $this->Event = clone $this->event;
-                $this->event->resetEventObject();
-                $this->event->name= $eventName;
-                if (isset ($this->pluginCache[$pluginId])) {
-                    $plugin= $this->newObject(modPlugin::class);
-                    $plugin->fromArray($this->pluginCache[$pluginId], '', true, true);
-                    $plugin->_processed = false;
-                    if ($plugin->get('disabled')) {
-                        $plugin= null;
+        $results = [];
+        $previousEvent = $this->event;
+        try {
+            if (count($this->eventMap[$eventName])) {
+                $this->event = new modSystemEvent();
+                foreach ($this->eventMap[$eventName] as $pluginId => $pluginPropset) {
+                    /** @var modPlugin $plugin */
+                    $plugin = null;
+                    $this->Event = clone $this->event;
+                    $this->event->resetEventObject();
+                    $this->event->name = $eventName;
+                    if (isset($this->pluginCache[$pluginId])) {
+                        $plugin = $this->newObject(modPlugin::class);
+                        $plugin->fromArray($this->pluginCache[$pluginId], '', true, true);
+                        $plugin->_processed = false;
+                        if ($plugin->get('disabled')) {
+                            $plugin = null;
+                        }
+                    } else {
+                        $plugin = $this->getObject(
+                            modPlugin::class,
+                            ['id' => intval($pluginId), 'disabled' => '0'],
+                            true
+                        );
                     }
-                } else {
-                    $plugin= $this->getObject(modPlugin::class, ['id' => intval($pluginId), 'disabled' => '0'], true);
-                }
-                if ($plugin && !$plugin->get('disabled')) {
-                    $this->event->plugin =& $plugin;
-                    $this->event->activated= true;
-                    $this->event->activePlugin= $plugin->get('name');
-                    $this->event->propertySet= (($pspos = strpos($pluginPropset, ':')) >= 1) ? substr($pluginPropset, $pspos + 1) : '';
+                    if ($plugin && !$plugin->get('disabled')) {
+                        $this->event->plugin =& $plugin;
+                        $this->event->activated = true;
+                        $this->event->activePlugin = $plugin->get('name');
+                        $pspos = strpos($pluginPropset, ':');
+                        $this->event->propertySet = ($pspos >= 1) ? substr($pluginPropset, $pspos + 1) : '';
 
-                    /* merge in plugin properties */
-                    $eventParams = array_merge($plugin->getProperties(),$params);
+                        /* merge in plugin properties */
+                        $eventParams = array_merge($plugin->getProperties(), $params);
 
-                    $msg= $plugin->process($eventParams);
-                    $results[]= $this->event->_output;
-                    if ($msg && is_string($msg)) {
-                        $this->log(modX::LOG_LEVEL_ERROR, '[' . $this->event->name . ']' . $msg);
-                    } elseif ($msg === false) {
-                        $this->log(modX::LOG_LEVEL_ERROR, '[' . $this->event->name . '] Plugin ' . $plugin->name . ' failed!');
-                    }
-                    $this->event->plugin = null;
-                    $this->event->activePlugin= '';
-                    $this->event->propertySet= '';
-                    if (!$this->event->isPropagatable()) {
-                        break;
+                        $msg = $plugin->process($eventParams);
+                        $results[] = $this->event->_output;
+                        if ($msg && is_string($msg)) {
+                            $this->log(modX::LOG_LEVEL_ERROR, '[' . $this->event->name . ']' . $msg);
+                        } elseif ($msg === false) {
+                            $this->log(
+                                modX::LOG_LEVEL_ERROR,
+                                '[' . $this->event->name . '] Plugin ' . $plugin->name . ' failed!'
+                            );
+                        }
+                        $this->event->plugin = null;
+                        $this->event->activePlugin = '';
+                        $this->event->propertySet = '';
+                        if (!$this->event->isPropagatable()) {
+                            break;
+                        }
                     }
                 }
             }
+            return $results;
+        } finally {
+            $this->event = $previousEvent;
         }
-        return $results;
     }
 
     /**

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1585,12 +1585,12 @@ class modX extends xPDO {
         }
         $this->loadedjscripts[$src]= true;
         if (strpos(strtolower($src), "<style") !== false || strpos(strtolower($src), "<link") !== false) {
-            $this->sjscripts[count($this->sjscripts)]= $src;
+            $this->sjscripts[count($this->sjscripts)] = $src;
         } else {
             if (!empty($media)) {
                 $media = ' media="' . $media .'"';
             }
-            $this->sjscripts[count($this->sjscripts)]= '<link rel="stylesheet" href="' . $src . '" type="text/css"' . $media . ' />';
+            $this->sjscripts[count($this->sjscripts)] = '<link rel="stylesheet" href="' . $src . '" type="text/css"' . $media . ' />';
         }
     }
 
@@ -1609,11 +1609,11 @@ class modX extends xPDO {
                 return;
             $this->loadedjscripts[$src]= true;
             if ($plaintext == true) {
-                $this->sjscripts[count($this->sjscripts)]= $src;
+                $this->sjscripts[count($this->sjscripts)] = $src;
             } elseif (strpos(strtolower($src), "<script") !== false) {
-                $this->sjscripts[count($this->sjscripts)]= $src;
+                $this->sjscripts[count($this->sjscripts)] = $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)] = '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1632,11 +1632,11 @@ class modX extends xPDO {
             return;
         $this->loadedjscripts[$src]= true;
         if ($plaintext == true) {
-            $this->jscripts[count($this->jscripts)]= $src;
+            $this->jscripts[count($this->jscripts)] = $src;
         } elseif (strpos(strtolower($src), "<script") !== false) {
-            $this->jscripts[count($this->jscripts)]= $src;
+            $this->jscripts[count($this->jscripts)] = $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)] = '<script src="' . $src . '"></script>';
         }
     }
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1590,7 +1590,8 @@ class modX extends xPDO {
             if (!empty($media)) {
                 $media = ' media="' . $media .'"';
             }
-            $this->sjscripts[count($this->sjscripts)] = '<link rel="stylesheet" href="' . $src . '" type="text/css"' . $media . ' />';
+            $this->sjscripts[count($this->sjscripts)] =
+                '<link rel="stylesheet" href="' . $src . '" type="text/css"' . $media . ' />';
         }
     }
 


### PR DESCRIPTION
### What changed and why

Nested `$modx->invokeEvent()` calls overwrote `$modx->event`. Outer plugins then read the inner event name (for example `OnMediaSourceGetProperties` instead of `OnWebPageInit`) (#14063).

This PR saves and restores `$this->event` in `invokeEvent()` with try/finally.

### How to test

`$modx->event` is one shared object. A nested `invokeEvent()` used to replace it, so after the inner call returned the outer plugin still saw the inner event. This branch keeps the previous `$this->event` and restores it in `finally`.

You do not need a custom media source class. The stock Filesystem source (usually id 1) is enough.

**Plugin `showEventName`**, event `OnWebPageInit` (static file or inline):

```php
$before = $modx->event->name;
$source = $modx->getObject(\MODX\Revolution\Sources\modMediaSource::class, 1);
$source->initialize();
$source->getProperties();
$after = $modx->event->name;
die("before={$before} after={$after}");
```

`getProperties()` fires `OnMediaSourceGetProperties` from inside the outer plugin.

**Plugin `checkMediaSource`**, event `OnMediaSourceGetProperties`. Empty body is enough.

Clear the cache, then open any frontend resource.

| | `before` | `after` |
|---|---|---|
| 3.x | `OnWebPageInit` | `OnMediaSourceGetProperties` |
| this PR | `OnWebPageInit` | `OnWebPageInit` |

The original report in #14063 used `die($modx->event->name)` on a static `OnWebPageInit` plugin. Adding the empty `OnMediaSourceGetProperties` plugin was enough on that site because core already loaded media source properties during the request.

### Related issue(s)/PR(s)

Resolves #14063

### Compatibility notes

All contexts using `invokeEvent()`. Plugins that accidentally relied on nested overwrite may behave differently.

### Breaking change assessment

Restores documented isolation for nested events. No signature changes. Patch-safe for well-behaved plugins; plugins that depended on leaked inner event state will see the outer event again.

### Test coverage

No new PHPUnit in this PR. Use the dummy plugins above.

### Contributors

@rthrash asked for a before/after and dummy plugins for review.

### AI tool use

Cursor helped expand the How to test section after review.
