### PR TITLE
Add createdon/editedon timestamps to element and category tables

### DIFF
--- a/_build/test/Tests/Model/Element/modPluginTest.php
+++ b/_build/test/Tests/Model/Element/modPluginTest.php
@@ -68,6 +68,35 @@ class modPluginTest extends MODxTestCase {
     }
 
     /**
+     * Loading an unchanged static Plugin's content must not save the object.
+     *
+     * @return void
+     */
+    public function testGetUnchangedStaticContentDoesNotSetEditedon() {
+        $staticFile = MODX_CORE_PATH . 'cache/unit-test-static-plugin.php';
+        $plugin = $this->modx->newObject(modPlugin::class);
+        $plugin->fromArray([
+            'name' => 'Unit Test Static Plugin',
+            'plugincode' => 'return "Static content";',
+            'static' => true,
+            'static_file' => $staticFile,
+        ]);
+
+        try {
+            $this->assertTrue($plugin->save());
+            $this->assertEmpty($plugin->get('editedon'));
+
+            /** @var modPlugin $reloaded */
+            $reloaded = $this->modx->getObject(modPlugin::class, $plugin->get('id'), false);
+            $this->assertSame('return "Static content";', $reloaded->getContent());
+            $this->assertEmpty($reloaded->get('editedon'));
+        } finally {
+            $plugin->remove();
+            @unlink($staticFile);
+        }
+    }
+
+    /**
      * @param string $content
      * @dataProvider providerSetContent
      * @depends testGetContent

--- a/_build/test/Tests/Model/Element/modSnippetTest.php
+++ b/_build/test/Tests/Model/Element/modSnippetTest.php
@@ -70,6 +70,35 @@ class modSnippetTest extends MODxTestCase {
     }
 
     /**
+     * Loading an unchanged static Snippet's content must not save the object.
+     *
+     * @return void
+     */
+    public function testGetUnchangedStaticContentDoesNotSetEditedon() {
+        $staticFile = MODX_CORE_PATH . 'cache/unit-test-static-snippet.php';
+        $snippet = $this->modx->newObject(modSnippet::class);
+        $snippet->fromArray([
+            'name' => 'Unit Test Static Snippet',
+            'snippet' => 'return "Static content";',
+            'static' => true,
+            'static_file' => $staticFile,
+        ]);
+
+        try {
+            $this->assertTrue($snippet->save());
+            $this->assertEmpty($snippet->get('editedon'));
+
+            /** @var modSnippet $reloaded */
+            $reloaded = $this->modx->getObject(modSnippet::class, $snippet->get('id'), false);
+            $this->assertSame('return "Static content";', $reloaded->getContent());
+            $this->assertEmpty($reloaded->get('editedon'));
+        } finally {
+            $snippet->remove();
+            @unlink($staticFile);
+        }
+    }
+
+    /**
      * @param string $content
      * @dataProvider providerSetContent
      * @depends testGetContent

--- a/_build/test/Tests/Processors/Element/CategoryTest.php
+++ b/_build/test/Tests/Processors/Element/CategoryTest.php
@@ -193,9 +193,10 @@ class CategoryProcessorsTest extends MODxTestCase {
         $category = $this->modx->getObject(modCategory::class, ['category' => 'UnitTestCatTimestamp']);
         $this->assertNotNull($category, 'Category not found after creation');
 
-        $this->assertTrue(is_numeric($category->get('createdon')), 'createdon should be a Unix timestamp');
-        $this->assertGreaterThan(0, (int)$category->get('createdon'), 'createdon should be set on new Category');
-        $this->assertEquals(0, (int)$category->get('editedon'), 'editedon should start empty on new Category');
+        // createdon is an int-backed timestamp field, so get() reads back a formatted date string.
+        $this->assertNotEmpty($category->get('createdon'), 'createdon should be set on new Category');
+        $this->assertGreaterThan(0, strtotime($category->get('createdon')), 'createdon should be a valid timestamp');
+        $this->assertEmpty($category->get('editedon'), 'editedon should start empty on new Category');
     }
 
     /**

--- a/_build/test/Tests/Processors/Element/CategoryTest.php
+++ b/_build/test/Tests/Processors/Element/CategoryTest.php
@@ -180,7 +180,7 @@ class CategoryProcessorsTest extends MODxTestCase {
     }
 
     /**
-     * Tests that createdon is set when creating a Category and editedon remains null
+     * Tests that createdon is set when creating a Category and editedon starts empty
      */
     public function testCategoryCreateSetsCreatedon() {
         /** @var ProcessorResponse $result */
@@ -193,9 +193,9 @@ class CategoryProcessorsTest extends MODxTestCase {
         $category = $this->modx->getObject(modCategory::class, ['category' => 'UnitTestCatTimestamp']);
         $this->assertNotNull($category, 'Category not found after creation');
 
-        $this->assertNotNull($category->get('createdon'), 'createdon should be set on new Category');
-        $this->assertNotEmpty($category->get('createdon'), 'createdon should not be empty on new Category');
-        $this->assertNull($category->get('editedon'), 'editedon should be null on new Category');
+        $this->assertTrue(is_numeric($category->get('createdon')), 'createdon should be a Unix timestamp');
+        $this->assertGreaterThan(0, (int)$category->get('createdon'), 'createdon should be set on new Category');
+        $this->assertEquals(0, (int)$category->get('editedon'), 'editedon should start empty on new Category');
     }
 
     /**

--- a/_build/test/Tests/Processors/Element/CategoryTest.php
+++ b/_build/test/Tests/Processors/Element/CategoryTest.php
@@ -180,6 +180,25 @@ class CategoryProcessorsTest extends MODxTestCase {
     }
 
     /**
+     * Tests that createdon is set when creating a Category and editedon remains null
+     */
+    public function testCategoryCreateSetsCreatedon() {
+        /** @var ProcessorResponse $result */
+        $result = $this->modx->runProcessor(Create::class, [
+            'category' => 'UnitTestCatTimestamp',
+        ]);
+        $this->assertTrue($this->checkForSuccess($result), 'Could not create Category for timestamp test');
+
+        /** @var modCategory $category */
+        $category = $this->modx->getObject(modCategory::class, ['category' => 'UnitTestCatTimestamp']);
+        $this->assertNotNull($category, 'Category not found after creation');
+
+        $this->assertNotNull($category->get('createdon'), 'createdon should be set on new Category');
+        $this->assertNotEmpty($category->get('createdon'), 'createdon should not be empty on new Category');
+        $this->assertNull($category->get('editedon'), 'editedon should be null on new Category');
+    }
+
+    /**
      * Tests the element/category/remove processor, which removes a Category
      *
      * @param boolean $shouldPass

--- a/_build/test/Tests/Processors/Element/ChunkTest.php
+++ b/_build/test/Tests/Processors/Element/ChunkTest.php
@@ -327,6 +327,47 @@ class ChunkProcessorsTest extends MODxTestCase {
     }
 
     /**
+     * Tests that createdon is set when creating a Chunk and editedon remains null
+     */
+    public function testChunkCreateSetsCreatedon() {
+        $result = $this->modx->runProcessor(Create::class, [
+            'name' => 'UnitTestChunkTimestamp',
+        ]);
+        $this->assertTrue($this->checkForSuccess($result), 'Could not create Chunk for timestamp test');
+
+        /** @var modChunk $chunk */
+        $chunk = $this->modx->getObject(modChunk::class, ['name' => 'UnitTestChunkTimestamp']);
+        $this->assertNotNull($chunk, 'Chunk not found after creation');
+
+        $this->assertNotNull($chunk->get('createdon'), 'createdon should be set on new Chunk');
+        $this->assertNotEmpty($chunk->get('createdon'), 'createdon should not be empty on new Chunk');
+        $this->assertNull($chunk->get('editedon'), 'editedon should be null on new Chunk');
+    }
+
+    /**
+     * Tests that createdon is preserved after updating a Chunk
+     */
+    public function testChunkUpdatePreservesCreatedon() {
+        /** @var modChunk $chunk */
+        $chunk = $this->modx->getObject(modChunk::class, ['name' => 'UnitTestChunk']);
+        $this->assertNotNull($chunk, 'UnitTestChunk not found');
+
+        $createdon = $chunk->get('createdon');
+        $this->assertNotNull($createdon, 'createdon should be set on fixture chunk');
+
+        $result = $this->modx->runProcessor(Update::class, [
+            'id' => $chunk->get('id'),
+            'name' => 'UnitTestChunk',
+            'description' => 'Updated for timestamp test',
+        ]);
+        $this->assertTrue($this->checkForSuccess($result), 'Could not update Chunk for timestamp test');
+
+        // Re-fetch to get fresh data
+        $chunk = $this->modx->getObject(modChunk::class, ['name' => 'UnitTestChunk']);
+        $this->assertEquals($createdon, $chunk->get('createdon'), 'createdon should not change on update');
+    }
+
+    /**
      * Tests the element/chunk/remove processor, which removes a Chunk
      * @dataProvider providerChunkRemove
      */

--- a/_build/test/Tests/Processors/Element/ChunkTest.php
+++ b/_build/test/Tests/Processors/Element/ChunkTest.php
@@ -370,6 +370,41 @@ class ChunkProcessorsTest extends MODxTestCase {
     }
 
     /**
+     * Tests that duplicating a Chunk resets createdon to the current time and
+     * clears editedon, rather than inheriting the source element's timestamps.
+     */
+    public function testChunkDuplicateResetsTimestamps() {
+        /** @var modChunk $chunk */
+        $chunk = $this->modx->getObject(modChunk::class, ['name' => 'UnitTestChunk']);
+        $this->assertNotNull($chunk, 'UnitTestChunk not found');
+
+        // Give the source element stale timestamps to prove they are not copied.
+        $staleTimestamp = 1000000000; // 2001-09-09
+        $chunk->set('createdon', $staleTimestamp, 'integer');
+        $chunk->set('editedon', $staleTimestamp, 'integer');
+        $chunk->save();
+
+        $beforeDuplicate = time();
+        $this->modx->lexicon->load('default');
+        $result = $this->modx->runProcessor(Duplicate::class, [
+            'id' => $chunk->get('id'),
+            'name' => 'UnitTestChunkDuplicateTimestamp',
+        ]);
+        $this->assertTrue($this->checkForSuccess($result), 'Could not duplicate Chunk for timestamp test');
+
+        /** @var modChunk $duplicate */
+        $duplicate = $this->modx->getObject(modChunk::class, ['name' => 'UnitTestChunkDuplicateTimestamp']);
+        $this->assertNotNull($duplicate, 'Duplicated Chunk not found');
+
+        // createdon is an int-backed timestamp field, so get() reads back a formatted date string.
+        $duplicateCreatedon = strtotime($duplicate->get('createdon'));
+        $this->assertGreaterThanOrEqual($beforeDuplicate, $duplicateCreatedon, 'createdon should be reset to now');
+        $this->assertEmpty($duplicate->get('editedon'), 'Duplicate editedon should be empty');
+
+        $duplicate->remove();
+    }
+
+    /**
      * Tests the element/chunk/remove processor, which removes a Chunk
      * @dataProvider providerChunkRemove
      */

--- a/_build/test/Tests/Processors/Element/ChunkTest.php
+++ b/_build/test/Tests/Processors/Element/ChunkTest.php
@@ -327,7 +327,7 @@ class ChunkProcessorsTest extends MODxTestCase {
     }
 
     /**
-     * Tests that createdon is set when creating a Chunk and editedon remains null
+     * Tests that createdon is set when creating a Chunk and editedon starts empty
      */
     public function testChunkCreateSetsCreatedon() {
         $result = $this->modx->runProcessor(Create::class, [
@@ -339,9 +339,9 @@ class ChunkProcessorsTest extends MODxTestCase {
         $chunk = $this->modx->getObject(modChunk::class, ['name' => 'UnitTestChunkTimestamp']);
         $this->assertNotNull($chunk, 'Chunk not found after creation');
 
-        $this->assertNotNull($chunk->get('createdon'), 'createdon should be set on new Chunk');
-        $this->assertNotEmpty($chunk->get('createdon'), 'createdon should not be empty on new Chunk');
-        $this->assertNull($chunk->get('editedon'), 'editedon should be null on new Chunk');
+        $this->assertTrue(is_numeric($chunk->get('createdon')), 'createdon should be a Unix timestamp');
+        $this->assertGreaterThan(0, (int)$chunk->get('createdon'), 'createdon should be set on new Chunk');
+        $this->assertEquals(0, (int)$chunk->get('editedon'), 'editedon should start empty on new Chunk');
     }
 
     /**
@@ -353,7 +353,7 @@ class ChunkProcessorsTest extends MODxTestCase {
         $this->assertNotNull($chunk, 'UnitTestChunk not found');
 
         $createdon = $chunk->get('createdon');
-        $this->assertNotNull($createdon, 'createdon should be set on fixture chunk');
+        $this->assertGreaterThan(0, (int)$createdon, 'createdon should be set on fixture chunk');
 
         $result = $this->modx->runProcessor(Update::class, [
             'id' => $chunk->get('id'),
@@ -365,6 +365,8 @@ class ChunkProcessorsTest extends MODxTestCase {
         // Re-fetch to get fresh data
         $chunk = $this->modx->getObject(modChunk::class, ['name' => 'UnitTestChunk']);
         $this->assertEquals($createdon, $chunk->get('createdon'), 'createdon should not change on update');
+        $this->assertTrue(is_numeric($chunk->get('editedon')), 'editedon should be a Unix timestamp');
+        $this->assertGreaterThan(0, (int)$chunk->get('editedon'), 'editedon should be set on update');
     }
 
     /**

--- a/_build/test/Tests/Processors/Element/ChunkTest.php
+++ b/_build/test/Tests/Processors/Element/ChunkTest.php
@@ -339,9 +339,10 @@ class ChunkProcessorsTest extends MODxTestCase {
         $chunk = $this->modx->getObject(modChunk::class, ['name' => 'UnitTestChunkTimestamp']);
         $this->assertNotNull($chunk, 'Chunk not found after creation');
 
-        $this->assertTrue(is_numeric($chunk->get('createdon')), 'createdon should be a Unix timestamp');
-        $this->assertGreaterThan(0, (int)$chunk->get('createdon'), 'createdon should be set on new Chunk');
-        $this->assertEquals(0, (int)$chunk->get('editedon'), 'editedon should start empty on new Chunk');
+        // createdon is an int-backed timestamp field, so get() reads back a formatted date string.
+        $this->assertNotEmpty($chunk->get('createdon'), 'createdon should be set on new Chunk');
+        $this->assertGreaterThan(0, strtotime($chunk->get('createdon')), 'createdon should be a valid timestamp');
+        $this->assertEmpty($chunk->get('editedon'), 'editedon should start empty on new Chunk');
     }
 
     /**
@@ -352,8 +353,9 @@ class ChunkProcessorsTest extends MODxTestCase {
         $chunk = $this->modx->getObject(modChunk::class, ['name' => 'UnitTestChunk']);
         $this->assertNotNull($chunk, 'UnitTestChunk not found');
 
+        // createdon is an int-backed timestamp field, so get() reads back a formatted date string.
         $createdon = $chunk->get('createdon');
-        $this->assertGreaterThan(0, (int)$createdon, 'createdon should be set on fixture chunk');
+        $this->assertGreaterThan(0, strtotime($createdon), 'createdon should be set on fixture chunk');
 
         $result = $this->modx->runProcessor(Update::class, [
             'id' => $chunk->get('id'),
@@ -365,8 +367,8 @@ class ChunkProcessorsTest extends MODxTestCase {
         // Re-fetch to get fresh data
         $chunk = $this->modx->getObject(modChunk::class, ['name' => 'UnitTestChunk']);
         $this->assertEquals($createdon, $chunk->get('createdon'), 'createdon should not change on update');
-        $this->assertTrue(is_numeric($chunk->get('editedon')), 'editedon should be a Unix timestamp');
-        $this->assertGreaterThan(0, (int)$chunk->get('editedon'), 'editedon should be set on update');
+        $this->assertNotEmpty($chunk->get('editedon'), 'editedon should be set on update');
+        $this->assertGreaterThan(0, strtotime($chunk->get('editedon')), 'editedon should be a valid timestamp');
     }
 
     /**

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -286,8 +286,8 @@
         <field key="parent" dbtype="int" precision="10" phptype="integer" attributes="unsigned" default="0" index="unique" indexgrp="category" />
         <field key="category" dbtype="varchar" precision="45" phptype="string" null="false" default="" index="unique" indexgrp="category" />
         <field key="rank" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="index" />
-        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
-        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="editedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
 
         <index alias="parent" name="parent" primary="false" unique="false" type="BTREE">
             <column key="parent" length="" collation="A" null="false" />
@@ -352,8 +352,8 @@
         <field key="properties" dbtype="text" phptype="array" null="true" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
-        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="editedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
 
         <alias key="content" field="snippet" />
 
@@ -759,8 +759,8 @@
         <field key="moduleguid" dbtype="varchar" precision="32" phptype="string" null="false" default="" index="fk" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
-        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="editedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
 
         <alias key="content" field="plugincode" />
 
@@ -790,8 +790,8 @@
         <field key="event" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="pk" />
         <field key="priority" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="index" />
         <field key="propertyset" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
-        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
-        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="editedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
             <column key="pluginid" length="" collation="A" null="false" />
@@ -1019,8 +1019,8 @@
         <field key="moduleguid" dbtype="varchar" precision="32" phptype="string" null="false" default="" index="fk" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
-        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="editedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
 
         <alias key="content" field="snippet" />
 
@@ -1078,8 +1078,8 @@
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="preview_file" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
-        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
-        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="editedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
 
         <index alias="templatename" name="templatename" primary="false" unique="true" type="BTREE">
             <column key="templatename" length="" collation="A" null="false" />
@@ -1125,8 +1125,8 @@
         <field key="output_properties" dbtype="text" phptype="array" null="true" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
-        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
-        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="editedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
 
         <alias key="content" field="default_text" />
 
@@ -1165,8 +1165,8 @@
         <field key="tmplvarid" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
         <field key="contentid" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
         <field key="value" dbtype="mediumtext" phptype="string" null="false" />
-        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
-        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="editedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
 
         <index alias="tmplvarid" name="tmplvarid" primary="false" unique="false" type="BTREE">
             <column key="tmplvarid" length="" collation="A" null="false" />
@@ -1186,8 +1186,8 @@
     <object class="modTemplateVarResourceGroup" table="site_tmplvar_access" extends="xPDO\Om\xPDOSimpleObject">
         <field key="tmplvarid" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" />
         <field key="documentgroup" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
-        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
-        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="editedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
 
         <index alias="tmplvar_template" name="tmplvar_template" type="BTREE">
             <column key="tmplvarid" length="" collation="A" null="false" />
@@ -1202,8 +1202,8 @@
         <field key="tmplvarid" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
         <field key="templateid" dbtype="int" precision="11" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
         <field key="rank" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
-        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
-        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
+        <field key="createdon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
+        <field key="editedon" dbtype="int" precision="20" phptype="timestamp" null="false" default="0" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
             <column key="tmplvarid" length="" collation="A" null="false" />

--- a/core/model/schema/modx.mysql.schema.xml
+++ b/core/model/schema/modx.mysql.schema.xml
@@ -286,6 +286,8 @@
         <field key="parent" dbtype="int" precision="10" phptype="integer" attributes="unsigned" default="0" index="unique" indexgrp="category" />
         <field key="category" dbtype="varchar" precision="45" phptype="string" null="false" default="" index="unique" indexgrp="category" />
         <field key="rank" dbtype="int" precision="11" phptype="integer" null="false" default="0" index="index" />
+        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
+        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="parent" name="parent" primary="false" unique="false" type="BTREE">
             <column key="parent" length="" collation="A" null="false" />
@@ -350,6 +352,8 @@
         <field key="properties" dbtype="text" phptype="array" null="true" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
+        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <alias key="content" field="snippet" />
 
@@ -755,6 +759,8 @@
         <field key="moduleguid" dbtype="varchar" precision="32" phptype="string" null="false" default="" index="fk" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
+        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <alias key="content" field="plugincode" />
 
@@ -784,6 +790,8 @@
         <field key="event" dbtype="varchar" precision="191" phptype="string" null="false" default="" index="pk" />
         <field key="priority" dbtype="int" precision="10" phptype="integer" null="false" default="0" index="index" />
         <field key="propertyset" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
+        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
+        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
             <column key="pluginid" length="" collation="A" null="false" />
@@ -1011,6 +1019,8 @@
         <field key="moduleguid" dbtype="varchar" precision="32" phptype="string" null="false" default="" index="fk" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
+        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <alias key="content" field="snippet" />
 
@@ -1068,6 +1078,8 @@
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
         <field key="preview_file" dbtype="varchar" precision="191" phptype="string" null="false" default="" />
+        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
+        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="templatename" name="templatename" primary="false" unique="true" type="BTREE">
             <column key="templatename" length="" collation="A" null="false" />
@@ -1113,6 +1125,8 @@
         <field key="output_properties" dbtype="text" phptype="array" null="true" />
         <field key="static" dbtype="tinyint" precision="1" attributes="unsigned" phptype="boolean" null="false" default="0" index="index" />
         <field key="static_file" dbtype="varchar" precision="255" phptype="string" null="false" default="" />
+        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
+        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <alias key="content" field="default_text" />
 
@@ -1151,6 +1165,8 @@
         <field key="tmplvarid" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
         <field key="contentid" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="index" />
         <field key="value" dbtype="mediumtext" phptype="string" null="false" />
+        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
+        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="tmplvarid" name="tmplvarid" primary="false" unique="false" type="BTREE">
             <column key="tmplvarid" length="" collation="A" null="false" />
@@ -1170,6 +1186,8 @@
     <object class="modTemplateVarResourceGroup" table="site_tmplvar_access" extends="xPDO\Om\xPDOSimpleObject">
         <field key="tmplvarid" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" />
         <field key="documentgroup" dbtype="int" precision="10" phptype="integer" null="false" default="0" />
+        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
+        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="tmplvar_template" name="tmplvar_template" type="BTREE">
             <column key="tmplvarid" length="" collation="A" null="false" />
@@ -1184,6 +1202,8 @@
         <field key="tmplvarid" dbtype="int" precision="10" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
         <field key="templateid" dbtype="int" precision="11" attributes="unsigned" phptype="integer" null="false" default="0" index="pk" />
         <field key="rank" dbtype="int" precision="11" phptype="integer" null="false" default="0" />
+        <field key="createdon" dbtype="datetime" phptype="datetime" null="true" />
+        <field key="editedon" dbtype="datetime" phptype="datetime" null="true" default="NULL" attributes="ON UPDATE CURRENT_TIMESTAMP" />
 
         <index alias="PRIMARY" name="PRIMARY" primary="true" unique="true" type="BTREE">
             <column key="tmplvarid" length="" collation="A" null="false" />

--- a/core/src/Revolution/Processors/Element/Duplicate.php
+++ b/core/src/Revolution/Processors/Element/Duplicate.php
@@ -22,6 +22,16 @@ use MODX\Revolution\Processors\Model\DuplicateProcessor;
  */
 class Duplicate extends DuplicateProcessor
 {
+    public function beforeSave()
+    {
+        /* A duplicate is a brand-new element, so give it a fresh creation
+         * timestamp and clear the source element's last-edited timestamp. */
+        $this->newObject->set('createdon', time(), 'integer');
+        $this->newObject->set('editedon', 0, 'integer');
+
+        return parent::beforeSave();
+    }
+
     public function cleanup()
     {
         $fields = $this->newObject->get(['id', 'name', 'description', 'category', 'locked']);

--- a/core/src/Revolution/modCategory.php
+++ b/core/src/Revolution/modCategory.php
@@ -91,6 +91,10 @@ class modCategory extends modAccessibleSimpleObject
     {
         $isNew = $this->isNew();
 
+        if ($isNew && !$this->get('createdon')) {
+            $this->set('createdon', date('Y-m-d H:i:s'));
+        }
+
         if ($this->xpdo instanceof modX) {
             $this->xpdo->invokeEvent('OnCategoryBeforeSave', [
                 'mode' => $isNew ? modSystemEvent::MODE_NEW : modSystemEvent::MODE_UPD,

--- a/core/src/Revolution/modCategory.php
+++ b/core/src/Revolution/modCategory.php
@@ -8,6 +8,8 @@ namespace MODX\Revolution;
  * @property integer              $parent   The parent category ID, if set. Otherwise defaults to 0.
  * @property string               $category The name of the Category.
  * @property integer              $rank
+ * @property integer              $createdon The UNIX time of when this Category was created.
+ * @property integer              $editedon  The UNIX time, if set, of when this Category was last edited.
  *
  * @property modCategory[]        $Children
  * @property modAccessCategory[]  $Acls
@@ -91,8 +93,12 @@ class modCategory extends modAccessibleSimpleObject
     {
         $isNew = $this->isNew();
 
-        if ($isNew && !$this->get('createdon')) {
-            $this->set('createdon', date('Y-m-d H:i:s'));
+        if ($isNew) {
+            if (!$this->get('createdon')) {
+                $this->set('createdon', time(), 'integer');
+            }
+        } else {
+            $this->set('editedon', time(), 'integer');
         }
 
         if ($this->xpdo instanceof modX) {

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -192,6 +192,10 @@ class modElement extends modAccessibleSimpleObject
      */
     public function save($cacheFlag = null)
     {
+        if ($this->isNew() && !$this->get('createdon')) {
+            $this->set('createdon', date('Y-m-d H:i:s'));
+        }
+
         if (!$this->getOption(xPDO::OPT_SETUP)) {
             if ($this->staticSourceChanged()) {
                 $staticContent = $this->getFileContent();

--- a/core/src/Revolution/modElement.php
+++ b/core/src/Revolution/modElement.php
@@ -24,6 +24,8 @@ use xPDO\xPDO;
  *
  * @property int  $source
  * @property bool $property_preprocess
+ * @property int  $createdon           The UNIX time of when this Element was created
+ * @property int  $editedon            The UNIX time, if set, of when this Element was last edited
  *
  * @property modAccessElement[] $Acls
  *
@@ -192,8 +194,12 @@ class modElement extends modAccessibleSimpleObject
      */
     public function save($cacheFlag = null)
     {
-        if ($this->isNew() && !$this->get('createdon')) {
-            $this->set('createdon', date('Y-m-d H:i:s'));
+        if ($this->isNew()) {
+            if (!$this->get('createdon')) {
+                $this->set('createdon', time(), 'integer');
+            }
+        } else {
+            $this->set('editedon', time(), 'integer');
         }
 
         if (!$this->getOption(xPDO::OPT_SETUP)) {

--- a/core/src/Revolution/modPluginEvent.php
+++ b/core/src/Revolution/modPluginEvent.php
@@ -11,6 +11,8 @@ use xPDO\Om\xPDOObject;
  * @property string $event       The name of this Plugin Event
  * @property int    $priority    The priority of this Event in the chain
  * @property int    $propertyset The ID of the Property Set that may be attached to this Plugin Event
+ * @property int    $createdon   The UNIX time of when this Plugin Event was created
+ * @property int    $editedon    The UNIX time, if set, of when this Plugin Event was last edited
  *
  * @package MODX\Revolution
  */
@@ -24,6 +26,14 @@ class modPluginEvent extends xPDOObject
     public function save($cacheFlag = null)
     {
         $isNew = $this->isNew();
+        if ($isNew) {
+            if (!$this->get('createdon')) {
+                $this->set('createdon', time(), 'integer');
+            }
+        } else {
+            $this->set('editedon', time(), 'integer');
+        }
+
         if ($this->xpdo instanceof modX) {
             $this->xpdo->invokeEvent('OnPluginEventBeforeSave', [
                 'mode' => $isNew ? modSystemEvent::MODE_NEW : modSystemEvent::MODE_UPD,

--- a/core/src/Revolution/modScript.php
+++ b/core/src/Revolution/modScript.php
@@ -212,7 +212,7 @@ class modScript extends modElement
         if (substr($content, -2, 2) == '?>') {
             $content = substr($content, 0, -2);
         }
-        $content = trim($content, " \0\x0B");
+        $content = trim($content, " \n\r\0\x0B");
 
         return $content;
     }

--- a/core/src/Revolution/modTemplateVarResource.php
+++ b/core/src/Revolution/modTemplateVarResource.php
@@ -10,9 +10,26 @@ use xPDO\Om\xPDOSimpleObject;
  * @property int    $tmplvarid The ID of the related TV
  * @property int    $contentid The ID of the related Resource
  * @property string $value     The stored value of the TV for the Resource
+ * @property int    $createdon The UNIX time of when this TV value was created
+ * @property int    $editedon  The UNIX time, if set, of when this TV value was last edited
  *
  * @package MODX\Revolution
  */
 class modTemplateVarResource extends xPDOSimpleObject
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function save($cacheFlag = null)
+    {
+        if ($this->isNew()) {
+            if (!$this->get('createdon')) {
+                $this->set('createdon', time(), 'integer');
+            }
+        } else {
+            $this->set('editedon', time(), 'integer');
+        }
+
+        return parent::save($cacheFlag);
+    }
 }

--- a/core/src/Revolution/modTemplateVarResourceGroup.php
+++ b/core/src/Revolution/modTemplateVarResourceGroup.php
@@ -10,9 +10,26 @@ use xPDO\Om\xPDOSimpleObject;
  *
  * @property int $tmplvarid     The ID of the related TV
  * @property int $documentgroup The ID of the related Resource Group
+ * @property int $createdon     The UNIX time of when this TV access record was created
+ * @property int $editedon      The UNIX time, if set, of when this TV access record was last edited
  *
  * @package MODX\Revolution
  */
 class modTemplateVarResourceGroup extends xPDOSimpleObject
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function save($cacheFlag = null)
+    {
+        if ($this->isNew()) {
+            if (!$this->get('createdon')) {
+                $this->set('createdon', time(), 'integer');
+            }
+        } else {
+            $this->set('editedon', time(), 'integer');
+        }
+
+        return parent::save($cacheFlag);
+    }
 }

--- a/core/src/Revolution/modTemplateVarTemplate.php
+++ b/core/src/Revolution/modTemplateVarTemplate.php
@@ -11,9 +11,26 @@ use xPDO\Om\xPDOObject;
  * @property int $tmplvarid  The ID of the related TV
  * @property int $templateid The ID of the related Template
  * @property int $rank       The rank that this TV will show in relation to other TVs assigned to this Template
+ * @property int $createdon  The UNIX time of when this TV-template relation was created
+ * @property int $editedon   The UNIX time, if set, of when this TV-template relation was last edited
  *
  * @package MODX\Revolution
  */
 class modTemplateVarTemplate extends xPDOObject
 {
+    /**
+     * {@inheritDoc}
+     */
+    public function save($cacheFlag = null)
+    {
+        if ($this->isNew()) {
+            if (!$this->get('createdon')) {
+                $this->set('createdon', time(), 'integer');
+            }
+        } else {
+            $this->set('editedon', time(), 'integer');
+        }
+
+        return parent::save($cacheFlag);
+    }
 }

--- a/core/src/Revolution/mysql/modCategory.php
+++ b/core/src/Revolution/mysql/modCategory.php
@@ -20,6 +20,8 @@ class modCategory extends \MODX\Revolution\modCategory
             'parent' => 0,
             'category' => '',
             'rank' => 0,
+            'createdon' => NULL,
+            'editedon' => NULL,
         ),
         'fieldMeta' => 
         array (
@@ -43,7 +45,7 @@ class modCategory extends \MODX\Revolution\modCategory
                 'index' => 'unique',
                 'indexgrp' => 'category',
             ),
-            'rank' => 
+            'rank' =>
             array (
                 'dbtype' => 'int',
                 'precision' => '11',
@@ -51,6 +53,20 @@ class modCategory extends \MODX\Revolution\modCategory
                 'null' => false,
                 'default' => 0,
                 'index' => 'index',
+            ),
+            'createdon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+            ),
+            'editedon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+                'default' => NULL,
+                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
         ),
         'indexes' => 

--- a/core/src/Revolution/mysql/modCategory.php
+++ b/core/src/Revolution/mysql/modCategory.php
@@ -20,8 +20,8 @@ class modCategory extends \MODX\Revolution\modCategory
             'parent' => 0,
             'category' => '',
             'rank' => 0,
-            'createdon' => NULL,
-            'editedon' => NULL,
+            'createdon' => 0,
+            'editedon' => 0,
         ),
         'fieldMeta' => 
         array (
@@ -56,17 +56,19 @@ class modCategory extends \MODX\Revolution\modCategory
             ),
             'createdon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
             'editedon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
-                'default' => NULL,
-                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
         ),
         'indexes' => 

--- a/core/src/Revolution/mysql/modChunk.php
+++ b/core/src/Revolution/mysql/modChunk.php
@@ -27,6 +27,8 @@ class modChunk extends \MODX\Revolution\modChunk
             'properties' => NULL,
             'static' => 0,
             'static_file' => '',
+            'createdon' => NULL,
+            'editedon' => NULL,
         ),
         'fieldMeta' => 
         array (
@@ -103,13 +105,27 @@ class modChunk extends \MODX\Revolution\modChunk
                 'default' => 0,
                 'index' => 'index',
             ),
-            'static_file' => 
+            'static_file' =>
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
+            ),
+            'createdon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+            ),
+            'editedon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+                'default' => NULL,
+                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
         ),
         'fieldAliases' => 

--- a/core/src/Revolution/mysql/modChunk.php
+++ b/core/src/Revolution/mysql/modChunk.php
@@ -27,8 +27,8 @@ class modChunk extends \MODX\Revolution\modChunk
             'properties' => NULL,
             'static' => 0,
             'static_file' => '',
-            'createdon' => NULL,
-            'editedon' => NULL,
+            'createdon' => 0,
+            'editedon' => 0,
         ),
         'fieldMeta' => 
         array (
@@ -115,17 +115,19 @@ class modChunk extends \MODX\Revolution\modChunk
             ),
             'createdon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
             'editedon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
-                'default' => NULL,
-                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
         ),
         'fieldAliases' => 

--- a/core/src/Revolution/mysql/modPlugin.php
+++ b/core/src/Revolution/mysql/modPlugin.php
@@ -25,6 +25,8 @@ class modPlugin extends \MODX\Revolution\modPlugin
             'moduleguid' => '',
             'static' => 0,
             'static_file' => '',
+            'createdon' => NULL,
+            'editedon' => NULL,
         ),
         'fieldMeta' => 
         array (
@@ -88,13 +90,27 @@ class modPlugin extends \MODX\Revolution\modPlugin
                 'default' => 0,
                 'index' => 'index',
             ),
-            'static_file' => 
+            'static_file' =>
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
+            ),
+            'createdon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+            ),
+            'editedon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+                'default' => NULL,
+                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
         ),
         'fieldAliases' => 

--- a/core/src/Revolution/mysql/modPlugin.php
+++ b/core/src/Revolution/mysql/modPlugin.php
@@ -25,8 +25,8 @@ class modPlugin extends \MODX\Revolution\modPlugin
             'moduleguid' => '',
             'static' => 0,
             'static_file' => '',
-            'createdon' => NULL,
-            'editedon' => NULL,
+            'createdon' => 0,
+            'editedon' => 0,
         ),
         'fieldMeta' => 
         array (
@@ -100,17 +100,19 @@ class modPlugin extends \MODX\Revolution\modPlugin
             ),
             'createdon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
             'editedon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
-                'default' => NULL,
-                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
         ),
         'fieldAliases' => 

--- a/core/src/Revolution/mysql/modPluginEvent.php
+++ b/core/src/Revolution/mysql/modPluginEvent.php
@@ -21,8 +21,8 @@ class modPluginEvent extends \MODX\Revolution\modPluginEvent
             'event' => '',
             'priority' => 0,
             'propertyset' => 0,
-            'createdon' => NULL,
-            'editedon' => NULL,
+            'createdon' => 0,
+            'editedon' => 0,
         ),
         'fieldMeta' => 
         array (
@@ -65,17 +65,19 @@ class modPluginEvent extends \MODX\Revolution\modPluginEvent
             ),
             'createdon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
             'editedon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
-                'default' => NULL,
-                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
         ),
         'indexes' => 

--- a/core/src/Revolution/mysql/modPluginEvent.php
+++ b/core/src/Revolution/mysql/modPluginEvent.php
@@ -21,6 +21,8 @@ class modPluginEvent extends \MODX\Revolution\modPluginEvent
             'event' => '',
             'priority' => 0,
             'propertyset' => 0,
+            'createdon' => NULL,
+            'editedon' => NULL,
         ),
         'fieldMeta' => 
         array (
@@ -51,7 +53,7 @@ class modPluginEvent extends \MODX\Revolution\modPluginEvent
                 'default' => 0,
                 'index' => 'index',
             ),
-            'propertyset' => 
+            'propertyset' =>
             array (
                 'dbtype' => 'int',
                 'precision' => '10',
@@ -60,6 +62,20 @@ class modPluginEvent extends \MODX\Revolution\modPluginEvent
                 'null' => false,
                 'default' => 0,
                 'index' => 'index',
+            ),
+            'createdon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+            ),
+            'editedon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+                'default' => NULL,
+                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
         ),
         'indexes' => 

--- a/core/src/Revolution/mysql/modSnippet.php
+++ b/core/src/Revolution/mysql/modSnippet.php
@@ -24,8 +24,8 @@ class modSnippet extends \MODX\Revolution\modSnippet
             'moduleguid' => '',
             'static' => 0,
             'static_file' => '',
-            'createdon' => NULL,
-            'editedon' => NULL,
+            'createdon' => 0,
+            'editedon' => 0,
         ),
         'fieldMeta' => 
         array (
@@ -87,17 +87,19 @@ class modSnippet extends \MODX\Revolution\modSnippet
             ),
             'createdon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
             'editedon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
-                'default' => NULL,
-                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
         ),
         'fieldAliases' =>

