### PR TITLE
Fix package metadata format

### DIFF
--- a/core/src/Revolution/Processors/Workspace/Packages/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/GetList.php
@@ -170,9 +170,9 @@ class GetList extends GetListProcessor
     {
         $metadata = $packageArray['metadata'];
         if (!empty($metadata)) {
-            foreach ($metadata as $k => $v) {
-                if ($k === 'description') {
-                    $packageArray['readme'] = nl2br($v);
+            foreach ($metadata as $key => $value) {
+                if ($key === 'description') {
+                    $packageArray['readme'] = nl2br($value);
                     break;
                 }
             }

--- a/core/src/Revolution/Processors/Workspace/Packages/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/GetList.php
@@ -170,9 +170,9 @@ class GetList extends GetListProcessor
     {
         $metadata = $packageArray['metadata'];
         if (!empty($metadata)) {
-            foreach ($metadata as $row) {
-                if (!empty($row['name']) && $row['name'] === 'description') {
-                    $packageArray['readme'] = nl2br($row['text']);
+            foreach ($metadata as $k => $v) {
+                if ($k === 'description') {
+                    $packageArray['readme'] = nl2br($v);
                     break;
                 }
             }


### PR DESCRIPTION
### What does it do?
Adjust Processors\Workspace\Packages\GetList class's function getPackageMeta

### Why is it needed?
At some point in the last 14-17 years, the provider started responding with a different model than what was expected. Rather than changing the provider and potentially breaking a lot more areas that work with the metadata field, I propose to change the processor. 

### How to test
Open your package management page `/manager/?a=workspaces` and try to expand an extra that was installed with the provider. It will expose an empty field. 

### Related issue(s)/PR(s)
This was pointed out in Community Slack
