### PR TITLE
fix(manager): persist manager language across logout/login

### DIFF
--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1585,12 +1585,12 @@ class modX extends xPDO {
         }
         $this->loadedjscripts[$src]= true;
         if (strpos(strtolower($src), "<style") !== false || strpos(strtolower($src), "<link") !== false) {
-            $this->sjscripts[count($this->sjscripts)]= $src;
+            $this->sjscripts[count($this->sjscripts)] = $src;
         } else {
             if (!empty($media)) {
                 $media = ' media="' . $media .'"';
             }
-            $this->sjscripts[count($this->sjscripts)]= '<link rel="stylesheet" href="' . $src . '" type="text/css"' . $media . ' />';
+            $this->sjscripts[count($this->sjscripts)] = '<link rel="stylesheet" href="' . $src . '" type="text/css"' . $media . ' />';
         }
     }
 
@@ -1609,11 +1609,11 @@ class modX extends xPDO {
                 return;
             $this->loadedjscripts[$src]= true;
             if ($plaintext == true) {
-                $this->sjscripts[count($this->sjscripts)]= $src;
+                $this->sjscripts[count($this->sjscripts)] = $src;
             } elseif (strpos(strtolower($src), "<script") !== false) {
-                $this->sjscripts[count($this->sjscripts)]= $src;
+                $this->sjscripts[count($this->sjscripts)] = $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)] = '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1632,11 +1632,11 @@ class modX extends xPDO {
             return;
         $this->loadedjscripts[$src]= true;
         if ($plaintext == true) {
-            $this->jscripts[count($this->jscripts)]= $src;
+            $this->jscripts[count($this->jscripts)] = $src;
         } elseif (strpos(strtolower($src), "<script") !== false) {
-            $this->jscripts[count($this->jscripts)]= $src;
+            $this->jscripts[count($this->jscripts)] = $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)] = '<script src="' . $src . '"></script>';
         }
     }
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2907,6 +2907,36 @@ class modX extends xPDO {
     }
 
     /**
+     * Persist manager language preference in a cookie so it survives logout (issue #16072).
+     * Uses session cookie path and SameSite for consistency with session cookies.
+     *
+     * @param string $language Valid language code from lexicon->getLanguageList() (e.g. 'en', 'de')
+     * @return void
+     */
+    public function setManagerLanguageCookie($language)
+    {
+        $cookiePath = $this->getOption('session_cookie_path', null, '');
+        if (empty($cookiePath)) {
+            $cookiePath = $this->getOption('base_url', null, MODX_BASE_URL);
+        }
+        if (empty($cookiePath)) {
+            $cookiePath = '/';
+        }
+        $cookieOptions = [
+            'expires' => time() + 31536000,
+            'path' => $cookiePath,
+            'domain' => '',
+            'secure' => (bool) $this->getOption('session_cookie_secure', null, false),
+            'httponly' => false,
+        ];
+        $samesite = $this->getOption('session_cookie_samesite', null, 'Lax');
+        if ($samesite !== '') {
+            $cookieOptions['samesite'] = $samesite;
+        }
+        setcookie('modx_manager_language', $language, $cookieOptions);
+    }
+
+    /**
      * Loads the modX system configuration settings.
      *
      * @access protected

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -362,7 +362,12 @@ Ext.extend(MODx,Ext.Component,{
                 ,listeners: {
                     'success': {fn:function(r) {
                         if (this.fireEvent('afterLogout',r)) {
-                            location.href = './';
+                            var lang = Ext.util.Cookies && Ext.util.Cookies.get("modx_manager_language");
+                            var url = "./";
+                            if (lang) {
+                                url = "./?manager_language=" + encodeURIComponent(lang);
+                            }
+                            location.href = url;
                         }
                     },scope:this}
                 }

--- a/manager/controllers/default/language.class.php
+++ b/manager/controllers/default/language.class.php
@@ -3,7 +3,7 @@
 use MODX\Revolution\modParsedManagerController;
 
 /**
- * Switches the current manger language to requested.
+ * Switches the current manager language to requested.
  *
  * Class LanguageManagerController
  */
@@ -30,6 +30,7 @@ class LanguageManagerController extends modParsedManagerController
             }
         }
         $_SESSION['manager_language'] = $targetLanguage;
