### PR TITLE
Add PSR-3 logging support in MODX

### DIFF
--- a/_build/test/Tests/Model/TestLogger.php
+++ b/_build/test/Tests/Model/TestLogger.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+
+namespace MODX\Revolution\Tests\Model;
+
+use Psr\Log\AbstractLogger;
+
+class TestLogger extends AbstractLogger
+{
+    /** @var array */
+    public $records = [];
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+        ];
+    }
+}

--- a/_build/test/Tests/Model/modXLoggingTest.php
+++ b/_build/test/Tests/Model/modXLoggingTest.php
@@ -1,0 +1,444 @@
+<?php
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+namespace MODX\Revolution\Tests\Model;
+
+use MODX\Revolution\modX;
+use MODX\Revolution\MODxTestCase;
+use Psr\Log\AbstractLogger;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
+use xPDO\xPDO;
+use xPDO\Cache\xPDOCacheManager;
+
+/**
+ * Tests related to modX logging behavior.
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Model
+ * @group modX
+ * @group Logging
+ */
+class modXLoggingTest extends MODxTestCase
+{
+    /**
+     * @var int Original log level to restore after each test.
+     */
+    private $originalLogLevel;
+
+    /**
+     * @var mixed Original log target to restore after each test.
+     */
+    private $originalLogTarget;
+
+    /**
+     * @before
+     * @throws \xPDO\xPDOException
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+        $this->originalLogLevel = $this->modx->getLogLevel();
+        $this->originalLogTarget = $this->modx->getLogTarget();
+        // Ensure no PSR-3 logger is set for baseline tests
+        $this->modx->logger = null;
+    }
+
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
+    {
+        $this->modx->setLogLevel($this->originalLogLevel);
+        $this->modx->setLogTarget($this->originalLogTarget);
+        $this->modx->setDebug(false);
+        $this->modx->logger = null;
+        parent::tearDownFixtures();
+    }
+
+    // ---------------------------------------------------------------
+    // Baseline tests: legacy logging behavior (no PSR-3 logger)
+    // ---------------------------------------------------------------
+
+    public function testFileTargetWritesLog()
+    {
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        $cachePath = $this->modx->getCachePath();
+        $filepath = $cachePath . xPDOCacheManager::LOG_DIR;
+        $filename = 'modx_logging_test.log';
+        $fullpath = $filepath . $filename;
+        if (file_exists($fullpath)) {
+            unlink($fullpath);
+        }
+
+        $target = [
+            'target' => 'FILE',
+            'options' => [
+                'filename' => $filename,
+                'filepath' => $filepath,
+            ],
+        ];
+
+        $this->modx->log(xPDO::LOG_LEVEL_ERROR, 'File write test', $target, 'UnitTest', __FILE__, 123);
+
+        $this->assertFileExists($fullpath);
+        $contents = file_get_contents($fullpath);
+        $pattern = '/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] \(ERROR in UnitTest @ '
+            . preg_quote(__FILE__, '/')
+            . ' : 123\) File write test\n$/';
+        $this->assertMatchesRegularExpression($pattern, $contents);
+        unlink($fullpath);
+    }
+
+    public function testEchoTargetOutputsFormattedMessage()
+    {
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        ob_start();
+        $this->modx->log(xPDO::LOG_LEVEL_INFO, 'Echo test', 'ECHO', 'UnitTest', __FILE__, 456);
+        $output = ob_get_clean();
+
+        $pattern = '/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] \(INFO in UnitTest @ '
+            . preg_quote(__FILE__, '/')
+            . ' : 456\) Echo test\n$/';
+        $this->assertMatchesRegularExpression($pattern, $output);
+    }
+
+    public function testHtmlTargetOutputsHtmlFormattedMessage()
+    {
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        ob_start();
+        $this->modx->log(xPDO::LOG_LEVEL_INFO, 'Html test', 'HTML', 'UnitTest', __FILE__, 789);
+        $output = ob_get_clean();
+
+        $pattern = '/^<h5>\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] \(INFO in UnitTest @ '
+            . preg_quote(__FILE__, '/')
+            . ' : 789\)<\/h5><pre>Html test<\/pre>\n$/';
+        $this->assertMatchesRegularExpression($pattern, $output);
+    }
+
+    public function testArrayTargetAppendsFormattedString()
+    {
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        $output = [];
+        $target = [
+            'target' => 'ARRAY',
+            'options' => [
+                'var' => &$output,
+            ],
+        ];
+
+        $this->modx->log(xPDO::LOG_LEVEL_ERROR, 'Array test', $target, 'UnitTest', __FILE__, 111);
+
+        $this->assertCount(1, $output);
+        $pattern = '/^\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] \(ERROR in UnitTest @ '
+            . preg_quote(__FILE__, '/')
+            . ' : 111\) Array test\n$/';
+        $this->assertMatchesRegularExpression($pattern, $output[0]);
+    }
+
+    public function testArrayExtendedTargetAppendsStructuredArray()
+    {
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        $output = [];
+        $target = [
+            'target' => 'ARRAY_EXTENDED',
+            'options' => [
+                'var' => &$output,
+            ],
+        ];
+
+        $this->modx->log(xPDO::LOG_LEVEL_WARN, 'Extended test', $target, 'UnitTest', __FILE__, 222);
+
+        $this->assertCount(1, $output);
+        $entry = $output[0];
+        $this->assertSame('WARN', $entry['level']);
+        $this->assertSame('Extended test', $entry['msg']);
+        $this->assertSame(' in UnitTest', $entry['def']);
+        $this->assertSame(' @ ' . __FILE__, $entry['file']);
+        $this->assertSame(' : 222', $entry['line']);
+        $this->assertArrayHasKey('content', $entry);
+    }
+
+    public function testLevelFilteringBlocksMessagesBelowThreshold()
+    {
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_ERROR);
+
+        $output = [];
+        $target = [
+            'target' => 'ARRAY',
+            'options' => [
+                'var' => &$output,
+            ],
+        ];
+
+        $this->modx->log(xPDO::LOG_LEVEL_INFO, 'Should not appear', $target, 'UnitTest', __FILE__, 333);
+
+        $this->assertCount(0, $output);
+    }
+
+    public function testDebugModeOverridesLevelFiltering()
+    {
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_ERROR);
+        $this->modx->setDebug(true);
+
+        $output = [];
+        $target = [
+            'target' => 'ARRAY',
+            'options' => [
+                'var' => &$output,
+            ],
+        ];
+
+        $this->modx->log(xPDO::LOG_LEVEL_DEBUG, 'Debug override', $target, 'UnitTest', __FILE__, 444);
+
+        $this->assertCount(1, $output);
+        $this->assertStringContainsString('Debug override', $output[0]);
+    }
+
+    public function testFileAndLineAutoResolutionFromBacktrace()
+    {
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        $output = [];
+        $target = [
+            'target' => 'ARRAY',
+            'options' => [
+                'var' => &$output,
+            ],
+        ];
+
+        // Log without explicit file/line — backtrace should fill them in
+        $this->modx->log(xPDO::LOG_LEVEL_INFO, 'Backtrace test', $target, 'UnitTest');
+
+        $this->assertCount(1, $output);
+        // Should contain a file reference (from backtrace) — at minimum the @ separator
+        $this->assertStringContainsString(' @ ', $output[0]);
+    }
+
+    public function testDefaultConfigLogLevelIsError()
+    {
+        // modX constructor defaults to LOG_LEVEL_ERROR when no log_level config is set.
+        // In the test harness, the config may override this. We verify the constant default
+        // by checking that the constructor fallback value is LOG_LEVEL_ERROR.
+        // The actual runtime level depends on config + test harness overrides.
+        $this->assertSame(1, xPDO::LOG_LEVEL_ERROR);
+        $this->assertSame(0, xPDO::LOG_LEVEL_FATAL);
+        $this->assertSame(2, xPDO::LOG_LEVEL_WARN);
+        $this->assertSame(3, xPDO::LOG_LEVEL_INFO);
+        $this->assertSame(4, xPDO::LOG_LEVEL_DEBUG);
+    }
+
+    public function testLevelFilteringAllowsMessagesAtThreshold()
+    {
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_WARN);
+
+        $output = [];
+        $target = [
+            'target' => 'ARRAY',
+            'options' => [
+                'var' => &$output,
+            ],
+        ];
+
+        $this->modx->log(xPDO::LOG_LEVEL_WARN, 'At threshold', $target, 'UnitTest', __FILE__, 555);
+
+        $this->assertCount(1, $output);
+        $this->assertStringContainsString('At threshold', $output[0]);
+    }
+
+    public function testLevelFilteringAllowsMessagesBelowThreshold()
+    {
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_WARN);
+
+        $output = [];
+        $target = [
+            'target' => 'ARRAY',
+            'options' => [
+                'var' => &$output,
+            ],
+        ];
+
+        // ERROR (1) is below WARN (2) threshold, so it should pass
+        $this->modx->log(xPDO::LOG_LEVEL_ERROR, 'Below threshold', $target, 'UnitTest', __FILE__, 666);
+
+        $this->assertCount(1, $output);
+        $this->assertStringContainsString('Below threshold', $output[0]);
+    }
+
+    // ---------------------------------------------------------------
+    // PSR-3 logger tests
+    // ---------------------------------------------------------------
+
+    public function testPsrLoggerReceivesMessages()
+    {
+        $logger = new TestLogger();
+        $this->modx->setLogger($logger);
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        $this->modx->log(xPDO::LOG_LEVEL_ERROR, 'PSR-3 test', '', 'UnitTest', __FILE__, 100);
+
+        $this->assertCount(1, $logger->records);
+        $this->assertSame(LogLevel::ERROR, $logger->records[0]['level']);
+        $this->assertSame('PSR-3 test', $logger->records[0]['message']);
+    }
+
+    public function testPsrLoggerLevelMapping()
+    {
+        $logger = new TestLogger();
+        $this->modx->setLogger($logger);
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        $this->modx->log(xPDO::LOG_LEVEL_DEBUG, 'debug msg', '', 'Test', __FILE__, 1);
+        $this->modx->log(xPDO::LOG_LEVEL_INFO, 'info msg', '', 'Test', __FILE__, 2);
+        $this->modx->log(xPDO::LOG_LEVEL_WARN, 'warn msg', '', 'Test', __FILE__, 3);
+        $this->modx->log(xPDO::LOG_LEVEL_ERROR, 'error msg', '', 'Test', __FILE__, 4);
+
+        $this->assertCount(4, $logger->records);
+        $this->assertSame(LogLevel::DEBUG, $logger->records[0]['level']);
+        $this->assertSame(LogLevel::INFO, $logger->records[1]['level']);
+        $this->assertSame(LogLevel::WARNING, $logger->records[2]['level']);
+        $this->assertSame(LogLevel::ERROR, $logger->records[3]['level']);
+    }
+
+    public function testPsrLoggerRespectsLogLevelThreshold()
+    {
+        $logger = new TestLogger();
+        $this->modx->setLogger($logger);
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_ERROR);
+
+        $this->modx->log(xPDO::LOG_LEVEL_INFO, 'Should not appear');
+
+        $this->assertCount(0, $logger->records);
+    }
+
+    public function testPsrLoggerReplacesLegacyOutput()
+    {
+        $logger = new TestLogger();
+        $this->modx->setLogger($logger);
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        $cachePath = $this->modx->getCachePath();
+        $filepath = $cachePath . xPDOCacheManager::LOG_DIR;
+        $filename = 'psr3_replace_test.log';
+        $fullpath = $filepath . $filename;
+        if (file_exists($fullpath)) {
+            unlink($fullpath);
+        }
+
+        $target = [
+            'target' => 'FILE',
+            'options' => [
+                'filename' => $filename,
+                'filepath' => $filepath,
+            ],
+        ];
+
+        $this->modx->log(xPDO::LOG_LEVEL_ERROR, 'PSR-3 only', $target, 'UnitTest', __FILE__, 200);
+
+        // PSR-3 logger received the message
+        $this->assertCount(1, $logger->records);
+        $this->assertSame('PSR-3 only', $logger->records[0]['message']);
+
+        // Legacy FILE target should NOT have been written
+        $this->assertFileDoesNotExist($fullpath);
+    }
+
+    public function testPsrLoggerReplacesLegacyEchoOutput()
+    {
+        $logger = new TestLogger();
+        $this->modx->setLogger($logger);
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        ob_start();
+        $this->modx->log(xPDO::LOG_LEVEL_INFO, 'No echo', 'ECHO', 'UnitTest', __FILE__, 300);
+        $output = ob_get_clean();
+
+        // PSR-3 logger received it
+        $this->assertCount(1, $logger->records);
+        // No echo output
+        $this->assertEmpty($output);
+    }
+
+    public function testSetLoggerSetsLoggerProperty()
+    {
+        $logger = new TestLogger();
+        $this->modx->setLogger($logger);
+
+        $this->assertSame($logger, $this->modx->logger);
+        $this->assertInstanceOf(LoggerInterface::class, $this->modx->logger);
+    }
+
+    public function testPsrLoggerContextIncludesDefAndLevel()
+    {
+        $logger = new TestLogger();
+        $this->modx->setLogger($logger);
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        $this->modx->log(xPDO::LOG_LEVEL_WARN, 'Context test', '', 'MyClass', 'myfile.php', 42);
+
+        $this->assertCount(1, $logger->records);
+        $context = $logger->records[0]['context'];
+        $this->assertSame('MyClass', $context['def']);
+        $this->assertSame('myfile.php', $context['file']);
+        $this->assertSame(42, $context['line']);
+        $this->assertSame(xPDO::LOG_LEVEL_WARN, $context['xpdo_level']);
+    }
+
+    public function testPsrLoggerFileLineEmptyWhenCallerDoesNotProvide()
+    {
+        $logger = new TestLogger();
+        $this->modx->setLogger($logger);
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        // Log without explicit file/line
+        $this->modx->log(xPDO::LOG_LEVEL_INFO, 'No file info');
+
+        $this->assertCount(1, $logger->records);
+        $context = $logger->records[0]['context'];
+        // PSR-3 path does NOT resolve backtrace — file/line should be empty
+        $this->assertEmpty($context['file']);
+        $this->assertEmpty($context['line']);
+    }
+
+    public function testPsrLoggerStringifiesNonStringMessages()
+    {
+        $logger = new TestLogger();
+        $this->modx->setLogger($logger);
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        $this->modx->log(xPDO::LOG_LEVEL_INFO, ['key' => 'value']);
+
+        $this->assertCount(1, $logger->records);
+        $this->assertStringContainsString('key', $logger->records[0]['message']);
+        $this->assertStringContainsString('value', $logger->records[0]['message']);
+    }
+}
+
+class TestLogger extends AbstractLogger
+{
+    /** @var array */
+    public $records = [];
+
+    public function log($level, $message, array $context = []): void
+    {
+        $this->records[] = [
+            'level' => $level,
+            'message' => $message,
+            'context' => $context,
+        ];
+    }
+}

