### PR TITLE
feat(search): include Template Variable values in manager search

### DIFF
--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -10,7 +11,6 @@
 
 namespace MODX\Revolution\Processors\Search;
 
-
 use MODX\Revolution\modChunk;
 use MODX\Revolution\modContext;
 use MODX\Revolution\modElement;
@@ -20,6 +20,7 @@ use MODX\Revolution\modResource;
 use MODX\Revolution\modSnippet;
 use MODX\Revolution\modTemplate;
 use MODX\Revolution\modTemplateVar;
+use MODX\Revolution\modTemplateVarResource;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserProfile;
 
@@ -100,55 +101,142 @@ class Search extends Processor
     }
 
     /**
-     * Search in resources
+     * Returns context keys for resource search (excluding mgr).
+     *
+     * @return array<int, string>
      */
-    protected function searchResources()
+    protected function getResourceContextKeys(): array
     {
         $contextKeys = [];
         $contexts = $this->modx->getIterator(modContext::class, ['key:!=' => 'mgr']);
         foreach ($contexts as $context) {
             $contextKeys[] = $context->get('key');
         }
+        return $contextKeys;
+    }
 
-        $c = $this->modx->newQuery(modResource::class);
-        $c->leftJoin(modTemplate::class, 'modTemplate', 'modResource.template = modTemplate.id');
-        $c->select($this->modx->getSelectColumns(modResource::class, 'modResource'));
-        $c->select('modTemplate.icon as icon');
+    /**
+     * Returns resource IDs that have the search query in any TV value.
+     *
+     * @return array<int, int>
+     */
+    protected function getResourceIdsMatchingTvValues(): array
+    {
+        if (!$this->searchInContent()) {
+            return [];
+        }
 
+        $c = $this->modx->newQuery(modTemplateVarResource::class);
+        $c->select('contentid');
+        $c->where(['value:LIKE' => '%' . $this->query . '%']);
+        $c->limit($this->getMaxResults() * 2);
+
+        $ids = [];
+        foreach ($this->modx->getIterator(modTemplateVarResource::class, $c) as $row) {
+            $ids[] = (int) $row->get('contentid');
+        }
+
+        return array_values(array_unique($ids));
+    }
+
+    /**
+     * Builds search criteria and context for resource query, including TV-matched IDs.
+     *
+     * @param array<int, string> $contextKeys
+     * @return array{search: array, context: array, tvIds: array<int, int>}
+     */
+    protected function buildResourceSearchCriteria(array $contextKeys): array
+    {
         $querySearch = [
-            'modResource.pagetitle:LIKE' => '%' . $this->query .'%',
-            'OR:modResource.longtitle:LIKE' => '%' . $this->query .'%',
-            'OR:modResource.alias:LIKE' => '%' . $this->query .'%',
-            'OR:modResource.description:LIKE' => '%' . $this->query .'%',
-            'OR:modResource.introtext:LIKE' => '%' . $this->query .'%',
+            'modResource.pagetitle:LIKE' => '%' . $this->query . '%',
+            'OR:modResource.longtitle:LIKE' => '%' . $this->query . '%',
+            'OR:modResource.alias:LIKE' => '%' . $this->query . '%',
+            'OR:modResource.description:LIKE' => '%' . $this->query . '%',
+            'OR:modResource.introtext:LIKE' => '%' . $this->query . '%',
         ];
+        $tvIds = [];
         if ($this->searchInContent()) {
-            $querySearch['OR:modResource.content:LIKE'] = '%' . $this->query .'%';
+            $querySearch['OR:modResource.content:LIKE'] = '%' . $this->query . '%';
+            $tvIds = $this->getResourceIdsMatchingTvValues();
+            if (!empty($tvIds)) {
+                $querySearch['OR:modResource.id:IN'] = $tvIds;
+            }
         }
         $querySearch['OR:modResource.id:='] = $this->query;
         $queryContext = [
             'modResource.context_key:IN' => $contextKeys,
         ];
-        $c->where($querySearch, $queryContext);
 
-        $c->sortby('IF(`modResource`.`pagetitle` = ' . $this->modx->quote($this->query) . ', 0, 1)');
+        return ['search' => $querySearch, 'context' => $queryContext, 'tvIds' => $tvIds];
+    }
+
+    /**
+     * Applies relevance-based sort order to the resource search query.
+     *
+     * @param \xPDO\Om\xPDOQuery $c
+     * @param array<int, int> $tvIds
+     */
+    protected function applyResourceSearchSortBy($c, array $tvIds): void
+    {
+        $q = $this->modx->quote($this->query);
+        $qLike = $this->modx->quote($this->query . '%');
+        $qContains = $this->modx->quote('%' . $this->query . '%');
+
+        $c->sortby('(`modResource`.`pagetitle` = ' . $q . ')', 'DESC');
+        $c->sortby('(`modResource`.`pagetitle` LIKE ' . $qLike . ')', 'DESC');
+        $otherFieldsLike = '(`modResource`.`longtitle` LIKE ' . $qContains
+            . ' OR `modResource`.`alias` LIKE ' . $qContains
+            . ' OR `modResource`.`description` LIKE ' . $qContains
+            . ' OR `modResource`.`introtext` LIKE ' . $qContains . ')';
+        $c->sortby($otherFieldsLike, 'DESC');
+        if ($this->searchInContent()) {
+            $c->sortby('(`modResource`.`content` LIKE ' . $qContains . ')', 'DESC');
+            if (!empty($tvIds)) {
+                $ids = implode(',', array_map('intval', $tvIds));
+                $c->sortby('(`modResource`.`id` IN (' . $ids . '))', 'DESC');
+            }
+        }
         $c->sortby('modResource.createdon', 'DESC');
+    }
 
