### PR TITLE
fix(manager): scope trash and deleted counts to listable contexts

### DIFF
--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -12,7 +13,9 @@
 namespace MODX\Revolution\Tests\Model;
 
 use MODX\Revolution\modCacheManager;
+use MODX\Revolution\modContext;
 use MODX\Revolution\modParser;
+use MODX\Revolution\modResource;
 use MODX\Revolution\modX;
 use MODX\Revolution\MODxTestCase;
 use stdClass;
@@ -392,5 +395,74 @@ class modXTest extends MODxTestCase
             [6, null, [], [7, 8, 9, 10, 11, 12, 13, 14, 15, 16]],
             [22, 2, ['context' => 'custom'], [23, 24]]
         ];
+    }
+
+    /**
+     * Unknown context key must not be treated as listable in the manager.
+     */
+    public function testIsContextListableByCurrentUserReturnsFalseForMissingContext()
+    {
+        $this->assertFalse($this->modx->isContextListableByCurrentUser('__no_such_context_modx_test__'));
+    }
+
+    /**
+     * When a context exists, listability must match modContext::checkPolicy('list').
+     *
+     * @param string $contextKey
+     * @dataProvider providerKnownContextKeysForListPolicy
+     */
+    public function testIsContextListableByCurrentUserMatchesContextListPolicy($contextKey)
+    {
+        $context = $this->modx->getContext($contextKey);
+        if (!($context instanceof modContext)) {
+            $this->markTestSkipped("Context {$contextKey} is not available in this database fixture.");
+        }
+        $expected = $context->checkPolicy('list');
+        $this->assertSame(
+            $expected,
+            $this->modx->isContextListableByCurrentUser($contextKey),
+            "isContextListableByCurrentUser({$contextKey}) must match context list policy"
+        );
+    }
+
+    /**
+     * @return array<int, array{0: string}>
+     */
+    public function providerKnownContextKeysForListPolicy()
+    {
+        return [
+            ['web'],
+            ['mgr'],
+        ];
+    }
+
+    /**
+     * Deleted count scoped to listable contexts must not exceed all deleted resources.
+     */
+    public function testCountDeletedResourcesInListableContextsIsBoundedByAllDeleted()
+    {
+        $scoped = $this->modx->countDeletedResourcesInListableContexts();
+        $allDeleted = (int) $this->modx->getCount(modResource::class, ['deleted' => 1]);
+        $this->assertGreaterThanOrEqual(0, $scoped);
+        $this->assertLessThanOrEqual($allDeleted, $scoped);
+    }
+
+    /**
+     * Single-query counter must match per-context sum (guards context_key:IN optimization).
+     */
+    public function testCountDeletedResourcesInListableContextsMatchesPerContextSum()
+    {
+        $expected = 0;
+        $contexts = $this->modx->getCollection(modContext::class, ['key:!=' => 'mgr']);
+        foreach ($contexts as $ctx) {
+            if (!$ctx->checkPolicy('list')) {
+                continue;
+            }
+            $expected += (int) $this->modx->getCount(modResource::class, [
+                'deleted' => 1,
+                'context_key' => $ctx->get('key'),
+            ]);
+        }
+        $this->assertSame($expected, $this->modx->countDeletedResourcesInListableContexts());
     }
 }