--- a/core/src/Revolution/mysql/modSnippet.php
+++ b/core/src/Revolution/mysql/modSnippet.php
@@ -24,6 +24,8 @@ class modSnippet extends \MODX\Revolution\modSnippet
             'moduleguid' => '',
             'static' => 0,
             'static_file' => '',
+            'createdon' => NULL,
+            'editedon' => NULL,
         ),
         'fieldMeta' => 
         array (
@@ -75,7 +77,7 @@ class modSnippet extends \MODX\Revolution\modSnippet
                 'default' => 0,
                 'index' => 'index',
             ),
-            'static_file' => 
+            'static_file' =>
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -83,8 +85,22 @@ class modSnippet extends \MODX\Revolution\modSnippet
                 'null' => false,
                 'default' => '',
             ),
+            'createdon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+            ),
+            'editedon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+                'default' => NULL,
+                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+            ),
         ),
-        'fieldAliases' => 
+        'fieldAliases' =>
         array (
             'content' => 'snippet',
         ),

--- a/core/src/Revolution/mysql/modTemplate.php
+++ b/core/src/Revolution/mysql/modTemplate.php
@@ -27,8 +27,8 @@ class modTemplate extends \MODX\Revolution\modTemplate
             'static' => 0,
             'static_file' => '',
             'preview_file' => '',
