### PR TITLE
feat(core): add SOCKS5 proxy support for package management and remote providers

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1201,6 +1201,15 @@ $settings['proxy_auth_type']->fromArray([
   'area' => 'proxy',
   'editedon' => null,
 ], '', true, true);
+$settings['proxy_type'] = $xpdo->newObject(modSystemSetting::class);
+$settings['proxy_type']->fromArray([
+  'key' => 'proxy_type',
+  'value' => 'HTTP',
+  'xtype' => 'textfield',
+  'namespace' => 'core',
+  'area' => 'proxy',
+  'editedon' => null,
+], '', true, true);
 $settings['proxy_host'] = $xpdo->newObject(modSystemSetting::class);
 $settings['proxy_host']->fromArray([
   'key' => 'proxy_host',

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -416,7 +416,7 @@ class modXTest extends MODxTestCase
             ['socks5', 'SOCKS5'],
             ['SOCKS4', 'SOCKS4'],
             ['SOCKS5_HOSTNAME', 'SOCKS5_HOSTNAME'],
-            ['socks5h', 'HTTP'],
+            ['socks5h', 'SOCKS5_HOSTNAME'],
             ['invalid', 'HTTP'],
             ['', 'HTTP'],
         ];

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -109,6 +109,8 @@ class modXTest extends MODxTestCase
         $this->modx->placeholders = [];
         $this->modx->resourceMap = [[1]];
         unset($this->modx->contexts['custom']);
+        $this->modx->setOption('proxy_host', '');
+        $this->modx->setOption('proxy_type', 'HTTP');
     }
     /**
      * Test getting the modCacheManager instance.
@@ -391,6 +393,65 @@ class modXTest extends MODxTestCase
             [6, 5, [], [7, 8, 9, 10, 11]],
             [6, null, [], [7, 8, 9, 10, 11, 12, 13, 14, 15, 16]],
             [22, 2, ['context' => 'custom'], [23, 24]]
+        ];
+    }
+
+    /**
+     * @param string $proxyType   Option value for proxy_type
+     * @param string $expected   Expected normalized result
+     * @dataProvider providerGetProxyType
+     */
+    public function testGetProxyType($proxyType, $expected)
+    {
+        $this->modx->setOption('proxy_type', $proxyType);
+        $this->assertEquals($expected, $this->modx->getProxyType());
+    }
+
+    public function providerGetProxyType()
+    {
+        return [
+            ['HTTP', 'HTTP'],
+            ['http', 'HTTP'],
+            ['SOCKS5', 'SOCKS5'],
+            ['socks5', 'SOCKS5'],
+            ['SOCKS4', 'SOCKS4'],
+            ['SOCKS5_HOSTNAME', 'SOCKS5_HOSTNAME'],
+            ['socks5h', 'HTTP'],
+            ['invalid', 'HTTP'],
+            ['', 'HTTP'],
+        ];
+    }
+
+    /**
+     * @param string $proxyHost
+     * @param string $proxyPort
+     * @param string $proxyType
+     * @param string $proxyUsername
+     * @param string $proxyPassword
+     * @param string $expected
+     * @dataProvider providerGetProxyUrl
+     */
+    public function testGetProxyUrl($proxyHost, $proxyPort, $proxyType, $proxyUsername, $proxyPassword, $expected)
+    {
+        $this->modx->setOption('proxy_host', $proxyHost);
+        $this->modx->setOption('proxy_port', $proxyPort);
+        $this->modx->setOption('proxy_type', $proxyType);
+        $this->modx->setOption('proxy_username', $proxyUsername);
+        $this->modx->setOption('proxy_password', $proxyPassword);
+        $this->assertEquals($expected, $this->modx->getProxyUrl());
+    }
+
+    public function providerGetProxyUrl()
+    {
+        return [
+            ['', '', 'HTTP', '', '', ''],
+            ['proxy.example.com', '', 'HTTP', '', '', 'http://proxy.example.com'],
+            ['proxy.example.com', '8080', 'HTTP', '', '', 'http://proxy.example.com:8080'],
+            ['proxy.example.com', '1080', 'SOCKS5', '', '', 'socks5://proxy.example.com:1080'],
+            ['proxy.example.com', '1080', 'SOCKS5_HOSTNAME', '', '', 'socks5h://proxy.example.com:1080'],
+            ['proxy.example.com', '8080', 'HTTP', 'user', 'pass', 'http://user:pass@proxy.example.com:8080'],
+            ['proxy.example.com', '', 'SOCKS5', 'u', 'p', 'socks5://u:p@proxy.example.com'],
+            ['host', '3128', 'HTTP', 'u%3A', 'p@ss', 'http://u%253A:p%40ss@host:3128'],
         ];
     }
 }

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -525,6 +525,9 @@ $_lang['setting_principal_targets_desc'] = 'Customize the ACL targets to load fo
 $_lang['setting_proxy_auth_type'] = 'Proxy Authentication Type';
 $_lang['setting_proxy_auth_type_desc'] = 'Supports either BASIC or NTLM.';
 
