### PR TITLE
fix(forms): Add templatename to Form Customization Set list (avoid N+1)

### DIFF
--- a/core/src/Revolution/Processors/Security/Forms/Set/GetList.php
+++ b/core/src/Revolution/Processors/Security/Forms/Set/GetList.php
@@ -93,6 +93,14 @@ class GetList extends GetListProcessor
     {
         $fcSetArray = $object->toArray();
 
+        // Use joined column from query when available to avoid N+1; fallback to relation if not hydrated
+        $templatename = $object->get('templatename');
+        if ($templatename === null || $templatename === '') {
+            $template = $object->getOne('Template');
+            $templatename = $template ? $template->get('templatename') : '';
+        }
+        $fcSetArray['templatename'] = (string) $templatename;
+
         $constraint_field = $object->get('constraint_field');
         $constraint = $object->get('constraint');
         if (!empty($constraint_field)) {


### PR DESCRIPTION
### What does it do?
In `Security/Forms/Set/GetList` processor, `prepareRow()` now populates `templatename` in the data returned for each Form Customization Set. The value is taken from the already-selected joined column `Template.templatename` when present on the object (no extra query); otherwise it falls back to `getOne('Template')`. The value is always cast to string for consistent JSON/API type.

### Why is it needed?
Template names were missing or incorrect in the Form Customization UI because the list processor did not include `templatename` in the row data. The query already joins `modTemplate` and selects `Template.templatename`; using it when available avoids N+1 queries.

### How to test
1. Open Manager → Form Customization.
2. Ensure the list of sets shows the correct template name for each set (column or tooltip).
3. Create/edit a set with a template assigned and confirm the name appears correctly in the list.

### Related issue(s)/PR(s)
Resolves #16300