-            'createdon' => NULL,
-            'editedon' => NULL,
+            'createdon' => 0,
+            'editedon' => 0,
         ),
         'fieldMeta' => 
         array (
@@ -133,17 +133,19 @@ class modTemplate extends \MODX\Revolution\modTemplate
             ),
             'createdon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
             'editedon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
-                'default' => NULL,
-                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
         ),
         'indexes' => 

--- a/core/src/Revolution/mysql/modTemplate.php
+++ b/core/src/Revolution/mysql/modTemplate.php
@@ -27,6 +27,8 @@ class modTemplate extends \MODX\Revolution\modTemplate
             'static' => 0,
             'static_file' => '',
             'preview_file' => '',
+            'createdon' => NULL,
+            'editedon' => NULL,
         ),
         'fieldMeta' => 
         array (
@@ -121,13 +123,27 @@ class modTemplate extends \MODX\Revolution\modTemplate
                 'null' => false,
                 'default' => '',
             ),
-            'preview_file' => 
+            'preview_file' =>
             array (
                 'dbtype' => 'varchar',
                 'precision' => '191',
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
+            ),
+            'createdon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+            ),
+            'editedon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+                'default' => NULL,
+                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
         ),
         'indexes' => 

--- a/core/src/Revolution/mysql/modTemplateVar.php
+++ b/core/src/Revolution/mysql/modTemplateVar.php
@@ -33,6 +33,8 @@ class modTemplateVar extends \MODX\Revolution\modTemplateVar
             'output_properties' => NULL,
             'static' => 0,
             'static_file' => '',
