### PR TITLE
feat(resource): Add childTemplate property for default child template

### DIFF
--- a/core/src/Revolution/Processors/Resource/Create.php
+++ b/core/src/Revolution/Processors/Resource/Create.php
@@ -325,57 +325,14 @@ class Create extends CreateProcessor
      */
     protected function resolveDefaultTemplate(): int
     {
-        $childTemplateId = $this->getChildTemplateIdFromParent();
+        $childTemplateId = $this->parentResource !== null
+            ? modTemplate::getChildTemplateId($this->parentResource)
+            : 0;
         if ($childTemplateId > 0) {
             return $childTemplateId;
         }
 
         return (int)$this->workingContext->getOption('default_template', 0);
-    }
-
-    /**
-     * Get template ID from parent resource's template property "childTemplate" when set and valid.
-     *
-     * @return int|null Template ID or null when not applicable
-     */
-    protected function getChildTemplateIdFromParent(): ?int
-    {
-        if ($this->parentResource === null) {
-            return null;
-        }
-
-        $parentTemplateId = (int)$this->parentResource->get('template');
-        if ($parentTemplateId <= 0) {
-            return null;
-        }
-
-        $parentTemplate = $this->modx->getObject(modTemplate::class, $parentTemplateId);
-        if ($parentTemplate === null) {
-            return null;
-        }
-
-        $properties = $parentTemplate->get('properties');
-        if (empty($properties) || !is_array($properties)) {
-            return null;
-        }
-
-        $childTemplateProp = $properties['childTemplate'] ?? null;
-        $value = is_array($childTemplateProp) ? ($childTemplateProp['value'] ?? null) : $childTemplateProp;
-        if ($value === null || $value === '') {
-            return null;
-        }
-
-        $templateId = (int)$value;
-        if ($templateId <= 0) {
-            return null;
-        }
-
-        $templateExists = $this->modx->getObject(
-            modTemplate::class,
-            $templateId
-        ) !== null;
-
-        return $templateExists ? $templateId : null;
     }
 
     /**

--- a/core/src/Revolution/Processors/Resource/Create.php
+++ b/core/src/Revolution/Processors/Resource/Create.php
@@ -247,7 +247,9 @@ class Create extends CreateProcessor
     public function setFieldDefaults()
     {
         $scriptProperties = $this->getProperties();
-        $scriptProperties['template'] = !isset($scriptProperties['template']) ? (int)$this->workingContext->getOption('default_template', 0) : (int)$scriptProperties['template'];
+        $scriptProperties['template'] = !isset($scriptProperties['template'])
+            ? $this->resolveDefaultTemplate()
+            : (int)$scriptProperties['template'];
         $scriptProperties['hidemenu'] = !isset($scriptProperties['hidemenu']) ? (int)$this->workingContext->getOption('hidemenu_default', 0) : (empty($scriptProperties['hidemenu']) ? 0 : 1);
         $scriptProperties['isfolder'] = empty($scriptProperties['isfolder']) ? 0 : 1;
         $scriptProperties['richtext'] = !isset($scriptProperties['richtext']) ? (int)$this->workingContext->getOption('richtext_default', 1) : (empty($scriptProperties['richtext']) ? 0 : 1);
@@ -313,6 +315,67 @@ class Create extends CreateProcessor
 
         $this->setProperties($scriptProperties);
         return true;
+    }
+
+    /**
+     * Resolve default template for the new resource.
+     * Uses parent template's childTemplate property when present and valid; otherwise context default.
+     *
+     * @return int Template ID
+     */
+    protected function resolveDefaultTemplate(): int
+    {
+        $childTemplateId = $this->getChildTemplateIdFromParent();
+        if ($childTemplateId > 0) {
+            return $childTemplateId;
+        }
+
+        return (int)$this->workingContext->getOption('default_template', 0);
+    }
+
+    /**
+     * Get template ID from parent resource's template property "childTemplate" when set and valid.
+     *
+     * @return int|null Template ID or null when not applicable
+     */
+    protected function getChildTemplateIdFromParent(): ?int
+    {
+        if ($this->parentResource === null) {
+            return null;
+        }
+
+        $parentTemplateId = (int)$this->parentResource->get('template');
+        if ($parentTemplateId <= 0) {
+            return null;
+        }
+
+        $parentTemplate = $this->modx->getObject(modTemplate::class, $parentTemplateId);
+        if ($parentTemplate === null) {
+            return null;
+        }
+
+        $properties = $parentTemplate->get('properties');
+        if (empty($properties) || !is_array($properties)) {
+            return null;
+        }
+
+        $childTemplateProp = $properties['childTemplate'] ?? null;
+        $value = is_array($childTemplateProp) ? ($childTemplateProp['value'] ?? null) : $childTemplateProp;
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        $templateId = (int)$value;
+        if ($templateId <= 0) {
+            return null;
+        }
+
+        $templateExists = $this->modx->getObject(
+            modTemplate::class,
+            $templateId
+        ) !== null;
+
+        return $templateExists ? $templateId : null;
     }
 
     /**

--- a/core/src/Revolution/modTemplate.php
+++ b/core/src/Revolution/modTemplate.php
@@ -225,6 +225,53 @@ class modTemplate extends modElement
     }
 
     /**
+     * Get the template ID from the childTemplate property for a parent resource.
+     * Returns the template ID that should be used for child resources, or 0 if not set or invalid.
+     *
+     * @param modResource $parent The parent resource.
+     * @return int Template ID or 0 when not applicable.
+     */
+    public static function getChildTemplateId(modResource $parent): int
+    {
+        $xpdo = $parent->xpdo;
+        if (!$xpdo instanceof modX) {
+            return 0;
+        }
+
+        $parentTemplateId = (int)$parent->get('template');
+        if ($parentTemplateId <= 0) {
+            return 0;
+        }
+
+        $parentTemplate = $xpdo->getObject(modTemplate::class, $parentTemplateId);
+        if ($parentTemplate === null) {
+            return 0;
+        }
+
+        $properties = $parentTemplate->get('properties');
+        if (empty($properties) || !is_array($properties)) {
+            return 0;
+        }
+
+        $childTemplateProp = $properties['childTemplate'] ?? null;
+        $value = is_array($childTemplateProp) ? ($childTemplateProp['value'] ?? null) : $childTemplateProp;
+        if ($value === null || $value === '') {
+            return 0;
+        }
+
+        $templateId = (int)$value;
+        if ($templateId <= 0) {
+            return 0;
+        }
+
+        if ($xpdo->getCount(modTemplate::class, ['id' => $templateId]) === 0) {
+            return 0;
+        }
+
+        return $templateId;
+    }
+
+    /**
      * Check to see if this Template is assigned the specified Template Var
      *
      * @param mixed $tvPk Either the ID, name or object of the Template Var

--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -13,6 +13,7 @@ use MODX\Revolution\modFormCustomizationProfile;
 use MODX\Revolution\modFormCustomizationProfileUserGroup;
 use MODX\Revolution\modFormCustomizationSet;
 use MODX\Revolution\modResource;
+use MODX\Revolution\modTemplate;
 use xPDO\Om\xPDOQuery;
 
 require_once __DIR__ . '/resource.class.php';
@@ -162,8 +163,11 @@ class ResourceCreateManagerController extends ResourceManagerController
             $this->resourceArray = array_merge($this->resourceArray, $reloadData);
             $this->resourceArray['resourceGroups'] = [];
             $this->resourceArray['parents'] = $this->getParents();
-            $this->resourceArray['resource_groups'] = $this->modx->getOption('resource_groups',
-                $this->resourceArray, []);
+            $this->resourceArray['resource_groups'] = $this->modx->getOption(
+                'resource_groups',
+                $this->resourceArray,
+                []
+            );
             $this->resourceArray['resource_groups'] = is_array($this->resourceArray['resource_groups'])
                 ? $this->resourceArray['resource_groups']
                 : json_decode($this->resourceArray['resource_groups'], true);
@@ -224,31 +228,38 @@ class ResourceCreateManagerController extends ResourceManagerController
         if (isset($this->scriptProperties['template'])) {
             $defaultTemplate = $this->scriptProperties['template'];
         } else {
-            switch ($this->context->getOption('automatic_template_assignment', 'parent', $this->modx->_userConfig)) {
-                case 'parent':
-                    if (!empty($this->parent->id))
-                        $defaultTemplate = $this->parent->get('template');
-                    break;
-                case 'sibling':
-                    if (!empty($this->parent->id)) {
-                        $c = $this->modx->newQuery(modResource::class);
-                        $c->where(['parent' => $this->parent->id, 'context_key' => $this->ctx]);
-                        $c->sortby('id', 'DESC');
-                        $c->limit(1);
-                        if ($siblings = $this->modx->getCollection(modResource::class, $c)) {
-                            /** @var modResource $sibling */
-                            foreach ($siblings as $sibling) {
-                                $defaultTemplate = $sibling->get('template');
-                            }
-                        } else {
-                            if (!empty($this->parent->id))
-                                $defaultTemplate = $this->parent->get('template');
+            $childTemplateId = $this->getChildTemplateIdFromParentTemplate();
+            if ($childTemplateId > 0) {
+                $defaultTemplate = $childTemplateId;
+            } else {
+                switch ($this->context->getOption('automatic_template_assignment', 'parent', $this->modx->_userConfig)) {
+                    case 'parent':
+                        if (!empty($this->parent->id)) {
+                            $defaultTemplate = $this->parent->get('template');
                         }
-                    }
-                    break;
-                case 'system':
-                    // already established
-                    break;
+                        break;
+                    case 'sibling':
+                        if (!empty($this->parent->id)) {
+                            $c = $this->modx->newQuery(modResource::class);
+                            $c->where(['parent' => $this->parent->id, 'context_key' => $this->ctx]);
+                            $c->sortby('id', 'DESC');
+                            $c->limit(1);
+                            if ($siblings = $this->modx->getCollection(modResource::class, $c)) {
+                                /** @var modResource $sibling */
+                                foreach ($siblings as $sibling) {
+                                    $defaultTemplate = $sibling->get('template');
+                                }
+                            } else {
+                                if (!empty($this->parent->id)) {
+                                    $defaultTemplate = $this->parent->get('template');
+                                }
+                            }
+                        }
+                        break;
+                    case 'system':
+                        // already established
+                        break;
+                }
             }
         }
         $userGroups = $this->modx->user->getUserGroups();
