### PR TITLE
fix(core): lexicons and cache after install/upgrade

### DIFF
--- a/core/src/Revolution/Processors/Workspace/Lexicon/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/GetList.php
@@ -117,7 +117,7 @@ class GetList extends Processor
          */
         if ($this->getProperty('namespace') === 'core' && empty($entries)) {
             $this->modx->lexicon->clearCache();
-            $this->modx->log(xPDO::LOG_LEVEL_DEBUG, 'Lexicon GetList: core topic empty, cleared cache and retried (#15465)');
+            $this->modx->log(xPDO::LOG_LEVEL_DEBUG, 'Lexicon GetList: core topic empty, cleared cache and retried');
             $entries = $this->modx->lexicon->getFileTopic(
                 $this->getProperty('language'),
                 $this->getProperty('namespace'),

--- a/core/src/Revolution/Processors/Workspace/Lexicon/GetList.php
+++ b/core/src/Revolution/Processors/Workspace/Lexicon/GetList.php
@@ -14,6 +14,7 @@ namespace MODX\Revolution\Processors\Workspace\Lexicon;
 use MODX\Revolution\Formatter\modManagerDateFormatter;
 use MODX\Revolution\modLexiconEntry;
 use MODX\Revolution\Processors\Processor;
+use xPDO\xPDO;
 
 /**
  * Gets a list of lexicon entries
@@ -110,23 +111,24 @@ class GetList extends Processor
         );
         $entries = is_array($entries) ? $entries : [];
 
+        /*
+         * Core namespace and empty: clear lexicon cache so loadCache() elsewhere gets fresh data,
+         * then retry getFileTopic once in case result depended on cache/path state (#15465).
+         */
+        if ($this->getProperty('namespace') === 'core' && empty($entries)) {
+            $this->modx->lexicon->clearCache();
+            $this->modx->log(xPDO::LOG_LEVEL_DEBUG, 'Lexicon GetList: core topic empty, cleared cache and retried (#15465)');
+            $entries = $this->modx->lexicon->getFileTopic(
+                $this->getProperty('language'),
+                $this->getProperty('namespace'),
+                $this->getProperty('topic')
+            );
+            $entries = is_array($entries) ? $entries : [];
+        }
+
         /* if searching */
         if (!empty($query)) {
-            function parseArray($needle, array $haystack = [])
-            {
-                if (!is_array($haystack)) {
-                    return false;
-                }
-                $results = [];
-                foreach ($haystack as $key => $value) {
-                    if (strpos($key, $needle) !== false || strpos($value, $needle) !== false) {
-                        $results[$key] = $value;
-                    }
-                }
-                return $results;
-            }
-
-            $entries = parseArray($query, $entries);
+            $entries = $this->filterEntriesByQuery($query, $entries);
         }
 
         /* add in unique entries */
@@ -171,5 +173,25 @@ class GetList extends Processor
         }
 
         return $this->outputArray($list, $count);
+    }
+
+    /**
+     * Filter lexicon entries by search query (key or value contains needle).
+     *
+     * @param string $query Search string.
+     * @param array $entries Name => value entries.
+     * @return array Filtered entries.
+     */
+    private function filterEntriesByQuery(string $query, array $entries): array
+    {
+        $results = [];
+        foreach ($entries as $key => $value) {
+            $keyMatch = strpos((string) $key, $query) !== false;
+            $valueMatch = is_string($value) && strpos($value, $query) !== false;
+            if ($keyMatch || $valueMatch) {
+                $results[$key] = $value;
+            }
+        }
+        return $results;
     }
 }

--- a/manager/templates/default/browser/index.tpl
+++ b/manager/templates/default/browser/index.tpl
@@ -5,19 +5,19 @@
 <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
 
 
-<link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
-<link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/index{if $_config.compress_css}-min{/if}.css" />
+<link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css?v={$versionToken}" />
+<link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/index{if $_config.compress_css}-min{/if}.css?v={$versionToken}" />
 
 {if isset($_config.ext_debug) && $_config.ext_debug}
-<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js"></script>
-<script src="{$_config.manager_url}assets/ext3/ext-all-debug.js"></script>
+<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js?v={$versionToken}"></script>
+<script src="{$_config.manager_url}assets/ext3/ext-all-debug.js?v={$versionToken}"></script>
 {else}
-<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js"></script>
-<script src="{$_config.manager_url}assets/ext3/ext-all.js"></script>
+<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js?v={$versionToken}"></script>
+<script src="{$_config.manager_url}assets/ext3/ext-all.js?v={$versionToken}"></script>
 {/if}
