### PR TITLE
fix(setup): require mbstring extension in installer

### DIFF
--- a/setup/provisioner/requirements.php
+++ b/setup/provisioner/requirements.php
@@ -16,6 +16,7 @@ define('MODX_REQUIRED_EXTENSIONS', [
     "fileinfo",
     "gd",
     "json",
+    "mbstring",
     "pdo",
     "simplexml",
     "xml",


### PR DESCRIPTION
### What does it do?
Adds `mbstring` to `MODX_REQUIRED_EXTENSIONS` in the setup provisioner so the installer checks for the extension before proceeding. If mbstring is missing, the requirements screen lists it and blocks installation.

### Why is it needed?
MODX and Smarty use multibyte string functions (e.g. `mb_split()`). Without the mbstring extension, the setup fails with a fatal error (e.g. "Call to undefined function mb_split()") instead of a clear requirement message. Checking at installer time prevents this and matches the expected behaviour described in #14990.

### How to test
1. Disable the `mbstring` extension (or use a PHP build without it).
2. Run the MODX installer.
3. Confirm the requirements screen lists "MODX requires the PHP mbstring extension" and setup does not proceed until it is enabled.

### Related issue(s)/PR(s)
Resolves #14990.  
Split from #16921 per review (extension requirements as a separate change for discussion).