+    /**
+     * Formats a resource record for the search results array.
+     *
+     * @param modResource $record
+     * @return array<string, mixed>
+     */
+    protected function formatResourceSearchResult(modResource $record): array
+    {
+        return [
+            'name' => $this->modx->hasPermission('tree_show_resource_ids')
+                ? $record->get('pagetitle') . ' (' . $record->get('id') . ')'
+                : $record->get('pagetitle'),
+            '_action' => 'resource/update&id=' . $record->get('id'),
+            'description' => $record->get('description'),
+            'type' => static::TYPE_RESOURCE . 's',
+            'class' => $record->get('class_key'),
+            'icon' => str_replace('icon-', '', $record->get('icon')),
+        ];
+    }
+
+    /**
+     * Search in resources
+     */
+    protected function searchResources()
+    {
+        $contextKeys = $this->getResourceContextKeys();
+        $criteria = $this->buildResourceSearchCriteria($contextKeys);
+
+        $c = $this->modx->newQuery(modResource::class);
+        $c->leftJoin(modTemplate::class, 'modTemplate', 'modResource.template = modTemplate.id');
+        $c->select($this->modx->getSelectColumns(modResource::class, 'modResource'));
+        $c->select('modTemplate.icon as icon');
+        $c->where($criteria['search'], $criteria['context']);
+        $this->applyResourceSearchSortBy($c, $criteria['tvIds']);
         $c->limit($this->getMaxResults());
 
-        $collection = $this->modx->getIterator(modResource::class, $c);
-        /** @var modResource $record */
-        foreach ($collection as $record) {
-            $this->results[] = [
-                'name' => $this->modx->hasPermission('tree_show_resource_ids')
-                    ? $record->get('pagetitle') . ' (' . $record->get('id') . ')'
-                    : $record->get('pagetitle'),
-                '_action' => 'resource/update&id=' . $record->get('id'),
-                'description' => $record->get('description'),
-                'type' => static::TYPE_RESOURCE . 's',
-                'class' => $record->get('class_key'),
-                'icon' => str_replace('icon-', '', $record->get('icon'))
-            ];
+        foreach ($this->modx->getIterator(modResource::class, $c) as $record) {
+            $this->results[] = $this->formatResourceSearchResult($record);
         }
     }
 
@@ -165,10 +253,10 @@ class Search extends Processor
         $c = $this->modx->newQuery($class);
         $querySearch = [
             $nameField . ':LIKE' => '%' . $this->query . '%',
-            'OR:' . $descriptionField . ':LIKE' => '%' . $this->query .'%',
+            'OR:' . $descriptionField . ':LIKE' => '%' . $this->query . '%',
         ];
         if ($this->searchInContent() && !empty($contentField)) {
-            $querySearch['OR:' . $contentField . ':LIKE'] = '%' . $this->query .'%';
+            $querySearch['OR:' . $contentField . ':LIKE'] = '%' . $this->query . '%';
         }
         $querySearch['OR:id:='] = $this->query;
         $c->where($querySearch);
@@ -203,8 +291,8 @@ class Search extends Processor
         $c->leftJoin(modUserProfile::class, 'Profile');
         $c->where([
             'username:LIKE' => '%' . $this->query . '%',
-            'OR:Profile.fullname:LIKE' => '%' . $this->query .'%',
-            'OR:Profile.email:LIKE' => '%' . $this->query .'%',
+            'OR:Profile.fullname:LIKE' => '%' . $this->query . '%',
+            'OR:Profile.email:LIKE' => '%' . $this->query . '%',
             'OR:id:=' => $this->query,
         ]);
 
@@ -218,7 +306,7 @@ class Search extends Processor
         foreach ($collection as $record) {
             $this->results[] = [
                 'name' => $record->get('username'),
-                'description' => $record->get('fullname') .' / '. $record->get('email'),
+                'description' => $record->get('fullname') . ' / ' . $record->get('email'),
                 '_action' => 'security/user/update&id=' . $record->get('internalKey'),
                 'type' => static::TYPE_USER . 's',
             ];

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -126,9 +126,11 @@ class Search extends Processor
             return [];
         }
 
+        $escaped = addcslashes($this->query, '%_');
         $c = $this->modx->newQuery(modTemplateVarResource::class);
         $c->select('contentid');
-        $c->where(['value:LIKE' => '%' . $this->query . '%']);
+        $c->where(['value:LIKE' => '%' . $escaped . '%']);
+        $c->groupby('contentid');
         $c->limit($this->getMaxResults() * 2);
 
         $ids = [];
@@ -172,11 +174,12 @@ class Search extends Processor
 
     /**
      * Applies relevance-based sort order to the resource search query.
+     * Sort levels must stay in sync with fields in buildResourceSearchCriteria().
      *
      * @param \xPDO\Om\xPDOQuery $c
      * @param array<int, int> $tvIds
      */
-    protected function applyResourceSearchSortBy($c, array $tvIds): void
+    protected function applyResourceSearchSortBy(\xPDO\Om\xPDOQuery $c, array $tvIds): void
     {
         $q = $this->modx->quote($this->query);
         $qLike = $this->modx->quote($this->query . '%');

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -146,7 +146,7 @@ class Search extends Processor
         $c->leftJoin(modTemplateVar::class, 'Tv', 'Tv.id = TvTemplate.tmplvarid');
         $c->leftJoin(modTemplateVarResource::class, 'TvResource', [
             'TvResource.contentid = modResource.id',
-            'AND:TvResource.tmplvarid = Tv.id',
+            'TvResource.tmplvarid = Tv.id',
         ]);
     }
 

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -21,8 +21,10 @@ use MODX\Revolution\modSnippet;
 use MODX\Revolution\modTemplate;
 use MODX\Revolution\modTemplateVar;
 use MODX\Revolution\modTemplateVarResource;
+use MODX\Revolution\modTemplateVarTemplate;
 use MODX\Revolution\modUser;
 use MODX\Revolution\modUserProfile;
+use xPDO\Om\xPDOQuery;
 
 /**
  * Searches for elements, resources and users
@@ -116,60 +118,74 @@ class Search extends Processor
     }
 
     /**
-     * Returns resource IDs that have the search query in any TV value.
-     *
-     * @return array<int, int>
+     * Returns the search query as a LIKE pattern with wildcard characters escaped.
      */
-    protected function getResourceIdsMatchingTvValues(): array
+    protected function getEscapedQueryLike(): string
     {
-        if (!$this->searchInContent()) {
-            return [];
-        }
-
-        $escaped = addcslashes($this->query, '%_');
-        $c = $this->modx->newQuery(modTemplateVarResource::class);
-        $c->select('contentid');
-        $c->where(['value:LIKE' => '%' . $escaped . '%']);
-        $c->groupby('contentid');
-        $c->limit($this->getMaxResults() * 2);
-
-        $ids = [];
-        foreach ($this->modx->getIterator(modTemplateVarResource::class, $c) as $row) {
-            $ids[] = (int) $row->get('contentid');
-        }
-
-        return array_values(array_unique($ids));
+        return '%' . addcslashes($this->query, '%_') . '%';
     }
 
     /**
-     * Builds search criteria and context for resource query, including TV-matched IDs.
+     * SQL expression for the effective TV value on a resource (stored value or TV default).
+     */
+    protected function getEffectiveTvValueSql(): string
+    {
+        return 'IF(ISNULL(`TvResource`.`value`) OR `TvResource`.`value` = \'\', `Tv`.`default_text`, `TvResource`.`value`)';
+    }
+
+    /**
+     * Adds LEFT JOINs for template TVs and per-resource TV values.
+     *
+     * @param \xPDO\Om\xPDOQuery $c
+     */
+    protected function applyResourceTvJoin(\xPDO\Om\xPDOQuery $c): void
+    {
+        $c->leftJoin(modTemplateVarTemplate::class, 'TvTemplate', [
+            'TvTemplate.templateid = modResource.template',
+        ]);
+        $c->leftJoin(modTemplateVar::class, 'Tv', 'Tv.id = TvTemplate.tmplvarid');
+        $c->leftJoin(modTemplateVarResource::class, 'TvResource', [
+            'TvResource.contentid = modResource.id',
+            'AND:TvResource.tmplvarid = Tv.id',
+        ]);
+    }
+
+    /**
+     * SQL condition matching resources whose effective TV value contains the query.
+     */
+    protected function getTvValueMatchCondition(): string
+    {
+        return '(' . $this->getEffectiveTvValueSql() . ' LIKE ' . $this->modx->quote($this->getEscapedQueryLike())
+            . ' AND `Tv`.`id` IS NOT NULL)';
+    }
+
+    /**
+     * Builds search criteria and context for resource query.
+     *
+     * TV values are always included here; resource content is gated by quick_search_in_content.
      *
      * @param array<int, string> $contextKeys
-     * @return array{search: array, context: array, tvIds: array<int, int>}
+     * @return array{search: array, context: array}
      */
     protected function buildResourceSearchCriteria(array $contextKeys): array
     {
+        $like = $this->getEscapedQueryLike();
         $querySearch = [
-            'modResource.pagetitle:LIKE' => '%' . $this->query . '%',
-            'OR:modResource.longtitle:LIKE' => '%' . $this->query . '%',
-            'OR:modResource.alias:LIKE' => '%' . $this->query . '%',
-            'OR:modResource.description:LIKE' => '%' . $this->query . '%',
-            'OR:modResource.introtext:LIKE' => '%' . $this->query . '%',
+            'modResource.pagetitle:LIKE' => $like,
+            'OR:modResource.longtitle:LIKE' => $like,
+            'OR:modResource.alias:LIKE' => $like,
+            'OR:modResource.description:LIKE' => $like,
+            'OR:modResource.introtext:LIKE' => $like,
         ];
-        $tvIds = [];
         if ($this->searchInContent()) {
-            $querySearch['OR:modResource.content:LIKE'] = '%' . $this->query . '%';
-            $tvIds = $this->getResourceIdsMatchingTvValues();
-            if (!empty($tvIds)) {
-                $querySearch['OR:modResource.id:IN'] = $tvIds;
-            }
+            $querySearch['OR:modResource.content:LIKE'] = $like;
         }
         $querySearch['OR:modResource.id:='] = $this->query;
         $queryContext = [
             'modResource.context_key:IN' => $contextKeys,
         ];
 
-        return ['search' => $querySearch, 'context' => $queryContext, 'tvIds' => $tvIds];
+        return ['search' => $querySearch, 'context' => $queryContext];
     }
 
     /**
@@ -177,16 +193,16 @@ class Search extends Processor
      * Sort levels must stay in sync with fields in buildResourceSearchCriteria().
      *
      * @param \xPDO\Om\xPDOQuery $c
-     * @param array<int, int> $tvIds
      */
-    protected function applyResourceSearchSortBy(\xPDO\Om\xPDOQuery $c, array $tvIds): void
+    protected function applyResourceSearchSortBy(\xPDO\Om\xPDOQuery $c): void
     {
         $q = $this->modx->quote($this->query);
         $qLike = $this->modx->quote($this->query . '%');
-        $qContains = $this->modx->quote('%' . $this->query . '%');
+        $qContains = $this->modx->quote($this->getEscapedQueryLike());
 
         $c->sortby('(`modResource`.`pagetitle` = ' . $q . ')', 'DESC');
         $c->sortby('(`modResource`.`pagetitle` LIKE ' . $qLike . ')', 'DESC');
+        $c->sortby('(`modResource`.`pagetitle` LIKE ' . $qContains . ')', 'DESC');
         $otherFieldsLike = '(`modResource`.`longtitle` LIKE ' . $qContains
             . ' OR `modResource`.`alias` LIKE ' . $qContains
             . ' OR `modResource`.`description` LIKE ' . $qContains
@@ -194,11 +210,8 @@ class Search extends Processor
         $c->sortby($otherFieldsLike, 'DESC');
         if ($this->searchInContent()) {
             $c->sortby('(`modResource`.`content` LIKE ' . $qContains . ')', 'DESC');
-            if (!empty($tvIds)) {
-                $ids = implode(',', array_map('intval', $tvIds));
-                $c->sortby('(`modResource`.`id` IN (' . $ids . '))', 'DESC');
-            }
         }
+        $c->sortby('(' . $this->getTvValueMatchCondition() . ')', 'DESC');
         $c->sortby('modResource.createdon', 'DESC');
     }
 
@@ -232,10 +245,13 @@ class Search extends Processor
 
         $c = $this->modx->newQuery(modResource::class);
         $c->leftJoin(modTemplate::class, 'modTemplate', 'modResource.template = modTemplate.id');
+        $this->applyResourceTvJoin($c);
+        $c->distinct();
         $c->select($this->modx->getSelectColumns(modResource::class, 'modResource'));
         $c->select('modTemplate.icon as icon');
         $c->where($criteria['search'], $criteria['context']);
-        $this->applyResourceSearchSortBy($c, $criteria['tvIds']);
+        $c->where($this->getTvValueMatchCondition(), xPDOQuery::SQL_OR);
+        $this->applyResourceSearchSortBy($c);
         $c->limit($this->getMaxResults());
 
         foreach ($this->modx->getIterator(modResource::class, $c) as $record) {


### PR DESCRIPTION
### What changed and why

Manager search indexed resource fields but not Template Variable values. Content stored only in TVs was invisible to search (#16703).

This PR includes TV values in manager search results for resources.

### How to test

1. Create a resource with a distinctive string only in a TV (not pagetitle/content).
2. Run manager search for that string.
3. Confirm the resource appears in results.

### Related issue(s)/PR(s)

Resolves #16703

### Compatibility notes

Manager search only. May increase query work on large sites with many TVs.

### Breaking change assessment

No API changes. Broader search results only. Patch-safe.

### Test coverage

No automated tests in PR; manual search case above.

### Contributors

None beyond author.

### AI tool use

Cursor helped normalize this PR description to the repository template.