-<script src="{$_config.manager_url}assets/modext/core/modx.js"></script>
-<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=category,file,resource&action={$smarty.get.a|strip_tags|default:''}"></script>
-<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|strip_tags|default:''}{if $_ctx}&wctx={$_ctx}{/if}&HTTP_MODAUTH={$site_id|default|htmlspecialchars}"></script>
+<script src="{$_config.manager_url}assets/modext/core/modx.js?v={$versionToken}"></script>
+<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=category,file,resource&action={$smarty.get.a|strip_tags|default:''}&v={$versionToken}"></script>
+<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|strip_tags|default:''}{if $_ctx}&wctx={$_ctx}{/if}&HTTP_MODAUTH={$site_id|default|htmlspecialchars}&v={$versionToken}"></script>
 
 {$maincssjs}
 

--- a/manager/templates/default/header.tpl
+++ b/manager/templates/default/header.tpl
@@ -8,20 +8,20 @@
 
 {if $_config.manager_favicon_url}<link rel="shortcut icon" href="{$_config.manager_favicon_url}" />{/if}
 
-<link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css" />
+<link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all-notheme-min.css?v={$versionToken}" />
 <link rel="stylesheet" type="text/css" href="{$indexCss}?v={$versionToken}" />
 
 {if isset($_config.ext_debug) && $_config.ext_debug}
-<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js"></script>
-<script src="{$_config.manager_url}assets/ext3/ext-all-debug.js"></script>
+<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js?v={$versionToken}"></script>
+<script src="{$_config.manager_url}assets/ext3/ext-all-debug.js?v={$versionToken}"></script>
 {else}
-<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js"></script>
-<script src="{$_config.manager_url}assets/ext3/ext-all.js"></script>
+<script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js?v={$versionToken}"></script>
+<script src="{$_config.manager_url}assets/ext3/ext-all.js?v={$versionToken}"></script>
 {/if}
 <script src="{$_config.manager_url}assets/modext/core/modx.js?mv={$versionToken}"></script>
-<script src="{$_config.manager_url}assets/lib/popper.min.js"></script>
-<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,{$_lang_topics}&action={$smarty.get.a|default|htmlspecialchars}"></script>
-<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}&HTTP_MODAUTH={$_authToken|default|htmlspecialchars}"></script>
+<script src="{$_config.manager_url}assets/lib/popper.min.js?v={$versionToken}"></script>
+<script src="{$_config.connectors_url}lang.js.php?ctx=mgr&topic=topmenu,file,resource,{$_lang_topics}&action={$smarty.get.a|default|htmlspecialchars}&v={$versionToken}"></script>
+<script src="{$_config.connectors_url}modx.config.js.php?action={$smarty.get.a|default|htmlspecialchars}{if $_ctx}&wctx={$_ctx}{/if}&HTTP_MODAUTH={$_authToken|default|htmlspecialchars}&v={$versionToken}"></script>
 
 <script>
     const tvPanelOverrides = [];

--- a/manager/templates/default/security/login.tpl
+++ b/manager/templates/default/security/login.tpl
@@ -12,7 +12,7 @@
             <link rel="apple-touch-icon" href="{$_config.manager_favicon_url}">
         {/if}
 
-        <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/login{if $_config.compress_css}-min{/if}.css">
+        <link rel="stylesheet" type="text/css" href="{$_config.manager_url}templates/default/css/login{if $_config.compress_css}-min{/if}.css?v={$versionToken}">
     </head>
     <body id="login">
         {$onManagerLoginFormPrerender}
@@ -192,6 +192,6 @@
         </div>
         <div class="l-background" style="background-image:url({$background})"></div>
 
-        <script src="{$_config.manager_url}assets/modext/sections/login.js"></script>
+        <script src="{$_config.manager_url}assets/modext/sections/login.js?v={$versionToken}"></script>
     </body>
 </html>

--- a/manager/templates/default/security/logout.tpl
+++ b/manager/templates/default/security/logout.tpl
@@ -3,29 +3,29 @@
 <head>
     <title>MODx :: {$_lang.permission_denied}</title>
     <meta http-equiv="Content-Type" content="text/html; charset={$_config.modx_charset}" />
-    <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all.css" />
-    <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/xtheme-gray-extend.css" />
-    <link rel="stylesheet" type="text/css" href="{$indexCss}" />
-    <link rel="stylesheet" type="text/css" href="{$loginCss}" />
+    <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/ext-all.css?v={$versionToken}" />
+    <link rel="stylesheet" type="text/css" href="{$_config.manager_url}assets/ext3/resources/css/xtheme-gray-extend.css?v={$versionToken}" />
+    <link rel="stylesheet" type="text/css" href="{$indexCss}?v={$versionToken}" />
+    <link rel="stylesheet" type="text/css" href="{$loginCss}?v={$versionToken}" />
 
 
     {if isset($_config.ext_debug) && $_config.ext_debug}