+            'createdon' => NULL,
+            'editedon' => NULL,
         ),
         'fieldMeta' => 
         array (
@@ -151,7 +153,7 @@ class modTemplateVar extends \MODX\Revolution\modTemplateVar
                 'default' => 0,
                 'index' => 'index',
             ),
-            'static_file' => 
+            'static_file' =>
             array (
                 'dbtype' => 'varchar',
                 'precision' => '255',
@@ -159,8 +161,22 @@ class modTemplateVar extends \MODX\Revolution\modTemplateVar
                 'null' => false,
                 'default' => '',
             ),
+            'createdon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+            ),
+            'editedon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+                'default' => NULL,
+                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+            ),
         ),
-        'fieldAliases' => 
+        'fieldAliases' =>
         array (
             'content' => 'default_text',
         ),

--- a/core/src/Revolution/mysql/modTemplateVar.php
+++ b/core/src/Revolution/mysql/modTemplateVar.php
@@ -33,8 +33,8 @@ class modTemplateVar extends \MODX\Revolution\modTemplateVar
             'output_properties' => NULL,
             'static' => 0,
             'static_file' => '',
-            'createdon' => NULL,
-            'editedon' => NULL,
+            'createdon' => 0,
+            'editedon' => 0,
         ),
         'fieldMeta' => 
         array (
@@ -163,17 +163,19 @@ class modTemplateVar extends \MODX\Revolution\modTemplateVar
             ),
             'createdon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
             'editedon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
