### PR TITLE
fix(element): Add label to Property Set dropdown on Properties tab

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -134,7 +134,7 @@ MODx.grid.ElementProperties = function(config = {}) {
             pressed: true,
             disabled: !MODx.perm.unlock_element_properties,
             scope: this
-        }, '->', {
+        }, '->', _('propertysets') + ': ', {
             xtype: 'modx-combo-property-set',
             id: 'modx-combo-property-set',
             baseParams: {

--- a/manager/assets/modext/widgets/element/modx.panel.property.set.js
+++ b/manager/assets/modext/widgets/element/modx.panel.property.set.js
@@ -68,7 +68,7 @@ MODx.grid.PropertySetProperties = function(config = {}) {
     Ext.applyIf(config, {
         autoHeight: true,
         lockProperties: false,
-        tbar: [{
+        tbar: [_('propertysets') + ': ', {
             xtype: 'modx-combo-property-set',
             id: 'modx-combo-property-set',
             baseParams: {


### PR DESCRIPTION
### What does it do?
Adds a visible label **"Property Sets:"** for the Property Set dropdown on the Properties tab of elements (Chunk, Snippet, Template, etc.). The label is rendered in the toolbar in `modx.grid.element.properties.js` and in the tbar in `modx.panel.property.set.js`, using the existing lexicon key `propertysets`.

### Why is it needed?
The Property Set dropdown had no label, so users could not tell what the control was for. This change makes the UI clearer and fixes the missing label reported in the related issue.

### How to test
1. Edit a Chunk (or any element that has a Properties tab with Property Sets).
2. Open the **Properties** tab.
3. Confirm that the label **"Property Sets:"** appears next to the Property Set dropdown in the toolbar.

### Related issue(s)/PR(s)
Resolves #13901