### PR TITLE
Add OnManagerSearch event to allow extending quick search

### DIFF
--- a/_build/data/transport.core.events.php
+++ b/_build/data/transport.core.events.php
@@ -1197,6 +1197,14 @@ $events['OnMediaSourceDuplicate']->fromArray([
     'groupname' => 'Media Sources',
 ], '', true, true);
 
+/* Search */
+$events['OnManagerSearch']= $xpdo->newObject(modEvent::class);
+$events['OnManagerSearch']->fromArray([
+    'name' => 'OnManagerSearch',
+    'service' => 2,
+    'groupname' => 'System',
+], '', true, true);
+
 /* Package Manager */
 $events['OnPackageInstall']= $xpdo->newObject(modEvent::class);
 $events['OnPackageInstall']->fromArray([

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -243,7 +243,7 @@ class Search extends Processor
      * Searches using a provider configuration from the OnManagerSearch event.
      *
      * Required config keys: class, type, nameField, action.
-     * Optional: descriptionField, contentField, label, icon, permission, joins, searchFields.
+     * Optional: descriptionField, contentField, label, icon, permission, idField, joins, searchFields.
      *
      * @param array $config Provider configuration
      */
@@ -263,13 +263,23 @@ class Search extends Processor
         }
 
         $class = $config['class'];
+
+        if (!$this->modx->getTableName($class)) {
+            return;
+        }
+
         $nameField = $config['nameField'];
         $descriptionField = $config['descriptionField'] ?? '';
         $contentField = $config['contentField'] ?? '';
+        $idField = $config['idField'] ?? 'id';
 
         $c = $this->modx->newQuery($class);
 
         if (!empty($config['joins']) && is_array($config['joins'])) {
+            $pos = strrpos($class, '\\');
+            $classAlias = $pos !== false ? substr($class, $pos + 1) : $class;
+            $c->select($this->modx->getSelectColumns($class, $classAlias));
+
             foreach ($config['joins'] as $join) {
                 if (empty($join['class']) || empty($join['alias']) || empty($join['on'])) {
                     continue;
@@ -294,13 +304,16 @@ class Search extends Processor
         }
         if (!empty($config['searchFields']) && is_array($config['searchFields'])) {
             foreach ($config['searchFields'] as $field) {
-                $querySearch['OR:' . $field . ':LIKE'] = '%' . $this->query . '%';
+                if (is_string($field) && $field !== '') {
+                    $querySearch['OR:' . $field . ':LIKE'] = '%' . $this->query . '%';
+                }
             }
         }
-        $querySearch['OR:id:='] = $this->query;
+        $querySearch['OR:' . $idField . ':='] = $this->query;
         $c->where($querySearch);
 
-        $c->sortby('IF(`' . $nameField . '` = ' . $this->modx->quote($this->query) . ', 0, 1)');
+        $sortField = str_contains($nameField, '.') ? $nameField : '`' . $nameField . '`';
+        $c->sortby('IF(' . $sortField . ' = ' . $this->modx->quote($this->query) . ', 0, 1)');
 
         $c->limit($this->getMaxResults());
 
@@ -309,7 +322,7 @@ class Search extends Processor
             $result = [
                 'name' => $record->get($nameField),
                 'description' => !empty($descriptionField) ? $record->get($descriptionField) : '',
-                '_action' => $config['action'] . $record->get('id'),
+                '_action' => $config['action'] . $record->get($idField),
                 'type' => $config['type'],
             ];
             if (!empty($config['label'])) {

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -11,6 +11,7 @@
 namespace MODX\Revolution\Processors\Search;
 
 
+use ArrayObject;
 use MODX\Revolution\modChunk;
 use MODX\Revolution\modContext;
 use MODX\Revolution\modElement;
@@ -93,6 +94,19 @@ class Search extends Processor
             }
             if ($this->modx->hasPermission('edit_user')) {
                 $this->searchUsers();
+            }
+
+            $providers = new ArrayObject();
+            $this->modx->invokeEvent('OnManagerSearch', [
+                'query' => $this->query,
+                'providers' => $providers,
+                'maxResults' => $this->getMaxResults(),
+                'searchInContent' => $this->searchInContent(),
+            ]);
+            foreach ($providers as $provider) {
+                if (is_array($provider)) {
+                    $this->searchProvider($provider);
+                }
             }
         }
 
@@ -222,6 +236,89 @@ class Search extends Processor
                 '_action' => 'security/user/update&id=' . $record->get('internalKey'),
                 'type' => static::TYPE_USER . 's',
             ];
+        }
+    }
+
+    /**
+     * Searches using a provider configuration from the OnManagerSearch event.
+     *
+     * Required config keys: class, type, nameField, action.
+     * Optional: descriptionField, contentField, label, icon, permission, joins, searchFields.
+     *
+     * @param array $config Provider configuration
+     */
+    protected function searchProvider(array $config)
+    {
+        if (
+            empty($config['class'])
+            || empty($config['type'])
+            || empty($config['nameField'])
+            || empty($config['action'])
+        ) {
+            return;
+        }
+
+        if (!empty($config['permission']) && !$this->modx->hasPermission($config['permission'])) {
+            return;
+        }
+
+        $class = $config['class'];
+        $nameField = $config['nameField'];
+        $descriptionField = $config['descriptionField'] ?? '';
+        $contentField = $config['contentField'] ?? '';
+
+        $c = $this->modx->newQuery($class);
+
+        if (!empty($config['joins']) && is_array($config['joins'])) {
+            foreach ($config['joins'] as $join) {
+                if (empty($join['class']) || empty($join['alias']) || empty($join['on'])) {
+                    continue;
+                }
+                $joinType = strtolower($join['type'] ?? 'left');
+                match ($joinType) {
+                    'inner' => $c->innerJoin($join['class'], $join['alias'], $join['on']),
+                    'right' => $c->rightJoin($join['class'], $join['alias'], $join['on']),
+                    default => $c->leftJoin($join['class'], $join['alias'], $join['on']),
+                };
+            }
+        }
+
+        $querySearch = [
+            $nameField . ':LIKE' => '%' . $this->query . '%',
+        ];
+        if (!empty($descriptionField)) {
+            $querySearch['OR:' . $descriptionField . ':LIKE'] = '%' . $this->query . '%';
+        }
+        if ($this->searchInContent() && !empty($contentField)) {
+            $querySearch['OR:' . $contentField . ':LIKE'] = '%' . $this->query . '%';
+        }
+        if (!empty($config['searchFields']) && is_array($config['searchFields'])) {
+            foreach ($config['searchFields'] as $field) {
+                $querySearch['OR:' . $field . ':LIKE'] = '%' . $this->query . '%';
+            }
+        }
+        $querySearch['OR:id:='] = $this->query;
+        $c->where($querySearch);
+
+        $c->sortby('IF(`' . $nameField . '` = ' . $this->modx->quote($this->query) . ', 0, 1)');
+
+        $c->limit($this->getMaxResults());
+
+        $collection = $this->modx->getIterator($class, $c);
+        foreach ($collection as $record) {
+            $result = [
+                'name' => $record->get($nameField),
+                'description' => !empty($descriptionField) ? $record->get($descriptionField) : '',
+                '_action' => $config['action'] . $record->get('id'),
+                'type' => $config['type'],
+            ];
+            if (!empty($config['label'])) {
+                $result['label'] = $config['label'];
+            }
+            if (!empty($config['icon'])) {
+                $result['icon'] = $config['icon'];
+            }
+            $this->results[] = $result;
         }
     }
 }

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -291,6 +291,12 @@ class Search extends Processor
                     default => $c->leftJoin($join['class'], $join['alias'], $join['on']),
                 };
             }