--- a/_build/test/Tests/Model/modXLoggingTest.php
+++ b/_build/test/Tests/Model/modXLoggingTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -9,11 +10,11 @@
  *
  * @package modx-test
  */
+
 namespace MODX\Revolution\Tests\Model;
 
 use MODX\Revolution\modX;
 use MODX\Revolution\MODxTestCase;
-use Psr\Log\AbstractLogger;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LogLevel;
 use xPDO\xPDO;
@@ -425,20 +426,5 @@ class modXLoggingTest extends MODxTestCase
         $this->assertCount(1, $logger->records);
         $this->assertStringContainsString('key', $logger->records[0]['message']);
         $this->assertStringContainsString('value', $logger->records[0]['message']);
-    }
-}
-
-class TestLogger extends AbstractLogger
-{
-    /** @var array */
-    public $records = [];
-
-    public function log($level, $message, array $context = []): void
-    {
-        $this->records[] = [
-            'level' => $level,
-            'message' => $message,
-            'context' => $context,
-        ];
     }
 }

--- a/_build/test/phpunit.xml
+++ b/_build/test/phpunit.xml
@@ -18,6 +18,7 @@
         </testsuite>
         <testsuite name="Model">
             <file>Tests/Model/modXTest.php</file>
+            <file>Tests/Model/modXLoggingTest.php</file>
             <file>Tests/Model/modParserTest.php</file>
             <directory>Tests/Model/Dashboard</directory>
             <directory>Tests/Model/Element</directory>

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "xpdo/xpdo": "~3.1.0",
+        "xpdo/xpdo": "3.x-dev#55fd34318a86d9ebe2cf01564c7126d90034af2c",
         "league/flysystem": "^2.0",
         "league/flysystem-aws-s3-v3": "^2.0",
         "league/flysystem-ftp": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "xpdo/xpdo": "3.x-dev#55fd34318a86d9ebe2cf01564c7126d90034af2c",