--- a/core/src/Revolution/Processors/Resource/EmptyRecycleBin.php
+++ b/core/src/Revolution/Processors/Resource/EmptyRecycleBin.php
@@ -53,7 +53,12 @@ class EmptyRecycleBin extends Processor
         $ids = [];
         /** @var modResource $resource */
         foreach ($resources as $resource) {
-            if (!$resource->checkPolicy('delete')) continue;
+            if (!$this->modx->isContextListableByCurrentUser($resource->get('context_key'))) {
+                continue;
+            }
+            if (!$resource->checkPolicy('delete')) {
+                continue;
+            }
 
             $resourceGroupResources = $resource->getMany('ResourceGroupResources');
             $templateVarResources = $resource->getMany('TemplateVarResources');

--- a/core/src/Revolution/Processors/Resource/GetToolbar.php
+++ b/core/src/Revolution/Processors/Resource/GetToolbar.php
@@ -87,7 +87,7 @@ class GetToolbar extends Processor
         unset($context);
         $items[] = '->';
         if ($this->modx->hasPermission('purge_deleted')) {
-            $deletedResources = $this->modx->getCount(modResource::class, ['deleted' => 1]);
+            $deletedResources = $this->modx->countDeletedResourcesInListableContexts();
 
             $items[] = [
                 'id' => 'emptifier',

--- a/core/src/Revolution/Processors/Resource/Trash/GetList.php
+++ b/core/src/Revolution/Processors/Resource/Trash/GetList.php
@@ -115,18 +115,16 @@ class GetList extends GetListProcessor
         $c->where([
             $c->getAlias() . '.deleted' => true
         ]);
+        $resources = [];
         if ($c->prepare() && $c->stmt->execute()) {
             $resources = $c->stmt->fetchAll(PDO::FETCH_ASSOC);
         }
-        /*
-            TODO:
-            Filter out resources where user does not have at least one of the permissions
-            applicable to the actions available in the trash manager:
-            1. undelete_document - restore resource
-            2. purge_deleted - permanently destroy resource
-        */
+
         $deleted = [];
         foreach ($resources as $resource) {
+            if (!$this->modx->isContextListableByCurrentUser($resource['context_key'])) {
+                continue;
+            }
             $deleted[] = (int)$resource['id'];
             $children = $this->modx->getChildIds($resource['id'], 10, ['context' => $resource['context_key']]);
             $deleted = array_merge($deleted, $children);
@@ -140,11 +138,7 @@ class GetList extends GetListProcessor
      */
     public function prepareRow(xPDOObject $object)
     {
-        // quick exit if we don't have access to the context
-        // this is a strange workaround: obviously we can access the resources even if we don't have access to the context! Check that
-        // TODO check if that is the same for resource groups
-        $context = $this->modx->getContext($object->get('context_key'));
-        if (!$context) {
+        if (!$this->modx->isContextListableByCurrentUser($object->get('context_key'))) {
             return [];
         }
 

--- a/core/src/Revolution/Processors/Resource/Trash/Purge.php
+++ b/core/src/Revolution/Processors/Resource/Trash/Purge.php
@@ -78,16 +78,22 @@ class Purge extends Processor
         foreach ($this->resources as $resource) {
             $contextKey = $resource->get('context_key');
             if (!$this->modx->isContextListableByCurrentUser($contextKey)) {
-                $this->modx->log(modX::LOG_LEVEL_WARN,
-                    '[purge] context access denied for resource ' . $resource->id . ' in context ' . $contextKey);
+                $this->modx->log(
+                    modX::LOG_LEVEL_WARN,
+                    '[purge] context access denied for resource ' . $resource->id . ' in context ' . $contextKey
+                );
                 $this->failures[] = $resource->id;
                 continue;
             }
             if (!$resource->checkPolicy($policies_needed)) {
                 $canSave = $resource->checkPolicy(['save']);
                 $canDelete = $resource->checkPolicy(['delete']);
-                $this->modx->log(modX::LOG_LEVEL_WARN,
-                    '[purge] permissions denied for resource ' . $resource->id . ': save_ok=' . ($canSave ? '1' : '0') . ', delete_ok=' . ($canDelete ? '1' : '0'));
+                $this->modx->log(
+                    modX::LOG_LEVEL_WARN,
+                    '[purge] permissions denied for resource ' . $resource->id
+                    . ': save_ok=' . ($canSave ? '1' : '0')
+                    . ', delete_ok=' . ($canDelete ? '1' : '0')
+                );
                 $this->failures[] = $resource->id;
                 continue;
             }

--- a/core/src/Revolution/Processors/Resource/Trash/Purge.php
+++ b/core/src/Revolution/Processors/Resource/Trash/Purge.php
@@ -76,24 +76,22 @@ class Purge extends Processor
             'edit' => true,
         ];
         foreach ($this->resources as $resource) {
-            $context_allowed = $this->modx->getContext($resource->get('context_key'));
-            $policy_allowed = $resource->checkPolicy($policies_needed);
-
-            // again, if we do not want to allow deleting of resources in contexts we are not allowed to see, we have to check that manually
-            // this _should_ be done by the resources checkPolicy
-            if (!$context_allowed) {
+            $contextKey = $resource->get('context_key');
+            if (!$this->modx->isContextListableByCurrentUser($contextKey)) {
                 $this->modx->log(modX::LOG_LEVEL_WARN,
-                    '[purge] context access denied for resource ' . $resource->id . ' in context ' . $resource->get('context_key'));
+                    '[purge] context access denied for resource ' . $resource->id . ' in context ' . $contextKey);
                 $this->failures[] = $resource->id;
+                continue;
             }
-            if (!$policy_allowed) {
+            if (!$resource->checkPolicy($policies_needed)) {
+                $canSave = $resource->checkPolicy(['save']);
+                $canDelete = $resource->checkPolicy(['delete']);
                 $this->modx->log(modX::LOG_LEVEL_WARN,
-                    '[purge] permissions denied for resource ' . $resource->id . ': save=' . !$resource->checkPolicy(['save']) . ', delete=' . $resource->checkPolicy(['delete']));
+                    '[purge] permissions denied for resource ' . $resource->id . ': save_ok=' . ($canSave ? '1' : '0') . ', delete_ok=' . ($canDelete ? '1' : '0'));
                 $this->failures[] = $resource->id;
+                continue;
             }
-            if ($policy_allowed && $context_allowed) {
-                $success[] = $resource->id;
-            }
+            $success[] = $resource->id;
         }
 
         // we refresh the resources list here for the processor
@@ -131,6 +129,10 @@ class Purge extends Processor
 
         /** @var modResource $resource */
         foreach ($this->resources as $resource) {
+            if (!$this->modx->isContextListableByCurrentUser($resource->get('context_key'))) {
+                $this->failures[] = $resource->get('id');
+                continue;
+            }
             if (!$resource->checkPolicy($permissionsForPurge)) {
                 continue;
             }
@@ -198,7 +200,7 @@ class Purge extends Processor
             }
         }
 
-        $deletedCount = $this->modx->getCount(modResource::class, ['deleted' => 1]);
+        $deletedCount = $this->modx->countDeletedResourcesInListableContexts();
 
         return $this->success($msg, [
             'count_success' => count($success),

--- a/core/src/Revolution/Processors/Resource/Trash/Restore.php
+++ b/core/src/Revolution/Processors/Resource/Trash/Restore.php
@@ -80,9 +80,12 @@ class Restore extends Processor
         $contexts = [];
 
         foreach ($this->resources as $resource) {
-            $contexts[] = $resource->get('context_key');
-
             $id = $resource->get('id');
+
+            if (!$this->modx->isContextListableByCurrentUser($resource->get('context_key'))) {
+                $this->failures[] = $id;
+                continue;
+            }
 
             if (!$this->addLock($resource)) {
                 $lockedUser = $this->modx->getObject(modUser::class, $resource->getLock());
@@ -108,6 +111,7 @@ class Restore extends Processor
                 return $this->failure($this->modx->lexicon('resource_err_undelete'));
             } else {
                 $this->success[] = $id;
+                $contexts[] = $resource->get('context_key');
             }
 
             $this->fireAfterUnDeleteEvent($resource);
@@ -116,8 +120,16 @@ class Restore extends Processor
             $this->logManagerAction($resource);
             $this->removeLock($resource);
         }
+
+        if (count($this->success) === 0 && count($this->failures) > 0) {
+            return $this->failure($this->modx->lexicon('trash.restore_err', [
+                'list' => implode(', ', $this->failures),
+                'count_failures' => count($this->failures),
+            ]));
+        }
+
         /* empty cache */
-        $this->clearCache($contexts);
+        $this->clearCache(array_values(array_unique($contexts)));
 
         $outputArray = $resource->get(['id']);
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2169,6 +2169,39 @@ class modX extends xPDO {
     }
 
     /**
+     * Whether the current user may list the context in the manager (same rule as the resource tree).
+     */
+    public function isContextListableByCurrentUser(string $contextKey): bool
+    {
+        $context = $this->getContext($contextKey);
+
+        return $context instanceof modContext && $context->checkPolicy('list');
+    }
+
+    /**
+     * Count of deleted resources only in contexts the current user may list in the manager.
+     */
+    public function countDeletedResourcesInListableContexts(): int
+    {
+        $listableKeys = [];
+        $contexts = $this->getCollection(modContext::class, ['key:!=' => 'mgr']);
+        foreach ($contexts as $ctx) {
+            if ($ctx->checkPolicy('list')) {
+                $listableKeys[] = $ctx->get('key');
+            }
+        }
+
+        if ($listableKeys === []) {
+            return 0;
+        }
+
+        return (int) $this->getCount(modResource::class, [
+            'deleted' => 1,
+            'context_key:IN' => $listableKeys,
+        ]);
+    }
+
+    /**
      * Gets a map of events and registered plugins for the specified context.
      *
      * Service #s:

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -1607,13 +1607,13 @@ class modX extends xPDO {
         if (!empty ($src) && !array_key_exists($src, $this->loadedjscripts)) {
             if (isset ($this->loadedjscripts[$src]))
                 return;
-            $this->loadedjscripts[$src]= true;
+            $this->loadedjscripts[$src] = true;
             if ($plaintext == true) {
-                $this->sjscripts[count($this->sjscripts)]= $src;
+                $this->sjscripts[count($this->sjscripts)] = $src;
             } elseif (strpos(strtolower($src), "<script") !== false) {
-                $this->sjscripts[count($this->sjscripts)]= $src;
+                $this->sjscripts[count($this->sjscripts)] = $src;
             } else {
-                $this->sjscripts[count($this->sjscripts)]= '<script src="' . $src . '"></script>';
+                $this->sjscripts[count($this->sjscripts)] = '<script src="' . $src . '"></script>';
             }
         }
     }
@@ -1630,13 +1630,13 @@ class modX extends xPDO {
     public function regClientScript($src, $plaintext= false) {
         if (isset ($this->loadedjscripts[$src]))
             return;
-        $this->loadedjscripts[$src]= true;
+        $this->loadedjscripts[$src] = true;
         if ($plaintext == true) {
-            $this->jscripts[count($this->jscripts)]= $src;
+            $this->jscripts[count($this->jscripts)] = $src;
         } elseif (strpos(strtolower($src), "<script") !== false) {
-            $this->jscripts[count($this->jscripts)]= $src;
+            $this->jscripts[count($this->jscripts)] = $src;
         } else {
-            $this->jscripts[count($this->jscripts)]= '<script src="' . $src . '"></script>';
+            $this->jscripts[count($this->jscripts)] = '<script src="' . $src . '"></script>';
         }
     }
 


### PR DESCRIPTION
### What changed and why

Trash listing, purge, restore, empty-recycle-bin, and the manager toolbar deleted-resource counter used context access checks that did not match the resource tree. Users who cannot **list** a context could still see counts or act on deleted resources there.

This PR adds `modX::isContextListableByCurrentUser()` and `modX::countDeletedResourcesInListableContexts()`, then wires them through trash processors and `GetToolbar`.

### How to test

Run `modXTest` (listable-context helpers and counter consistency).

In the manager, as a user with access to only some contexts: trash grid, purge/restore/empty bin, and the deleted-resources toolbar count should only reflect contexts the user can list.

### Related issue(s)/PR(s)

Resolves #13491

### Compatibility notes

Manager-only. Behavior depends on context **list** policy (`modContext::checkPolicy('list')`), same rule as the resource tree.

### Breaking change assessment

No API signature changes. Stricter scoping for trash and counts; sites that relied on cross-context visibility for users without list permission will see less data. Patch-safe for typical ACL setups.

### Test coverage

PHPUnit in `modXTest` for the new helpers and counter consistency with a per-context sum.

### Contributors

None beyond author.

### AI tool use

Cursor helped normalize this PR description to the repository template.