+
+            foreach ([$nameField, $descriptionField, $contentField, $idField] as $field) {
+                if ($field !== '' && str_contains($field, '.')) {
+                    $c->select($field);
+                }
+            }
         }
 
         $querySearch = [
@@ -317,12 +323,17 @@ class Search extends Processor
 
         $c->limit($this->getMaxResults());
 
+        $nameFieldKey = str_contains($nameField, '.') ? substr($nameField, strrpos($nameField, '.') + 1) : $nameField;
+        $descFieldKey = ($descriptionField !== '' && str_contains($descriptionField, '.'))
+            ? substr($descriptionField, strrpos($descriptionField, '.') + 1) : $descriptionField;
+        $idFieldKey = str_contains($idField, '.') ? substr($idField, strrpos($idField, '.') + 1) : $idField;
+
         $collection = $this->modx->getIterator($class, $c);
         foreach ($collection as $record) {
             $result = [
-                'name' => $record->get($nameField),
-                'description' => !empty($descriptionField) ? $record->get($descriptionField) : '',
-                '_action' => $config['action'] . $record->get($idField),
+                'name' => $record->get($nameFieldKey),
+                'description' => !empty($descFieldKey) ? $record->get($descFieldKey) : '',
+                '_action' => $config['action'] . $record->get($idFieldKey),
                 'type' => $config['type'],
             ];
             if (!empty($config['label'])) {

--- a/setup/includes/upgrades/common/3.2.1-add-on-manager-search-event.php
+++ b/setup/includes/upgrades/common/3.2.1-add-on-manager-search-event.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Add OnManagerSearch system event
+ *
+ * @var modX $modx
+ * @var modInstallRunner $this
+ * @package setup
+ * @subpackage upgrades
+ */
+
+use MODX\Revolution\modEvent;
+
+$messageTemplate = '<p class="%s">%s</p>';
+
+$event = $modx->getObject(modEvent::class, ['name' => 'OnManagerSearch']);
+if (!$event) {
+    $event = $modx->newObject(modEvent::class);
+    $event->fromArray([
+        'name' => 'OnManagerSearch',
+        'service' => 2,
+        'groupname' => 'System',
+    ]);
+    if ($event->save()) {
+        $this->runner->addResult(
+            modInstallRunner::RESULT_SUCCESS,
+            sprintf($messageTemplate, 'ok', 'Added OnManagerSearch system event.')
+        );
+    } else {
+        $this->runner->addResult(
+            modInstallRunner::RESULT_ERROR,
+            sprintf($messageTemplate, 'error', 'Failed to add OnManagerSearch system event.')
+        );
+    }
+}

--- a/setup/includes/upgrades/mysql/3.2.1-pl.php
+++ b/setup/includes/upgrades/mysql/3.2.1-pl.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Specific upgrades for Revolution 3.2.1-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(__DIR__) . '/common/3.2.1-add-on-manager-search-event.php';


### PR DESCRIPTION
## Summary

Closes #16912

Adds the `OnManagerSearch` system event that fires during manager quick search (uberbar) processing. Plugins can register custom search providers through declarative configuration arrays — the processor builds and executes xPDO queries from these configs.

**Key changes:**
- New `OnManagerSearch` event (service=2, group=System) fired in `Search/Search` processor after built-in searches
- New `searchProvider()` method handles provider configs: builds xPDO queries with optional joins, custom search fields, permission checks, and custom icons/labels
- `ArrayObject` is used for the `$providers` parameter so that object identity is preserved through `array_merge`/`extract` in the event dispatch chain — all plugins share the same instance
- Upgrade script for existing installations
- No JS changes needed — the frontend already checks for `label` and `icon` fields before falling back to built-in mappings

**Plugin usage example:**

```php
// Plugin on OnManagerSearch event
// $query, $providers, $maxResults, $searchInContent are available via extract()

$providers[] = [
    'class'            => 'MyExtra\Model\Product',
    'type'             => 'products',
    'label'            => 'Products',
    'icon'             => 'shopping-cart',
    'permission'       => 'myextra_view',
    'nameField'        => 'name',
    'descriptionField' => 'sku',
    'contentField'     => 'description',
    'idField'          => 'id',
    'action'           => 'myextra/product/update&id=',
    'joins'            => [
        [
            'class' => 'MyExtra\Model\Category',
            'alias' => 'Category',
            'on'    => 'Product.category_id = Category.id',
            'type'  => 'left',
        ],
    ],
    'searchFields' => ['Category.name'],
];
```

**Provider config keys:**
| Key | Required | Description |
|---|---|---|
| `class` | yes | xPDO model class (validated via `getTableName`) |
| `type` | yes | Result group identifier |
| `nameField` | yes | Primary search/display field |
| `action` | yes | URL pattern (record ID is appended) |
| `descriptionField` | no | Secondary search/display field |
| `contentField` | no | Content field (respects `quick_search_in_content`) |
| `label` | no | Display label for group header |
| `icon` | no | FontAwesome icon name |
| `permission` | no | Permission to check before searching |
| `idField` | no | Primary key field name (default: `id`) |
| `joins` | no | Array of xPDO join configs (`class`, `alias`, `on`, `type`) |
| `searchFields` | no | Additional fields to search (e.g. from joins) |

## Test plan

- [ ] Verify built-in search (resources, elements, users) still works as before
- [ ] Create a test plugin on `OnManagerSearch` that registers a provider for an existing model (e.g. `modCategory`) and verify results appear in the search bar
- [ ] Verify `permission` check prevents results when user lacks the specified permission
- [ ] Verify `label` and `icon` display correctly in the search dropdown
- [ ] Verify `joins` and `searchFields` allow searching related model fields
- [ ] Verify malformed provider configs (missing required keys) are silently skipped
- [ ] Verify invalid xPDO class in provider config doesn't break the search
- [ ] Run upgrade on an existing 3.2.0 installation and verify the `OnManagerSearch` event is created