+$_lang['setting_proxy_type'] = 'Proxy Type';
+$_lang['setting_proxy_type_desc'] = 'Proxy protocol: HTTP, SOCKS4, SOCKS5, or SOCKS5_HOSTNAME (SOCKS5 with remote DNS resolution).';
+
 $_lang['setting_proxy_host'] = 'Proxy Host';
 $_lang['setting_proxy_host_desc'] = 'If your server is using a proxy, set the hostname here to enable MODX features that might need to use the proxy, such as Package Management.';
 

--- a/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
@@ -144,7 +144,9 @@ class Feed extends Processor
         $proxyUrl = $this->modx->getProxyUrl();
         if (!empty($proxyUrl)) {
             $config['CURLOPT_PROXY'] = $proxyUrl;
-            $config['CURLOPT_HTTPPROXYTUNNEL'] = true;
+            if ($this->modx->getProxyType() === 'HTTP') {
+                $config['CURLOPT_HTTPPROXYTUNNEL'] = true;
+            }
         }
         return $config;
     }

--- a/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
@@ -136,23 +136,15 @@ class Feed extends Processor
     /**
      * Build configuration for the SimplePie client based on configuration settings.
      *
-     * @return array The proxy configuration.
+     * @return array The proxy configuration (curl options).
      */
     private function buildProxyOptions()
     {
         $config = [];
-        $proxyHost = $this->modx->getOption('proxy_host', null, '');
-        if (!empty($proxyHost)) {
-            $config['CURLOPT_PROXY'] = $proxyHost;
-            $proxyPort = $this->modx->getOption('proxy_port', null, '');
-            if (!empty($proxyPort)) {
-                $config['CURLOPT_PROXY'] .= ':' . $proxyPort;
-            }
-            $proxyUsername = $this->modx->getOption('proxy_username', null, '');
-            if (!empty($proxyUsername)) {
-                $proxyPassword = $this->modx->getOption('proxy_password', null, '');
-                $config['CURLOPT_PROXYUSERPWD'] = $proxyUsername . ':' . $proxyPassword;
-            }
+        $proxyUrl = $this->modx->getProxyUrl();
+        if (!empty($proxyUrl)) {
+            $config['CURLOPT_PROXY'] = $proxyUrl;
+            $config['CURLOPT_HTTPPROXYTUNNEL'] = true;
         }
         return $config;
     }

--- a/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
+++ b/core/src/Revolution/Processors/System/Dashboard/Widget/Feed.php
@@ -143,9 +143,9 @@ class Feed extends Processor
         $config = [];
         $proxyUrl = $this->modx->getProxyUrl();
         if (!empty($proxyUrl)) {
-            $config['CURLOPT_PROXY'] = $proxyUrl;
+            $config[CURLOPT_PROXY] = $proxyUrl;
             if ($this->modx->getProxyType() === 'HTTP') {
-                $config['CURLOPT_HTTPPROXYTUNNEL'] = true;
+                $config[CURLOPT_HTTPPROXYTUNNEL] = true;
             }
         }
         return $config;

--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -464,17 +464,8 @@ class modTransportPackage extends xPDOObject
                 $proxyUrl = $this->xpdo->getProxyUrl();
                 if (!empty($proxyUrl)) {
                     curl_setopt($ch, CURLOPT_PROXY, $proxyUrl);
-                    curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, true);
                     if ($this->xpdo->getProxyType() === 'HTTP') {
-                        $proxyUsername = $this->xpdo->getOption('proxy_username', null, '');
-                        if ($proxyUsername !== '') {
-                            $proxyAuth = $this->xpdo->getOption('proxy_auth_type', null, 'BASIC');
-                            $proxyAuth = $proxyAuth === 'NTLM' ? CURLAUTH_NTLM : CURLAUTH_BASIC;
-                            curl_setopt($ch, CURLOPT_PROXYAUTH, $proxyAuth);
-                            $proxyPassword = $this->xpdo->getOption('proxy_password', null, '');
-                            $proxyUserPwd = rawurlencode($proxyUsername) . ':' . rawurlencode($proxyPassword);
-                            curl_setopt($ch, CURLOPT_PROXYUSERPWD, $proxyUserPwd);
-                        }
+                        curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, true);
                     }
                 }
                 $content = curl_exec($ch);

--- a/core/src/Revolution/Transport/modTransportPackage.php
+++ b/core/src/Revolution/Transport/modTransportPackage.php
@@ -461,21 +461,20 @@ class modTransportPackage extends xPDOObject
                     curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1);
                 }
 