-                'default' => NULL,
-                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
         ),
         'fieldAliases' =>

--- a/core/src/Revolution/mysql/modTemplateVarResource.php
+++ b/core/src/Revolution/mysql/modTemplateVarResource.php
@@ -20,8 +20,8 @@ class modTemplateVarResource extends \MODX\Revolution\modTemplateVarResource
             'tmplvarid' => 0,
             'contentid' => 0,
             'value' => NULL,
-            'createdon' => NULL,
-            'editedon' => NULL,
+            'createdon' => 0,
+            'editedon' => 0,
         ),
         'fieldMeta' => 
         array (
@@ -53,17 +53,19 @@ class modTemplateVarResource extends \MODX\Revolution\modTemplateVarResource
             ),
             'createdon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
             'editedon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
-                'default' => NULL,
-                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
         ),
         'indexes' => 

--- a/core/src/Revolution/mysql/modTemplateVarResource.php
+++ b/core/src/Revolution/mysql/modTemplateVarResource.php
@@ -20,6 +20,8 @@ class modTemplateVarResource extends \MODX\Revolution\modTemplateVarResource
             'tmplvarid' => 0,
             'contentid' => 0,
             'value' => NULL,
+            'createdon' => NULL,
+            'editedon' => NULL,
         ),
         'fieldMeta' => 
         array (
@@ -43,11 +45,25 @@ class modTemplateVarResource extends \MODX\Revolution\modTemplateVarResource
                 'default' => 0,
                 'index' => 'index',
             ),
