### PR TITLE
fix(setup): add idempotent upgrade for missing content_type.icon and dashboard.customizable

### DIFF
--- a/setup/includes/upgrades/common/3.2.1-missing-columns.php
+++ b/setup/includes/upgrades/common/3.2.1-missing-columns.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Idempotent upgrade script: add content_type.icon and dashboard.customizable
+ * if missing (fixes broken upgrades where 3.0.0 migrations did not complete).
+ *
+ * @var modInstallVersion $this
+ * @var modX $modx
+ * @package setup
+ */
+
+use MODX\Revolution\modContentType;
+use MODX\Revolution\modDashboard;
+
+$class = modContentType::class;
+$column = 'icon';
+$table = $modx->getTableName($class);
+$stmt = $modx->query('SHOW COLUMNS FROM ' . $modx->escape($table) . ' LIKE ' . $modx->quote($column));
+$iconExists = $stmt && $stmt->fetch() !== false;
+
+if (!$iconExists) {
+    $description = $this->install->lexicon('add_column', ['column' => $column, 'table' => $table]);
+    $this->processResults($class, $description, [$modx->manager, 'addField'], [$class, $column]);
+}
+
+$class = modDashboard::class;
+$column = 'customizable';
+$table = $modx->getTableName($class);
+$stmt = $modx->query('SHOW COLUMNS FROM ' . $modx->escape($table) . ' LIKE ' . $modx->quote($column));
+$customizableExists = $stmt && $stmt->fetch() !== false;
+
+if (!$customizableExists) {
+    $description = $this->install->lexicon('add_column', ['column' => $column, 'table' => $table]);
+    $this->processResults($class, $description, [$modx->manager, 'addField'], [$class, $column]);
+}

--- a/setup/includes/upgrades/mysql/3.2.1-pl.php
+++ b/setup/includes/upgrades/mysql/3.2.1-pl.php
@@ -1,0 +1,10 @@
+<?php
+/**
+ * Specific upgrades for Revolution 3.2.1-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+include dirname(__DIR__) . '/common/3.2.1-missing-columns.php';


### PR DESCRIPTION
### What changed and why

Some 3.x upgrades skipped or partially ran 3.0.0-pl migrations, leaving out `content_type.icon` and `dashboard.customizable`. The app then 500s and the web context disappears (#15504).

This PR adds idempotent upgrade 3.2.1-pl: `SHOW COLUMNS` before each `addField()` for both columns. Shared logic in `3.2.1-missing-columns.php`, MySQL entry in `3.2.1-pl.php`.

### How to test

1. DB missing one or both columns; `settings_version` < 3.2.1-pl.
2. Run setup upgrade; log shows add-column steps when needed.
3. Manager and frontend load; resource tree shows web context.
4. Re-run upgrade: no duplicate column errors.

### Related issue(s)/PR(s)

Resolves #15504

### Compatibility notes

MySQL upgrade path. Safe to run multiple times (idempotent).

### Breaking change assessment

No API changes. Schema repair only. Patch-safe.

### Test coverage

No PHPUnit; manual upgrade on a broken DB snapshot.

### Contributors

None beyond author.

### AI tool use

Cursor helped normalize this PR description to the repository template.