-                $proxyHost = $this->xpdo->getOption('proxy_host', null, '');
-                if (!empty($proxyHost)) {
-                    $proxyPort = $this->xpdo->getOption('proxy_port', null, '');
-                    curl_setopt($ch, CURLOPT_PROXY, $proxyHost);
-                    curl_setopt($ch, CURLOPT_PROXYPORT, $proxyPort);
-
-                    $proxyUsername = $this->xpdo->getOption('proxy_username', null, '');
-                    if (!empty($proxyUsername)) {
-                        $proxyAuth = $this->xpdo->getOption('proxy_auth_type', null, 'BASIC');
-                        $proxyAuth = $proxyAuth == 'NTLM' ? CURLAUTH_NTLM : CURLAUTH_BASIC;
-                        curl_setopt($ch, CURLOPT_PROXYAUTH, $proxyAuth);
-
-                        $proxyPassword = $this->xpdo->getOption('proxy_password', null, '');
-                        $up = $proxyUsername . (!empty($proxyPassword) ? ':' . $proxyPassword : '');
-                        curl_setopt($ch, CURLOPT_PROXYUSERPWD, $up);
+                $proxyUrl = $this->xpdo->getProxyUrl();
+                if (!empty($proxyUrl)) {
+                    curl_setopt($ch, CURLOPT_PROXY, $proxyUrl);
+                    curl_setopt($ch, CURLOPT_HTTPPROXYTUNNEL, true);
+                    if ($this->xpdo->getProxyType() === 'HTTP') {
+                        $proxyUsername = $this->xpdo->getOption('proxy_username', null, '');
+                        if ($proxyUsername !== '') {
+                            $proxyAuth = $this->xpdo->getOption('proxy_auth_type', null, 'BASIC');
+                            $proxyAuth = $proxyAuth === 'NTLM' ? CURLAUTH_NTLM : CURLAUTH_BASIC;
+                            curl_setopt($ch, CURLOPT_PROXYAUTH, $proxyAuth);
+                            $proxyPassword = $this->xpdo->getOption('proxy_password', null, '');
+                            $proxyUserPwd = rawurlencode($proxyUsername) . ':' . rawurlencode($proxyPassword);
+                            curl_setopt($ch, CURLOPT_PROXYUSERPWD, $proxyUserPwd);
+                        }
                     }
                 }
                 $content = curl_exec($ch);

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2792,6 +2792,9 @@ class modX extends xPDO {
     public function getProxyType()
     {
         $type = strtoupper((string) $this->getOption('proxy_type', null, 'HTTP'));
+        if ($type === 'SOCKS5H') {
+            $type = 'SOCKS5_HOSTNAME';
+        }
         $allowed = ['HTTP', 'SOCKS4', 'SOCKS5', 'SOCKS5_HOSTNAME'];
         return in_array($type, $allowed, true) ? $type : 'HTTP';
     }
@@ -2838,9 +2841,11 @@ class modX extends xPDO {
         $proxyUrl = $this->getProxyUrl();
         if (!empty($proxyUrl)) {
             $opts['proxy'] = $proxyUrl;
-            $opts['curl'] = [
-                CURLOPT_HTTPPROXYTUNNEL => true,
-            ];
+            if ($this->getProxyType() === 'HTTP') {
+                $opts['curl'] = [
+                    CURLOPT_HTTPPROXYTUNNEL => true,
+                ];
+            }
         }
         return $opts;
     }

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2778,10 +2778,53 @@ class modX extends xPDO {
             });
         }
         if (!$this->services->has(UriFactoryInterface::class)) {
-            $this->services->add(UriFactoryInterface::class, function() {
+            $this->services->add(UriFactoryInterface::class, function () {
                 return new HttpFactory();
             });
         }
+    }
+
+    /**
+     * Normalized proxy type (e.g. HTTP, SOCKS5) from system settings.
+     *
+     * @return string Uppercase proxy type; 'HTTP' if unknown or not set.
+     */
+    public function getProxyType()
+    {
+        $type = strtoupper((string) $this->getOption('proxy_type', null, 'HTTP'));
+        $allowed = ['HTTP', 'SOCKS4', 'SOCKS5', 'SOCKS5_HOSTNAME'];
+        return in_array($type, $allowed, true) ? $type : 'HTTP';
+    }
+
+    /**
+     * Build the full proxy URL including protocol prefix (e.g. http://, socks5h://).
+     * Used by HTTP client, transport package download, and dashboard feed.
+     * Username and password are rawurlencode'd to support : and @ in credentials.
+     *
+     * @return string Full proxy URL or empty string if proxy is not configured.
+     */
+    public function getProxyUrl()
+    {
+        $proxyHost = $this->getOption('proxy_host', null, '');
+        if (empty($proxyHost)) {
+            return '';
+        }
+        $protocolMap = [
+            'HTTP' => 'http://',
+            'SOCKS4' => 'socks4://',
+            'SOCKS5' => 'socks5://',
+            'SOCKS5_HOSTNAME' => 'socks5h://',
+        ];
+        $protocol = $protocolMap[$this->getProxyType()] ?? 'http://';
+        $proxyPort = $this->getOption('proxy_port', null, '');
+        $hostPart = $proxyHost . (!empty($proxyPort) ? ':' . $proxyPort : '');
+        $proxyUsername = $this->getOption('proxy_username', null, '');
+        $auth = '';
+        if ($proxyUsername !== '') {
+            $password = $this->getOption('proxy_password', null, '');
+            $auth = rawurlencode($proxyUsername) . ':' . rawurlencode($password) . '@';
+        }
+        return $protocol . $auth . $hostPart;
     }
 
     /**
@@ -2789,21 +2832,15 @@ class modX extends xPDO {
      *
      * @return array The HTTP client options.
      */
-    private function buildHttpClientOptions() {
+    private function buildHttpClientOptions()
+    {
         $opts = [];
-        $proxyHost = $this->getOption('proxy_host', null, '');
-        if (!empty($proxyHost)) {
-            $proxy_str = $proxyHost;
-            $proxyPort = $this->getOption('proxy_port', null, '');
-            if (!empty($proxyPort)) {
-                $proxy_str .= ':' . $proxyPort;
-            }
-            $proxyUsername = $this->getOption('proxy_username', null, '');
-            if (!empty($proxyUsername)) {
-                $proxyPassword = $this->getOption('proxy_password', null, '');
-                $proxy_str = $proxyUsername . ':' . $proxyPassword . '@' . $proxy_str;
-            }
-            $opts['proxy'] = $proxy_str;
+        $proxyUrl = $this->getProxyUrl();
+        if (!empty($proxyUrl)) {
+            $opts['proxy'] = $proxyUrl;
+            $opts['curl'] = [
+                CURLOPT_HTTPPROXYTUNNEL => true,
+            ];
         }
         return $opts;
     }

--- a/setup/includes/upgrades/common/3.2.1-add-proxy-type-setting.php
+++ b/setup/includes/upgrades/common/3.2.1-add-proxy-type-setting.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * Add proxy_type system setting for SOCKS5 support
+ *
+ * @var modX $modx
+ * @var modInstallRunner $this
+ * @package setup
+ * @subpackage upgrades
+ */
+
+use MODX\Revolution\modSystemSetting;
+
+$messageTemplate = '<p class="%s">%s</p>';
+
+$setting = $modx->getObject(modSystemSetting::class, ['key' => 'proxy_type']);
+if (!$setting) {
+    $setting = $modx->newObject(modSystemSetting::class);
+    $setting->fromArray([
+        'key' => 'proxy_type',
+        'value' => 'HTTP',
+        'xtype' => 'textfield',
+        'namespace' => 'core',
+        'area' => 'proxy',
+    ]);
+    if ($setting->save()) {
+        $msg = $this->install->lexicon('system_setting_update_success', ['key' => 'proxy_type']);
+        $this->runner->addResult(modInstallRunner::RESULT_SUCCESS, sprintf($messageTemplate, 'ok', $msg));
+    } else {
+        $msg = $this->install->lexicon('system_setting_update_failed', ['key' => 'proxy_type']);
+        $this->runner->addResult(modInstallRunner::RESULT_ERROR, sprintf($messageTemplate, 'error', $msg));
+    }
+}

--- a/setup/includes/upgrades/mysql/3.2.1-pl.php
+++ b/setup/includes/upgrades/mysql/3.2.1-pl.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Specific upgrades for Revolution 3.2.1-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(__DIR__) . '/common/3.2.1-add-proxy-type-setting.php';


### PR DESCRIPTION
### What changed and why

Sites behind SOCKS or HTTP proxies could not reach package providers or RSS feeds using existing `proxy_*` settings alone (#16900).

This PR routes package downloads and remote provider requests through SOCKS5/HTTP proxy configuration from system settings.

### How to test

1. Set `proxy_host`, `proxy_port`, and related proxy settings.
2. Refresh Package Management provider list.
3. Load a dashboard RSS widget that pulls a remote feed.

### Related issue(s)/PR(s)

Resolves #16900

### Compatibility notes

Requires proxy settings and network path to provider. Guzzle/cURL behavior depends on PHP build.

### Breaking change assessment

No public API signature changes. Opt-in via proxy settings. Patch-safe.

### Test coverage

No automated tests; manual proxy environment.

### Contributors

Discussion on #16900.

### AI tool use

Cursor helped normalize this PR description to the repository template.