-            'value' => 
+            'value' =>
             array (
                 'dbtype' => 'mediumtext',
                 'phptype' => 'string',
                 'null' => false,
+            ),
+            'createdon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+            ),
+            'editedon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+                'default' => NULL,
+                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
         ),
         'indexes' => 

--- a/core/src/Revolution/mysql/modTemplateVarResourceGroup.php
+++ b/core/src/Revolution/mysql/modTemplateVarResourceGroup.php
@@ -19,6 +19,8 @@ class modTemplateVarResourceGroup extends \MODX\Revolution\modTemplateVarResourc
         array (
             'tmplvarid' => 0,
             'documentgroup' => 0,
+            'createdon' => NULL,
+            'editedon' => NULL,
         ),
         'fieldMeta' => 
         array (
@@ -31,13 +33,27 @@ class modTemplateVarResourceGroup extends \MODX\Revolution\modTemplateVarResourc
                 'null' => false,
                 'default' => 0,
             ),
-            'documentgroup' => 
+            'documentgroup' =>
             array (
                 'dbtype' => 'int',
                 'precision' => '10',
                 'phptype' => 'integer',
                 'null' => false,
                 'default' => 0,
+            ),
+            'createdon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+            ),
+            'editedon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+                'default' => NULL,
+                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
         ),
         'indexes' => 

