### PR TITLE
fix(media): only call exif_read_data for JPEG/TIFF

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2300,7 +2300,7 @@ QTIP;
             } else {
                 $absolute_path = $path;
             }
-            if (function_exists('exif_read_data')) {
+            if (function_exists('exif_read_data') && $this->isExifSupportedExtension($ext)) {
                 $exif = @exif_read_data($absolute_path);
                 if (!empty($exif) && array_key_exists('Orientation', $exif) && $exif['Orientation'] >= 5) {
                     // This image was rotated
@@ -2347,6 +2347,18 @@ QTIP;
         ];
     }
 
+    /**
+     * Whether the file extension supports EXIF (only JPEG and TIFF do in PHP).
+     *
+     * @param string $ext File extension (case-insensitive).
+     * @return bool
+     */
+    private function isExifSupportedExtension($ext)
+    {
+        $supported = ['jpg', 'jpeg', 'tiff', 'tif'];
+
+        return in_array(strtolower($ext), $supported, true);
+    }
 
     /**
      * @param $path

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2353,7 +2353,7 @@ QTIP;
      * @param string $ext File extension (case-insensitive).
      * @return bool
      */
-    private function isExifSupportedExtension($ext)
+    protected function isExifSupportedExtension(string $ext): bool
     {
         $supported = ['jpg', 'jpeg', 'tiff', 'tif'];
 


### PR DESCRIPTION
### What does it do?
Call `exif_read_data()` only for file extensions that support EXIF in PHP (jpg, jpeg, tiff, tif). Adds `isExifSupportedExtension()` helper so .ico and other image types no longer trigger "File not supported" warnings in media source previews.

### Why is it needed?
`exif_read_data()` in PHP only supports JPEG and TIFF; calling it on .ico, PNG, WebP, etc. causes warnings and pollutes logs (Issue #16420).

### How to test
Open Media Source in the manager, browse to a folder containing .ico (or PNG/WebP) and confirm no PHP warning `exif_read_data(...): File not supported` appears; preview and rotation for JPEG/TIFF should still work.

### Related issue(s)/PR(s)
Resolves #16420