### PR TITLE
Catch failure checking S3 file visibility

### DIFF
--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -663,7 +663,7 @@ class modS3MediaSource extends modMediaSource
         if ($this->visibility_dirs) {
             try {
                 return $this->filesystem->visibility($path);
-            } catch (\Exception | FilesystemException $exception) {
+            } catch (FilesystemException | UnableToRetrieveMetadata $exception) {
                 $this->xpdo->log(modX::LOG_LEVEL_INFO, $exception->getMessage());
             }
         }

--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -652,7 +652,7 @@ class modS3MediaSource extends modMediaSource
             try {
                 return $this->filesystem->visibility($path);
             } catch (\Exception | FilesystemException $exception) {
-                $this->xpdo->log(modX::LOG_LEVEL_ERROR, $exception->getMessage());
+                $this->xpdo->log(modX::LOG_LEVEL_INFO, $exception->getMessage());
             }
         }
         return false;
@@ -664,7 +664,7 @@ class modS3MediaSource extends modMediaSource
             try {
                 return $this->filesystem->visibility($path);
             } catch (\Exception | FilesystemException $exception) {
-                $this->xpdo->log(modX::LOG_LEVEL_ERROR, $exception->getMessage());
+                $this->xpdo->log(modX::LOG_LEVEL_INFO, $exception->getMessage());
             }
         }
         return false;

--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -651,7 +651,7 @@ class modS3MediaSource extends modMediaSource
         if ($this->visibility_files) {
             try {
                 return $this->filesystem->visibility($path);
-            } catch (\Exception | FilesystemException $exception) {
+            } catch (FilesystemException | UnableToRetrieveMetadata $exception) {
                 $this->xpdo->log(modX::LOG_LEVEL_INFO, $exception->getMessage());
             }
         }

--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -649,7 +649,11 @@ class modS3MediaSource extends modMediaSource
     public function getVisibilityFile($path)
     {
         if ($this->visibility_files) {
-            return $this->filesystem->visibility($path);
+            try {
+                return $this->filesystem->visibility($path);
+            } catch (\Exception | FilesystemException $exception) {
+                $this->xpdo->log(modX::LOG_LEVEL_ERROR, $exception->getMessage());
+            }
         }
         return false;
     }
@@ -657,7 +661,11 @@ class modS3MediaSource extends modMediaSource
     public function getVisibilityDirectory($path)
     {
         if ($this->visibility_dirs) {
-            return $this->filesystem->visibility($path);
+            try {
+                return $this->filesystem->visibility($path);
+            } catch (\Exception | FilesystemException $exception) {
+                $this->xpdo->log(modX::LOG_LEVEL_ERROR, $exception->getMessage());
+            }
         }
         return false;
     }


### PR DESCRIPTION
### What does it do?
Adds a catch around the `$this->filesystem->visibility` function call in S3 media sources.

### Why is it needed?
Visibility can throw a `FilesystemException` exception if it is not implemented in the user's permissions. https://github.com/thephpleague/flysystem/blob/8aaffb653c5777781b0f7f69a5d937baf7ab6cdb/src/FilesystemAdapter.php#L68

### How to test
Ran into this on a site where the user did not have permissions to retrieve object metadata. However, I'm unsure how to replicate that. 