+        "xpdo/xpdo": "^3.2",
         "league/flysystem": "^2.0",
         "league/flysystem-aws-s3-v3": "^2.0",
         "league/flysystem-ftp": "^2.0",

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -33,7 +33,10 @@ use Psr\Http\Message\ServerRequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\UploadedFileFactoryInterface;
 use Psr\Http\Message\UriFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\LogLevel;
 use xPDO\Cache\xPDOFileCache;
+use xPDO\Logging\xPDOLogger;
 use xPDO\xPDO;
 use xPDO\xPDOException;
 use xPDO\Cache\xPDOCacheManager;
@@ -732,6 +735,20 @@ class modX extends xPDO {
             }
         }
         return $oldValue;
+    }
+
+    /**
+     * Set a PSR-3 logger for this MODX instance.
+     *
+     * When a PSR-3 logger is set, it replaces legacy FILE/ECHO/HTML output for
+     * all log messages that pass the configured logLevel threshold. modRegister
+     * logging is preserved alongside the PSR-3 logger.
+     *
+     * @param LoggerInterface $logger A PSR-3 compatible logger instance.
+     */
+    public function setLogger(LoggerInterface $logger): void
+    {
+        $this->logger = $logger;
     }
 
     /**
@@ -2924,11 +2941,19 @@ class modX extends xPDO {
     }
 
     /**
-     * Provides modX the ability to use modRegister instances as log targets.
+     * Provides modX the ability to use modRegister instances as log targets,
+     * and dispatches to a PSR-3 logger when one is set via {@see setLogger()}.
+     *
+     * When a PSR-3 logger is set it replaces legacy FILE/ECHO/HTML output.
+     * modRegister logging is always preserved alongside the PSR-3 logger.
      *
      * {@inheritdoc}
      */
     protected function _log($level, $msg, $target= '', $def= '', $file= '', $line= '') {
+        if ($level !== xPDO::LOG_LEVEL_FATAL && $level > $this->logLevel && $this->_debug !== true) {
+            return;
+        }
+
         if (empty($target)) {
             $target = $this->logTarget;
         }
@@ -2938,27 +2963,54 @@ class modX extends xPDO {
             if (isset($target['options'])) $targetOptions = $target['options'];
             $targetObj = isset($target['target']) ? $target['target'] : 'ECHO';
         }
+
+        $hasPsrLogger = $this->logger instanceof LoggerInterface && !($this->logger instanceof xPDOLogger);
+
+        // Dispatch to PSR-3 logger (no backtrace — file/line only if caller provided them)
+        if ($hasPsrLogger) {
+            $this->_dispatchToPsrLogger($level, $msg, $def, $file, $line);
+        }
+
+        // modRegister target
         if (is_object($targetObj) && $targetObj instanceof modRegister) {
+            if (empty($file)) {
+                $file = $_SERVER['PHP_SELF'] ?? ($_SERVER['SCRIPT_FILENAME'] ?? '');
+            }
             if ($level === modX::LOG_LEVEL_FATAL) {
-                if (empty ($file)) $file= (isset ($_SERVER['PHP_SELF'])) ? $_SERVER['PHP_SELF'] : (isset ($_SERVER['SCRIPT_FILENAME']) ? $_SERVER['SCRIPT_FILENAME'] : '');
                 $this->_logInRegister($targetObj, $level, $msg, $def, $file, $line);
                 $this->sendError('fatal');
             }
             if ($this->_debug === true || $level <= $this->logLevel) {
-                if (empty ($file)) $file= (isset ($_SERVER['PHP_SELF'])) ? $_SERVER['PHP_SELF'] : (isset ($_SERVER['SCRIPT_FILENAME']) ? $_SERVER['SCRIPT_FILENAME'] : '');
                 $this->_logInRegister($targetObj, $level, $msg, $def, $file, $line);
             }
-        } else {
+            return;
+        }
+
+        // PSR-3 logger replaces legacy FILE/ECHO/HTML output
+        if ($hasPsrLogger) {
             if ($level === modX::LOG_LEVEL_FATAL) {
-                while (ob_get_level() && @ob_end_clean()) {}
-                if ($targetObj == 'FILE' && $cacheManager= $this->getCacheManager()) {
-                    $filename = isset($targetOptions['filename']) ? $targetOptions['filename'] : 'error.log';
-                    $filepath = isset($targetOptions['filepath']) ? $targetOptions['filepath'] : $this->getCachePath() . xPDOCacheManager::LOG_DIR;
-                    $cacheManager->writeFile($filepath . $filename, '[' . date('Y-m-d H:i:s') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ') ' . $msg . "\n" . ($this->getDebug() === true ? '<pre>' . "\n" . print_r(debug_backtrace(), true) . "\n" . '</pre>' : ''), 'a');
-                }
                 $this->sendError('fatal');
             }
-            parent :: _log($level, $msg, $target, $def, $file, $line);
+            return;
+        }
+
+        // Legacy path (no PSR-3 logger)
+        if ($level === modX::LOG_LEVEL_FATAL) {
+            while (ob_get_level() && @ob_end_clean()) {}
+            if ($targetObj == 'FILE' && $cacheManager = $this->getCacheManager()) {
+                $filename = isset($targetOptions['filename']) ? $targetOptions['filename'] : 'error.log';
+                $filepath = isset($targetOptions['filepath']) ? $targetOptions['filepath'] : $this->getCachePath() . xPDOCacheManager::LOG_DIR;
+                $cacheManager->writeFile($filepath . $filename, '[' . date('Y-m-d H:i:s') . '] (' . $this->_getLogLevel($level) . $def . $file . $line . ') ' . $msg . "\n" . ($this->getDebug() === true ? '<pre>' . "\n" . print_r(debug_backtrace(), true) . "\n" . '</pre>' : ''), 'a');
+            }
+            $this->sendError('fatal');
+        }
+
+        $logger = $this->logger;
+        $this->logger = null;
+        try {
+            parent::_log($level, $msg, $target, $def, $file, $line);
+        } finally {
+            $this->logger = $logger;
         }
     }
 
