### PR TITLE
Fix PHP warning: Undefined array key "updateable"

### DIFF
--- a/core/src/Revolution/Processors/SoftwareUpdate/GetList.php
+++ b/core/src/Revolution/Processors/SoftwareUpdate/GetList.php
@@ -136,7 +136,7 @@ class GetList extends Base
                 $tmp = $packagesProcessor->checkForUpdates($package, $tmp);
                 if (!empty($tmp['updateable'])) {
                     $categoryData['names'][] = $package->get('package_name');
-                    $categoryData['updateable'] = (!empty($categoryData['updateable'])) ? $categoryData['updateable']++ : 1;
+                    $categoryData['updateable'] = (isset($categoryData['updateable'])) ? $categoryData['updateable']++ : 1;
                 }
             }
         }

--- a/core/src/Revolution/Processors/SoftwareUpdate/GetList.php
+++ b/core/src/Revolution/Processors/SoftwareUpdate/GetList.php
@@ -136,7 +136,7 @@ class GetList extends Base
                 $tmp = $packagesProcessor->checkForUpdates($package, $tmp);
                 if (!empty($tmp['updateable'])) {
                     $categoryData['names'][] = $package->get('package_name');
-                    $categoryData['updateable']++;
+                    $categoryData['updateable'] = (!empty($categoryData['updateable'])) ? $categoryData['updateable']++ : 1;
                 }
             }
         }


### PR DESCRIPTION
### What does it do?
Initialise the array key updateable before using it.

### Why is it needed?
PHP warning: Undefined array key "updateable"