### PR TITLE
Fix PHP warning: Undefined variable $image

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -2341,7 +2341,7 @@ QTIP;
         }
 
         return [
-            'src' => $image,
+            'src' => $image ?? '',
             'width' => $width,
             'height' => $height,
         ];


### PR DESCRIPTION
### What does it do?
Use the null coalescing operator to assign an empty string when $image is not defined

### Why is it needed?
PHP warning: Undefined variable $image