### PR TITLE
fix(setup): improve PHP version error message in bootstrap

### DIFF
--- a/setup/provisioner/bootstrap.php
+++ b/setup/provisioner/bootstrap.php
@@ -37,9 +37,9 @@ require_once __DIR__ . DIRECTORY_SEPARATOR . 'requirements.php';
 $phpVersionSatisfiesRequirement = version_compare(PHP_VERSION, MODX_MINIMUM_REQUIRED_PHP_VERSION, '>=');
 if (!$phpVersionSatisfiesRequirement) {
     $unsatisfiedRequirementsErrors[] = [
-        'title' => 'Wrong PHP Version!',
+        'title' => 'PHP version is not supported',
         'description' => sprintf(
-            'You\'re using PHP version %s, and MODX requires version %s or higher.',
+            'Your PHP version (%s) is no longer supported. Please upgrade to PHP %s or higher to install MODX.',
             PHP_VERSION,
             MODX_MINIMUM_REQUIRED_PHP_VERSION
         ),


### PR DESCRIPTION
### What does it do?
Updates the PHP version requirement error in the setup bootstrap: the title is changed to "PHP version is not supported" and the description to "Your PHP version (%s) is no longer supported. Please upgrade to PHP %s or higher to install MODX."

### Why is it needed?
Clearer, more neutral wording when the user's PHP version is below the minimum. Avoids a harsh "Wrong PHP Version!" message and gives a direct upgrade instruction. Addresses the UX concern from issue #14990 (showing a warning instead of a fatal error when possible).

### How to test
1. Run the MODX installer with PHP &lt; 7.4 (or the configured minimum).
2. Confirm the requirements screen shows the new title and description instead of "Wrong PHP Version!".

### Related issue(s)/PR(s)
Resolves #14990 (message part).  
Split from #16921 per review (separate concern from PHP extension requirements).