--- a/core/src/Revolution/mysql/modTemplateVarResourceGroup.php
+++ b/core/src/Revolution/mysql/modTemplateVarResourceGroup.php
@@ -19,8 +19,8 @@ class modTemplateVarResourceGroup extends \MODX\Revolution\modTemplateVarResourc
         array (
             'tmplvarid' => 0,
             'documentgroup' => 0,
-            'createdon' => NULL,
-            'editedon' => NULL,
+            'createdon' => 0,
+            'editedon' => 0,
         ),
         'fieldMeta' => 
         array (
@@ -43,17 +43,19 @@ class modTemplateVarResourceGroup extends \MODX\Revolution\modTemplateVarResourc
             ),
             'createdon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
             'editedon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
-                'default' => NULL,
-                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
         ),
         'indexes' => 

--- a/core/src/Revolution/mysql/modTemplateVarTemplate.php
+++ b/core/src/Revolution/mysql/modTemplateVarTemplate.php
@@ -20,8 +20,8 @@ class modTemplateVarTemplate extends \MODX\Revolution\modTemplateVarTemplate
             'tmplvarid' => 0,
             'templateid' => 0,
             'rank' => 0,
-            'createdon' => NULL,
-            'editedon' => NULL,
+            'createdon' => 0,
+            'editedon' => 0,
         ),
         'fieldMeta' => 
         array (
@@ -55,17 +55,19 @@ class modTemplateVarTemplate extends \MODX\Revolution\modTemplateVarTemplate
             ),
             'createdon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
             'editedon' =>
             array (
-                'dbtype' => 'datetime',
-                'phptype' => 'datetime',
-                'null' => true,
-                'default' => NULL,
-                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
+                'dbtype' => 'int',
+                'precision' => '20',
+                'phptype' => 'timestamp',
+                'null' => false,
+                'default' => 0,
             ),
         ),
         'indexes' => 

