### PR TITLE
fix(dashboard): update widget only stable releases, opt-in prereleases, To Download button

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -2194,5 +2194,14 @@ $settings['static_elements_html_extension']->fromArray([
     'area' => 'static_elements',
     'editedon' => null,
 ], '', true, true);
+$settings['updates_show_prereleases'] = $xpdo->newObject(modSystemSetting::class);
+$settings['updates_show_prereleases']->fromArray([
+    'key' => 'updates_show_prereleases',
+    'value' => false,
+    'xtype' => 'combo-boolean',
+    'namespace' => 'core',
+    'area' => 'system',
+    'editedon' => null,
+], '', true, true);
 
 return $settings;

--- a/core/lexicon/en/dashboard.inc.php
+++ b/core/lexicon/en/dashboard.inc.php
@@ -31,6 +31,7 @@ $_lang['updates_available'] = 'Updates available';
 $_lang['updates_update'] = 'Update';
 $_lang['updates_ok'] = 'Up to date';
 $_lang['updates_extras'] = 'Extras';
+$_lang['updates_to_download'] = 'To Download';
 
 $_lang['quicklinks'] = 'Quicklinks';
 $_lang['security_notices'] = 'Security Notices';

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -112,6 +112,9 @@ $_lang['setting_auto_check_pkg_updates_desc'] = 'If \'Yes\', MODX will automatic
 $_lang['setting_auto_check_pkg_updates_cache_expire'] = 'Cache Expiration Time for Automatic Package Updates Check';
 $_lang['setting_auto_check_pkg_updates_cache_expire_desc'] = 'The number of minutes that Package Management will cache the results for checking for package updates.';
 
+$_lang['setting_updates_show_prereleases'] = 'Show Unstable Core Updates in Dashboard';
+$_lang['setting_updates_show_prereleases_desc'] = 'If \'Yes\', the Updates dashboard widget will include prerelease and unstable MODX core versions. By default only stable releases are shown.';
+
 $_lang['setting_allow_multiple_emails'] = 'Allow Duplicate Emails for Users';
 $_lang['setting_allow_multiple_emails_desc'] = 'If enabled, Users may share the same email address.';
 

--- a/core/src/Revolution/Processors/SoftwareUpdate/GetList.php
+++ b/core/src/Revolution/Processors/SoftwareUpdate/GetList.php
@@ -18,7 +18,9 @@ use Psr\Http\Client\ClientExceptionInterface;
 use MODX\Revolution\modX;
 
 /**
- * Retrieves status data for use in the front end display of software updates (MODX and Extras)
+ * Retrieves status data for use in the front end display of software updates (MODX and Extras).
+ * MODX core upgrade list respects system setting updates_show_prereleases (default off) for
+ * including prerelease versions.
  *
  * @property string $softwareType Identifies which type of software status data should be
  * retrieved (currently only two options: 'modx' or 'extras')

--- a/core/src/Revolution/Processors/SoftwareUpdate/GetList.php
+++ b/core/src/Revolution/Processors/SoftwareUpdate/GetList.php
@@ -55,7 +55,8 @@ class GetList extends Base
     }
 
     /**
-     * Fetches a list of MODX update candidates
+     * Fetches a list of MODX update candidates (released versions only by default).
+     * When updates_show_prereleases is enabled, prerelease/unstable versions are included.
      *
      * @return array Data indicating whether the current installation is
      * updatable and the available releases if so
@@ -64,11 +65,13 @@ class GetList extends Base
     {
         $this->initApiClient();
 
+        $prereleases = (int) $this->modx->getOption('updates_show_prereleases', null, false);
+
         $uri = $this->buildRequestUri([
             'current' => $this->installedVersionData['full_version'],
             'level' => 'major',
             'variant' => 'Traditional',
-            'prereleases' => 0
+            'prereleases' => $prereleases
         ]);
 
         $request = $this->apiFactory->createRequest('GET', $uri)

--- a/manager/controllers/default/dashboard/widget.updates.php
+++ b/manager/controllers/default/dashboard/widget.updates.php
@@ -20,7 +20,8 @@ class modDashboardWidgetUpdates extends modDashboardWidgetInterface
      */
     public function render()
     {
-        $updateCacheKey = 'mgr/providers/updates/modx-core';
+        $prereleases = $this->modx->getOption('updates_show_prereleases', null, false);
+        $updateCacheKey = 'mgr/providers/updates/modx-core' . ($prereleases ? '-prereleases' : '');
         $updateCacheOptions = [
             xPDO::OPT_CACHE_KEY => $this->modx->cacheManager->getOption(
                 'cache_packages_key',

--- a/manager/controllers/default/dashboard/widget.updates.php
+++ b/manager/controllers/default/dashboard/widget.updates.php
@@ -20,7 +20,7 @@ class modDashboardWidgetUpdates extends modDashboardWidgetInterface
      */
     public function render()
     {
-        $prereleases = $this->modx->getOption('updates_show_prereleases', null, false);
+        $prereleases = (bool) $this->modx->getOption('updates_show_prereleases', null, false);
         $updateCacheKey = 'mgr/providers/updates/modx-core' . ($prereleases ? '-prereleases' : '');
         $updateCacheOptions = [
             xPDO::OPT_CACHE_KEY => $this->modx->cacheManager->getOption(

--- a/manager/templates/default/dashboard/updates.tpl
+++ b/manager/templates/default/dashboard/updates.tpl
@@ -20,12 +20,12 @@
                             class="dashboard-button modx"
                             target="_blank"
                         >
-                            {$_lang.download}
+                            {$_lang.updates_to_download}
                         </a>
                     </td>
                 {else}
                     <td><span class="updates-ok">{$_lang.updates_ok}</span></td>
-                    <td><button class="dashboard-button modx" disabled>{$_lang.download}</button></td>
+                    <td><button class="dashboard-button modx" disabled>{$_lang.updates_to_download}</button></td>
                 {/if}
             </tr>
             <tr>


### PR DESCRIPTION
### What does it do?
- Adds system setting `updates_show_prereleases` (default `false`) so the Updates dashboard widget can optionally include prerelease/unstable MODX core versions. When disabled, only stable releases are requested from the Sentinel API.
- Updates `SoftwareUpdate/GetList` to pass `prereleases` from the setting into the API request instead of a hardcoded `0`.
- Updates the dashboard widget cache key to include the prereleases flag (`modx-core` vs `modx-core-prereleases`) so changing the setting yields fresh data.
- Renames the core update action button from "Download" to "To Download" via new lexicon key `updates_to_download` in the dashboard (en only), since in-place update is not supported and the action leads to downloading the release.

### Why is it needed?
Addresses [issue #15483](https://github.com/modxcms/revolution/issues/15483): the widget was showing unreleased/unstable versions as available updates, and the button label was misleading. The fix keeps stable-only by default, adds an opt-in for prereleases, and clarifies the button as "To Download".

### How to test
1. Open Dashboard and ensure the Updates widget is visible.
2. With default settings, confirm only stable release(s) appear when an update is available; button label is "To Download".
3. In System Settings, enable "Show Unstable Core Updates in Dashboard" (`updates_show_prereleases`). Reload the dashboard and confirm the widget can show prerelease versions when the API returns them.
4. Disable the setting again and confirm the widget shows only stable again (cache key change should show correct data after reload).

### Related issue(s)/PR(s)
Resolves #15483
