### PR TITLE
fix(resource): Return full resource from resource/create getObject()

### DIFF
--- a/core/src/Revolution/Processors/Resource/Create.php
+++ b/core/src/Revolution/Processors/Resource/Create.php
@@ -237,7 +237,7 @@ class Create extends CreateProcessor
     {
         $this->object->removeLock();
         $this->clearCache();
-        return $this->success('', ['id' => $this->object->get('id')]);
+        return $this->success('', $this->object);
     }
 
     /**


### PR DESCRIPTION
### What changed and why

`resource/create` returned only `['id' => …]` from `getObject()` while other Create processors return the full record. API consumers expected pagetitle, content, and other fields (#13912).

This PR makes `Resource\Create::cleanup()` return the full resource object.

### How to test

1. `runProcessor('resource/create', …)`; inspect `getObject()` for full fields.
2. Run `ResourceCreateTest.php`.

### Related issue(s)/PR(s)

Resolves #13912

### Compatibility notes

Connector/API callers of `resource/create`.

### Breaking change assessment

**Intentional behavior change:** `getObject()` now includes all resource fields, not only `id`. Code that assumed a single-key array must use `['id']` explicitly or check keys. Not patch-safe for callers that depended on the minimal shape.

### Test coverage

`ResourceCreateTest.php` (existing or updated in branch).

### Contributors

None beyond author.

### AI tool use

Cursor helped normalize this PR description to the repository template.