-    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js"></script>
-    <script src="{$_config.manager_url}assets/ext3/ext-all-debug.js"></script>
+    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base-debug.js?v={$versionToken}"></script>
+    <script src="{$_config.manager_url}assets/ext3/ext-all-debug.js?v={$versionToken}"></script>
     {else}
-    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js"></script>
-    <script src="{$_config.manager_url}assets/ext3/ext-all.js"></script>
+    <script src="{$_config.manager_url}assets/ext3/adapter/ext/ext-base.js?v={$versionToken}"></script>
+    <script src="{$_config.manager_url}assets/ext3/ext-all.js?v={$versionToken}"></script>
     {/if}
-    <script src="{$_config.manager_url}assets/modext/core/modx.js"></script>
-    <script src="{$_config.connectors_url}lang.js.php?topic=login"></script>
-    <script src="{$_config.manager_url}assets/modext/core/modx.form.handler.js"></script>
-    <script src="{$_config.manager_url}assets/modext/core/modx.component.js"></script>
-    <script src="{$_config.manager_url}assets/modext/util/utilities.js"></script>
-    <script src="{$_config.manager_url}assets/modext/util/spotlight.js"></script>
-    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.panel.js"></script>
-    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.msg.js"></script>
-    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.window.js"></script>
-    <script src="{$_config.manager_url}assets/modext/sections/login.js"></script>
+    <script src="{$_config.manager_url}assets/modext/core/modx.js?v={$versionToken}"></script>
+    <script src="{$_config.connectors_url}lang.js.php?topic=login&v={$versionToken}"></script>
+    <script src="{$_config.manager_url}assets/modext/core/modx.form.handler.js?v={$versionToken}"></script>
+    <script src="{$_config.manager_url}assets/modext/core/modx.component.js?v={$versionToken}"></script>
+    <script src="{$_config.manager_url}assets/modext/util/utilities.js?v={$versionToken}"></script>
+    <script src="{$_config.manager_url}assets/modext/util/spotlight.js?v={$versionToken}"></script>
+    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.panel.js?v={$versionToken}"></script>
+    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.msg.js?v={$versionToken}"></script>
+    <script src="{$_config.manager_url}assets/modext/widgets/core/modx.window.js?v={$versionToken}"></script>
+    <script src="{$_config.manager_url}assets/modext/sections/login.js?v={$versionToken}"></script>
 
     <meta name="robots" content="noindex, nofollow" />
     {literal}<style>body, html { background: #fafafa !important; }</style>{/literal}

--- a/setup/includes/runner/modinstallrunnerweb.class.php
+++ b/setup/includes/runner/modinstallrunnerweb.class.php
@@ -104,6 +104,11 @@ class modInstallRunnerWeb extends modInstallRunner {
             ],
         ]);
 
+        /* refresh all cache partitions (e.g. lexicon_topics) so first manager load has correct data (#14952, #15465) */
+        if ($this->install->xpdo->cacheManager) {
+            $this->install->xpdo->cacheManager->refresh();
+        }
+
         $this->install->lock();
 
         $this->install->settings->store([

--- a/setup/includes/upgrade.install.php
+++ b/setup/includes/upgrade.install.php
@@ -386,4 +386,9 @@ if (!$setting && ('sdk' === trim($currentVersion['distro'], '@') || 'git' === tr
     $setting->save();
 }
 
+/* clear all cache partitions (including lexicon_topics) after upgrade so manager shows correct data (#14952) */
+if ($modx->getCacheManager()) {
+    $modx->cacheManager->refresh();
+}
+
 return true;


### PR DESCRIPTION
### What changed and why

After install or upgrade, stale lexicon and manager asset cache left the admin panel broken or showing keys without values until manual cache clear (#14952, #15465).

This PR:
- Clears all cache partitions via `cacheManager->refresh()` after upgrade/install paths.
- Retries lexicon load in `Workspace/Lexicon/GetList` when core topic is empty; refactors query filter into `filterEntriesByQuery()`.
- Adds `?v={$versionToken}` to static manager assets so browsers fetch new CSS/JS after upgrade.

### How to test

1. Upgrade 2.7.x → 3.x: manager loads without manual `core/cache` delete; lexicons show values.
2. Fresh git install: Lexicon management shows keys and values on first open.
3. After upgrade, asset URLs include new `v=` and load updated Ext/CSS.

### Related issue(s)/PR(s)

Resolves #14952

Resolves #15465

### Compatibility notes

Setup/upgrade and manager. `versionToken` derives from `settings_version` and site uuid.

### Breaking change assessment

No public API changes. Cache refresh on install/upgrade may briefly increase first-load work. Patch-safe.

### Test coverage

No new PHPUnit; manual install/upgrade paths above.

### Contributors

Issue reporters on #14952 and #15465.

### AI tool use

Cursor helped normalize this PR description to the repository template.