@@ -299,6 +310,49 @@ class ResourceCreateManagerController extends ResourceManagerController
         return $defaultTemplate;
     }
 
+    /**
+     * Get template ID from parent resource's template property "childTemplate" when set and valid.
+     *
+     * @return int Template ID or 0 when not applicable
+     */
+    protected function getChildTemplateIdFromParentTemplate(): int
+    {
+        if ($this->parent === null || empty($this->parent->get('id'))) {
+            return 0;
+        }
+
+        $parentTemplateId = (int)$this->parent->get('template');
+        if ($parentTemplateId <= 0) {
+            return 0;
+        }
+
+        $parentTemplate = $this->modx->getObject(modTemplate::class, $parentTemplateId);
+        if ($parentTemplate === null) {
+            return 0;
+        }
+
+        $properties = $parentTemplate->get('properties');
+        if (empty($properties) || !is_array($properties)) {
+            return 0;
+        }
+
+        $childTemplateProp = $properties['childTemplate'] ?? null;
+        $value = is_array($childTemplateProp)
+            ? ($childTemplateProp['value'] ?? null)
+            : $childTemplateProp;
+        if ($value === null || $value === '') {
+            return 0;
+        }
+
+        $templateId = (int)$value;
+        if ($templateId <= 0) {
+            return 0;
+        }
+
+        $templateExists = $this->modx->getObject(modTemplate::class, $templateId) !== null;
+
+        return $templateExists ? $templateId : 0;
+    }
 
     /**
      * Return the pagetitle

--- a/manager/controllers/default/resource/create.class.php
+++ b/manager/controllers/default/resource/create.class.php
@@ -228,7 +228,9 @@ class ResourceCreateManagerController extends ResourceManagerController
         if (isset($this->scriptProperties['template'])) {
             $defaultTemplate = $this->scriptProperties['template'];
         } else {
-            $childTemplateId = $this->getChildTemplateIdFromParentTemplate();
+            $childTemplateId = $this->parent !== null
+                ? modTemplate::getChildTemplateId($this->parent)
+                : 0;
             if ($childTemplateId > 0) {
                 $defaultTemplate = $childTemplateId;
             } else {
@@ -310,49 +312,6 @@ class ResourceCreateManagerController extends ResourceManagerController
         return $defaultTemplate;
     }
 
-    /**
-     * Get template ID from parent resource's template property "childTemplate" when set and valid.
-     *
-     * @return int Template ID or 0 when not applicable
-     */
-    protected function getChildTemplateIdFromParentTemplate(): int
-    {
-        if ($this->parent === null || empty($this->parent->get('id'))) {
-            return 0;
-        }
-
-        $parentTemplateId = (int)$this->parent->get('template');
-        if ($parentTemplateId <= 0) {
-            return 0;
-        }
-
-        $parentTemplate = $this->modx->getObject(modTemplate::class, $parentTemplateId);
-        if ($parentTemplate === null) {
-            return 0;
-        }
-
-        $properties = $parentTemplate->get('properties');
-        if (empty($properties) || !is_array($properties)) {
-            return 0;
-        }
-
-        $childTemplateProp = $properties['childTemplate'] ?? null;
-        $value = is_array($childTemplateProp)
-            ? ($childTemplateProp['value'] ?? null)
-            : $childTemplateProp;
-        if ($value === null || $value === '') {
-            return 0;
-        }
-
-        $templateId = (int)$value;
-        if ($templateId <= 0) {
-            return 0;
-        }
-
-        $templateExists = $this->modx->getObject(modTemplate::class, $templateId) !== null;
-
-        return $templateExists ? $templateId : 0;
-    }
 
     /**
      * Return the pagetitle


### PR DESCRIPTION
### What changed and why

Creating a child resource under a parent always required picking a template manually, even when the parent template defines a default child template (#13753).

This PR supports template property `childTemplate`. `Resource/Create` and the resource create controller read the parent template property and preselect that template (over `automatic_template_assignment` when set).

### How to test

1. Add `childTemplate` (template ID) to a parent template.
2. Create a child under a resource using that template.
3. Create form shows the child template; saved resource uses it.

### Related issue(s)/PR(s)

Resolves #13753

### Compatibility notes

Manager resource create and template properties. No DB schema change.

### Breaking change assessment

No API changes. New optional template property behavior. Patch-safe.

### Test coverage

No automated tests; manual create flow.

### Contributors

None beyond author.

### AI tool use

Cursor helped normalize this PR description to the repository template.
