### PR TITLE
Update welcome_screen_url for 3.2

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -1990,7 +1990,7 @@ $settings['welcome_screen']->fromArray([
 $settings['welcome_screen_url'] = $xpdo->newObject(modSystemSetting::class);
 $settings['welcome_screen_url']->fromArray([
   'key' => 'welcome_screen_url',
-  'value' => '//misc.modx.com/revolution/welcome.31.html',
+  'value' => '//misc.modx.com/revolution/welcome.32.html',
   'xtype' => 'textfield',
   'namespace' => 'core',
   'area' => 'manager',


### PR DESCRIPTION
### What does it do?
Updates the welcome_screen_url to point at content for the 3.2 release.

### Why is it needed?
This task was missed for 3.2.0 release.

### How to test
Install new and ensure the welcome screen that shows up on first login is for the 3.2 minor releases.

### Related issue(s)/PR(s)
n/a