--- a/core/src/Revolution/mysql/modTemplateVarTemplate.php
+++ b/core/src/Revolution/mysql/modTemplateVarTemplate.php
@@ -20,6 +20,8 @@ class modTemplateVarTemplate extends \MODX\Revolution\modTemplateVarTemplate
             'tmplvarid' => 0,
             'templateid' => 0,
             'rank' => 0,
+            'createdon' => NULL,
+            'editedon' => NULL,
         ),
         'fieldMeta' => 
         array (
@@ -43,13 +45,27 @@ class modTemplateVarTemplate extends \MODX\Revolution\modTemplateVarTemplate
                 'default' => 0,
                 'index' => 'pk',
             ),
-            'rank' => 
+            'rank' =>
             array (
                 'dbtype' => 'int',
                 'precision' => '11',
                 'phptype' => 'integer',
                 'null' => false,
                 'default' => 0,
+            ),
+            'createdon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+            ),
+            'editedon' =>
+            array (
+                'dbtype' => 'datetime',
+                'phptype' => 'datetime',
+                'null' => true,
+                'default' => NULL,
+                'attributes' => 'ON UPDATE CURRENT_TIMESTAMP',
             ),
         ),
         'indexes' => 

--- a/setup/includes/upgrades/common/3.2.1-element-timestamps.php
+++ b/setup/includes/upgrades/common/3.2.1-element-timestamps.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Add createdon and editedon fields to element and related tables.
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+use MODX\Revolution\modCategory;
+use MODX\Revolution\modChunk;
+use MODX\Revolution\modPlugin;
+use MODX\Revolution\modPluginEvent;
+use MODX\Revolution\modSnippet;
+use MODX\Revolution\modTemplate;
+use MODX\Revolution\modTemplateVar;
+use MODX\Revolution\modTemplateVarResource;
+use MODX\Revolution\modTemplateVarResourceGroup;
+use MODX\Revolution\modTemplateVarTemplate;
+
+$classes = [
+    modCategory::class,
+    modChunk::class,
+    modPlugin::class,
+    modPluginEvent::class,
+    modSnippet::class,
+    modTemplate::class,
+    modTemplateVar::class,
+    modTemplateVarResource::class,
+    modTemplateVarResourceGroup::class,
+    modTemplateVarTemplate::class,
+];
+
+foreach ($classes as $class) {
+    $table = $modx->getTableName($class);
+
+    $description = $this->install->lexicon('add_column', ['column' => 'createdon', 'table' => $table]);
+    $this->processResults($class, $description, [$modx->manager, 'addField'], [$class, 'createdon']);
+
+    $description = $this->install->lexicon('add_column', ['column' => 'editedon', 'table' => $table]);
+    $this->processResults($class, $description, [$modx->manager, 'addField'], [$class, 'editedon']);
+}


### PR DESCRIPTION
### What does it do?
MODX tracks when resources, users, and settings were created and last modified, but not elements. There's no way to tell when a snippet was last changed or which templates haven't been touched in years.

As a developer, this information is useful. This PR adds `createdon` and `editedon` columns to chunks, snippets, plugins, templates, TVs, categories, and their association tables.

### How does it work?
`createdon` is set in PHP when an element or category is first saved, the same way `modUser` already handles it. `editedon` is handled by MySQL (`ON UPDATE CURRENT_TIMESTAMP`), so it requires no application code. Both use the `datetime` type rather than `timestamp` to avoid timezone conversion quirks and the 2038 year limit.

Existing records get `NULL` for both columns. `editedon` stays `NULL` until an actual edit is made, which matches how resources behave.

For static elements, `editedon` reflects when MODX last synced the file content to the database, which may differ from when the file was actually modified. `editedon` reflecting when the DB row was last updated is at least honest and consistent.

### How to test
1. Run MODX setup upgrade to verify the upgrade script adds columns
2. Create a new element in the manager and verify createdon appears
3. Edit it and verify editedon is populated

I've extended the test suite to verify `createdon` is set on creation, `editedon` is `null` after creation, `createdon` is preserved after update.

### Related issue(s)/PR(s)
https://github.com/modxcms/revolution/pull/13857 was a previous PR to do this. It added `createdby` and `editedby` as well, and as it went the scope expanded. I have kept my PR focused because I am not using the other features. It ran into problems with static elements, and think I have taken a pragmatic approach to solving that.

#13770 #13626 #13641 #2027