+        $this->modx->setManagerLanguageCookie($targetLanguage);
 
         $this->modx->sendRedirect(MODX_MANAGER_URL . (($targetProperties) ? '?' . http_build_query($targetProperties) : ''));
     }

--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -205,16 +205,21 @@ class SecurityLoginManagerController extends modManagerController
 
         $ml = $this->modx->sanitizeString($this->modx->getOption('manager_language', $_REQUEST));
         if (!$ml || !in_array($ml, $languages)) {
-            $ml = $this->modx->getOption('manager_language', $_SESSION);
-            if (!$ml) {
-                // Try to detect default browser language
-                $accept_languages = strtolower($_SERVER['HTTP_ACCEPT_LANGUAGE']);
-                preg_match_all('#([\w-]+)(?:[^,\d]+([\d.]+))?#', $accept_languages, $matches, PREG_SET_ORDER);
-                foreach ($matches as $match) {
-                    $lang = trim(explode('-', $match[1])[0]);
-                    if (in_array($lang, $languages)) {
-                        $ml = $lang;
-                        break;
+            $ml = isset($_COOKIE['modx_manager_language'])
+                ? $this->modx->sanitizeString($_COOKIE['modx_manager_language'])
+                : null;
+            if (!$ml || !in_array($ml, $languages)) {
+                $ml = $this->modx->getOption('manager_language', $_SESSION);
+                if (!$ml) {
+                    // Try to detect default browser language
+                    $accept_languages = strtolower($_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '');
+                    preg_match_all('#([\w-]+)(?:[^,\d]+([\d.]+))?#', $accept_languages, $matches, PREG_SET_ORDER);
+                    foreach ($matches as $match) {
+                        $lang = trim(explode('-', $match[1])[0]);
+                        if (in_array($lang, $languages)) {
+                            $ml = $lang;
+                            break;
+                        }
                     }
                 }
             }
@@ -225,6 +230,7 @@ class SecurityLoginManagerController extends modManagerController
         }
         // Save manager language to session
         $_SESSION['manager_language'] = $ml;
+        $this->modx->setManagerLanguageCookie($ml);
         // If user tried to change language - make redirect to hide it from url
         if (!empty($_GET['manager_language'])) {
             unset($_GET['manager_language']);

--- a/manager/controllers/default/security/logout.class.php
+++ b/manager/controllers/default/security/logout.class.php
@@ -31,8 +31,18 @@ class SecurityLogoutManagerController extends modManagerController {
      * @return mixed
      */
     public function process(array $scriptProperties = []) {
+        $managerLanguage = null;
+        if (!empty($_SESSION['manager_language'])) {
+            $languages = $this->modx->lexicon->getLanguageList('core');
+            if (in_array($_SESSION['manager_language'], $languages)) {
+                $managerLanguage = $_SESSION['manager_language'];
+            }
+        }
         $this->modx->runProcessor('security/logout');
-        $url = $this->modx->getOption('manager_url',null,MODX_MANAGER_URL);
+        $url = $this->modx->getOption('manager_url', null, MODX_MANAGER_URL);
+        if ($managerLanguage !== null) {
+            $url .= (strpos($url, '?') !== false ? '&' : '?') . 'manager_language=' . urlencode($managerLanguage);
+        }
         $this->modx->sendRedirect($url);
     }
 


### PR DESCRIPTION
### What changed and why

Manager language lived only in `$_SESSION`. Logout destroyed the session, so the locale reset on the next login (#16072).

This PR persists the choice in cookie `modx_manager_language`, reads it on login, sets it on language change, and passes `manager_language` through the logout redirect (PHP + `modx.js`). Adds `modX::setManagerLanguageCookie()`.

### How to test

1. Log in, switch language (e.g. German).
2. Log out, log in again.
3. Confirm the manager stays on the chosen language.

### Related issue(s)/PR(s)

Resolves #16072

### Compatibility notes

Manager only. Cookie name `modx_manager_language`; value validated against available lexicons.

### Breaking change assessment

No API signature changes. Additive persistence for manager locale. Safe for patch releases.

### Test coverage

No automated tests added; manual login/logout flow.

### Contributors

None beyond author.

### AI tool use

Cursor helped normalize this PR description to the repository template.