@@ -2991,6 +3043,59 @@ class modX extends xPDO {
         }
         $register->send('', [$messageKey => $message], $options);
         $this->_logSequence++;
+    }
+
+    /**
+     * Dispatch a log message to the PSR-3 logger.
+     *
+     * Maps xPDO log levels to PSR-3 levels and builds a context array.
+     * File and line are passed as-is (no backtrace resolution); Monolog users
+     * can add IntrospectionProcessor for automatic caller info.
+     *
+     * @param int $level The xPDO log level constant.
+     * @param mixed $msg The log message.
+     * @param string $def The defining structure (class/method).
+     * @param string $file The source filename, if provided by the caller.
+     * @param string $line The source line number, if provided by the caller.
+     */
+    private function _dispatchToPsrLogger($level, $msg, $def, $file, $line): void
+    {
+        if (is_string($msg)) {
+            $message = $msg;
+        } elseif (is_object($msg) && method_exists($msg, '__toString')) {
+            $message = (string) $msg;
+        } else {
+            $message = print_r($msg, true);
+        }
+
+        $context = [
+            'def' => $def,
+            'file' => $file,
+            'line' => $line,
+            'xpdo_level' => $level,
+        ];
+
+        switch ($level) {
+            case xPDO::LOG_LEVEL_DEBUG:
+                $psrLevel = LogLevel::DEBUG;
+                break;
+            case xPDO::LOG_LEVEL_INFO:
+                $psrLevel = LogLevel::INFO;
+                break;
+            case xPDO::LOG_LEVEL_WARN:
+                $psrLevel = LogLevel::WARNING;
+                break;
+            case xPDO::LOG_LEVEL_ERROR:
+                $psrLevel = LogLevel::ERROR;
+                break;
+            case xPDO::LOG_LEVEL_FATAL:
+                $psrLevel = LogLevel::CRITICAL;
+                break;
+            default:
+                $psrLevel = LogLevel::NOTICE;
+        }
+
+        $this->logger->log($psrLevel, $message, $context);
     }
 
     /**


### PR DESCRIPTION
## What this does

Previously MODX hasn't supported PSR-3 logging. This was added to xPDO (commit https://github.com/modxcms/xpdo/commit/55fd34318a86d9ebe2cf01564c7126d90034af2c) but `modX::_log()` overrides it in several code paths, so a logger registered on xPDO never sees all of MODX's log output.

This PR adds `setLogger(LoggerInterface $logger)` to MODX, restructures `_log()` to dispatch to a PSR-3 logger when one is set, and adds 20 new tests (11 baseline, 9 PSR-3).

```php
use Monolog\Logger;
use Monolog\Handler\StreamHandler;

$logger = new Logger('modx');
$logger->pushHandler(new StreamHandler('/path/to/modx.log', Logger::DEBUG));
$logger->pushProcessor(new Monolog\Processor\IntrospectionProcessor());

$modx->setLogger($logger);
$modx->setLogLevel(modX::LOG_LEVEL_DEBUG); // control what reaches the logger
```

## Backward compatibility

When no PSR-3 logger is registered (`$this->logger === null`, the default), all logging behaviour is identical to the previous implementation. I added 11 tests as a baseline to verify this.

## Design decisions and alternatives

Three questions came up during implementation where the answer isn't obvious. I went back and forth on them @opengeek and picked one to finish the code, but without a strong view on them.

### 1. Should the PSR-3 logger respect MODX's `logLevel`, or receive everything?

- **A. Respect `logLevel` (chosen):** The PSR-3 logger only sees messages that pass the `logLevel` threshold. Users call `$modx->setLogLevel(modX::LOG_LEVEL_DEBUG)` when they want full visibility, and can filter further in their logger config (e.g. Monolog handler levels).

- **B. Send everything to the logger:** The PSR-3 logger receives all messages regardless of `logLevel`. The logger's own filtering decides what to keep.

I chose A because it seemed right, but have been doubting that since. Initially I chose 2B (below) so it made sense for performance, as every `log()` call that isn't filtered out early triggers `debug_backtrace()` in the legacy path to resolve the calling file and line. The early `logLevel` check (an integer comparison) skips all that work for messages below threshold. With option B and the default `LOG_LEVEL_ERROR`, every DEBUG/INFO/WARN call would still build context and dispatch to the logger. The cost of A is one extra line of config (`setLogLevel`) when setting up a logger.

But then I switched to 2A so the performance impact of 1B would be minimal.

**To switch to B:** Remove the early return at the top of `_log()` for the PSR-3 path.

### 2. Should `debug_backtrace()` be called for the PSR-3 path?

- **A. Skip backtrace for PSR-3 (chosen):** The `file` and `line` context fields are only populated if the caller passed them (e.g. `__FILE__`, `__LINE__`). When not provided, they're empty strings. Monolog users add `IntrospectionProcessor` for automatic caller info.

- **B. Always resolve backtrace:** Every log call resolves the backtrace so that `file`/`line` are always in the PSR-3 context, matching legacy behavior.

I chose A because `debug_backtrace()` is the most expensive operation in the log path. I felt this should be left to the developer as e.g. Monolog's `IntrospectionProcessor` does the same thing but only for messages that survive handler-level filtering. So a DEBUG message discarded by the handler never triggers a backtrace.

**To switch to B:** Move the backtrace resolution to before the `_dispatchToPsrLogger()` call, so the PSR-3 context always has file/line. Simpler for users who don't want to configure logging processors, but costs a backtrace on every dispatched log call.

### 3. Should the PSR-3 logger replace legacy output, or be additive?

- **A. Replace legacy output (chosen):** When a PSR-3 logger is set, legacy FILE/ECHO/HTML/ARRAY output is suppressed. Only modRegister logging is preserved alongside the PSR-3 logger.

- **B. Additive (both):** Both the PSR-3 logger and legacy targets receive messages. The existing `error.log` continues alongside the custom logger.

- **C. Configurable:** Add an option (e.g. `psr_logger_exclusive`) to let users choose at runtime.

I chose A because if you've set up a PSR-3 logger, you're taking control of where logs go. Writing to `error.log` at the same time is confusing and wasteful. modRegister is preserved because it's a message queue, not traditional logging.

**To switch to B:** In the restructured `_log()`, remove the early return after the PSR-3 dispatch and let execution fall through to the legacy path. The `$this->logger = null` / `try/finally` pattern already exists for the legacy `parent::_log()` call and would prevent double-dispatch.

**To switch to C:** Add a config option check before the early return, e.g.:
```php
if ($hasPsrLogger && $this->getOption('psr_logger_exclusive', null, true)) {
    // skip legacy
    return;
}
// fall through to legacy path
```

### Other notes

- **xPDOLogger exclusion:** The bundled `xPDOLogger` (standalone xPDO's default logger) is excluded from MODX's PSR-3 dispatch. Its `handleXpdo()` calls `exit()` for FATAL, while MODX uses `sendError('fatal')` which renders a proper error page. Allowing `xPDOLogger` would change the current MODX behaviour, so I've assumed it is for standalone xPDO use only.

- **FATAL handling:** MODX uses `sendError('fatal')` for fatal log messages, not `exit()`. The PSR-3 logger receives the FATAL message (mapped to `LogLevel::CRITICAL`) before `sendError()` runs.

- **Backward compatibility:** When no PSR-3 logger is set (`$this->logger === null`, the default), behavior is identical to the previous implementation. The baseline tests verify this.

### Related issue(s)/PR(s)
- https://github.com/modxcms/revolution/issues/12262

