### PR TITLE
fix(setup): improve PHP version error message and require mbstring extension

### DIFF
--- a/setup/provisioner/bootstrap.php
+++ b/setup/provisioner/bootstrap.php
@@ -37,9 +37,9 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'requirements.php';
 $phpVersionSatisfiesRequirement = version_compare(PHP_VERSION, MODX_MINIMUM_REQUIRED_PHP_VERSION, '>=');
 if (!$phpVersionSatisfiesRequirement) {
     $unsatisfiedRequirementsErrors[] = [
-        'title' => 'Wrong PHP Version!',
+        'title' => 'PHP version is not supported',
         'description' => sprintf(
-            'You\'re using PHP version %s, and MODX requires version %s or higher.',
+            'Your PHP version (%s) is no longer supported. Please upgrade to PHP %s or higher to install MODX.',
             PHP_VERSION,
             MODX_MINIMUM_REQUIRED_PHP_VERSION
         ),

--- a/setup/provisioner/requirements.php
+++ b/setup/provisioner/requirements.php
@@ -16,6 +16,7 @@ define('MODX_REQUIRED_EXTENSIONS', [
     "fileinfo",
     "gd",
     "json",
+    "mbstring",
     "pdo",
     "simplexml",
     "xml",


### PR DESCRIPTION
### What does it do?
- **bootstrap.php**: Updates the PHP version requirement error message: title to "PHP version is not supported", description to "Your PHP version (%s) is no longer supported. Please upgrade to PHP %s or higher to install MODX."
- **requirements.php**: Adds `mbstring` to `MODX_REQUIRED_EXTENSIONS` so the installer checks for the extension before proceeding.

### Why is it needed?
- Clearer, more neutral wording when the user's PHP version is below the minimum.
- MODX relies on multibyte string handling; requiring `mbstring` at setup prevents runtime errors on systems where it is missing.

### How to test
1. Run the installer with PHP &lt; 7.4 (or the configured minimum): the new PHP version message should appear.
2. Disable the `mbstring` extension (or use a PHP build without it) and run the installer: the requirements screen should list "MODX requires the PHP mbstring extension".

### Related issue(s)/PR(s)
None.