### PR TITLE
feat(workspace): add logManagerAction for package install/upgrade/remove

### DIFF
--- a/core/src/Revolution/Processors/Workspace/Packages/Install.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Install.php
@@ -86,10 +86,14 @@ class Install extends Processor
         $this->modx->log(modX::LOG_LEVEL_WARN, $msg);
         $this->modx->log(modX::LOG_LEVEL_INFO, 'COMPLETED');
 
+        $isUpgrade = $this->package->previousVersionInstalled();
         $this->modx->invokeEvent('OnPackageInstall', [
             'package' => $this->package,
-            'action' => $this->package->previousVersionInstalled() ? xPDOTransport::ACTION_UPGRADE : xPDOTransport::ACTION_INSTALL,
+            'action' => $isUpgrade ? xPDOTransport::ACTION_UPGRADE : xPDOTransport::ACTION_INSTALL,
         ]);
+
+        $action = $isUpgrade ? 'package_upgrade' : 'package_install';
+        $this->modx->logManagerAction($action, modTransportPackage::class, $this->package->getPrimaryKey());
 
         return $this->success($msg);
     }

--- a/core/src/Revolution/Processors/Workspace/Packages/Install.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Install.php
@@ -92,10 +92,18 @@ class Install extends Processor
             'action' => $isUpgrade ? xPDOTransport::ACTION_UPGRADE : xPDOTransport::ACTION_INSTALL,
         ]);
 
-        $action = $isUpgrade ? 'package_upgrade' : 'package_install';
-        $this->modx->logManagerAction($action, modTransportPackage::class, $this->package->getPrimaryKey());
+        $this->logManagerAction();
 
         return $this->success($msg);
+    }
+
+    /**
+     * Log package install or upgrade to Manager Log.
+     */
+    public function logManagerAction()
+    {
+        $action = $this->package->previousVersionInstalled() ? 'package_upgrade' : 'package_install';
+        $this->modx->logManagerAction($action, modTransportPackage::class, $this->package->getPrimaryKey());
     }
 
     public function clearCache()

--- a/core/src/Revolution/Processors/Workspace/Packages/Remove.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Remove.php
@@ -94,8 +94,6 @@ class Remove extends Processor
         $this->removeTransportZip($transportZip);
         $this->removeTransportDirectory($transportDir);
 
-        $this->logManagerAction();
-
         return $this->cleanup();
     }
 
@@ -147,11 +145,6 @@ class Remove extends Processor
         }
     }
 
-    public function logManagerAction()
-    {
-        $this->modx->logManagerAction('package_remove', modTransportPackage::class, $this->package->getPrimaryKey());
-    }
-
     /**
      * Cleanup and return the result
      * @return array
@@ -162,10 +155,20 @@ class Remove extends Processor
         sleep(2);
         $this->modx->log(modX::LOG_LEVEL_INFO, 'COMPLETED');
 
+        $this->logManagerAction();
+
         $this->modx->invokeEvent('OnPackageRemove', [
             'package' => $this->package,
         ]);
 
         return $this->success();
+    }
+
+    /**
+     * Log package remove to Manager Log.
+     */
+    public function logManagerAction()
+    {
+        $this->modx->logManagerAction('package_remove', modTransportPackage::class, $this->package->getPrimaryKey());
     }
 }

--- a/core/src/Revolution/Processors/Workspace/Packages/Remove.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Remove.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -93,6 +94,8 @@ class Remove extends Processor
         $this->removeTransportZip($transportZip);
         $this->removeTransportDirectory($transportDir);
 
+        $this->logManagerAction();
+
         return $this->cleanup();
     }
 
@@ -142,6 +145,11 @@ class Remove extends Processor
         } else {
             $this->modx->log(xPDO::LOG_LEVEL_INFO, $this->modx->lexicon('package_remove_info_tdir'));
         }
+    }
+
+    public function logManagerAction()
+    {
+        $this->modx->logManagerAction('package_remove', modTransportPackage::class, $this->package->getPrimaryKey());
     }
 
     /**

--- a/core/src/Revolution/Processors/Workspace/Packages/Uninstall.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Uninstall.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -79,7 +80,9 @@ class Uninstall extends Processor
         ];
 
         if ($this->package->uninstall($options) === false) {
-            return $this->failure(sprintf($this->modx->lexicon('package_err_uninstall'), ['signature' => $this->package->get('signature')], $this->package->getPrimaryKey()));
+            return $this->failure($this->modx->lexicon('package_err_uninstall', [
+                'signature' => $this->package->get('signature'),
+            ]));
         }
 
         $this->modx->log(modX::LOG_LEVEL_WARN,
@@ -100,7 +103,7 @@ class Uninstall extends Processor
 
     public function logManagerAction()
     {
-        $this->modx->logManagerAction('package_uninstall', modTransportPackage::class, $this->package->get('id'));
+        $this->modx->logManagerAction('package_uninstall', modTransportPackage::class, $this->package->getPrimaryKey());
     }
 
     public function clearCache()

--- a/core/src/Revolution/Processors/Workspace/Packages/Update.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Update.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -82,6 +83,6 @@ class Update extends Processor
 
     public function logManagerAction()
     {
-        $this->modx->logManagerAction('package_update', modTransportPackage::class, $this->package->get('id'));
+        $this->modx->logManagerAction('package_update', modTransportPackage::class, $this->package->getPrimaryKey());
     }
 }

--- a/core/src/Revolution/Processors/Workspace/Packages/Version/Remove.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/Version/Remove.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -126,6 +127,6 @@ class Remove extends Processor
 
     public function logManagerAction()
     {
-        $this->modx->logManagerAction('package_remove', modTransportPackage::class, $this->package->get('id'));
+        $this->modx->logManagerAction('package_remove', modTransportPackage::class, $this->package->getPrimaryKey());
     }
 }


### PR DESCRIPTION
### What changed and why

Package install, upgrade, remove, and uninstall did not appear in Manager Log, so audits of workspace actions were incomplete (#16453).

This PR calls `logManagerAction()` from Install, Remove, Uninstall, Update, and Version/Remove processors. Uses `getPrimaryKey()` for signature. Fixes Uninstall lexicon placeholders (array instead of `sprintf()`).

### How to test

1. Install → log shows `package_install`.
2. Upgrade → `package_upgrade`.
3. Remove → `package_remove`.
4. Uninstall → no errors; log entry present.
5. Manager Log lists each action with correct package name.

### Related issue(s)/PR(s)

Resolves #16453

### Compatibility notes

Manager Log and workspace processors only.

### Breaking change assessment

No API changes. New log entries only. Patch-safe.

### Test coverage

No new PHPUnit; manual workspace actions above.

### Contributors

None beyond author.

### AI tool use

Cursor helped normalize this PR description to the repository template.
