### PR TITLE
Update Resource preview to support settings tag in Weblinks

### DIFF
--- a/core/lexicon/en/resource.inc.php
+++ b/core/lexicon/en/resource.inc.php
@@ -92,6 +92,7 @@ $_lang['resource_err_unpublish_errorpage_dates'] = 'The resource is linked to th
 $_lang['resource_err_unpublish_siteunavailable'] = 'The resource is linked to the site_unavailable_page variable and cannot be unpublished!';
 $_lang['resource_err_unpublish_siteunavailable_dates'] = 'The resource is linked to the site_unavailable_page variable and cannot have publish or unpublish dates set!';
 $_lang['resource_err_weblink_invalid'] = 'The weblink content “[[+content]]” provided in Resource id [[+id]] is invalid.';
+$_lang['resource_err_weblink_setting_empty'] = 'The weblink content in Resource id [[+id]] is provided by the setting “[[+setting]]” but that setting’s value is empty.';
 $_lang['resource_err_weblink_target_nf'] = 'You cannot set a weblink to a resource that does not exist.';
 $_lang['resource_err_weblink_target_self'] = 'You cannot set a weblink to itself.';
 $_lang['resource_folder'] = 'Container';

--- a/core/src/Revolution/modResource.php
+++ b/core/src/Revolution/modResource.php
@@ -1781,7 +1781,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
                 // Found URL, e.g., http[s]://www.mysite.com
                 return $linkContent;
             } elseif (preg_match('/^\[{2}~(\d+)\s?\?([^[]*)\]{2}$/', $linkContent, $match)) {
-                // Link tag with options, e.g., [[~45? &scheme=`abs`]]
+                // Found link tag with options, e.g., [[~45? &scheme=`abs`]]
                 $targetId = $match[1];
                 if (!$this->canPreviewResource($targetId, $id)) {
                     return '';
@@ -1799,7 +1799,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
                 }
                 return $url;
             } elseif (preg_match('/^\[{2}\+{2}([^[]*)\]{2}$/', $linkContent, $match)) {
-                // Link tag with settings, e.g., [[++setting-name]]
+                // Found settings tag, e.g., [[++setting-name]]
                 $targetContent = trim($this->parseContent());
                 if (empty($targetContent)) {
                     $msg = $this->xpdo->lexicon(

--- a/core/src/Revolution/modResource.php
+++ b/core/src/Revolution/modResource.php
@@ -1798,6 +1798,25 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
                     $url = rtrim($url, '&');
                 }
                 return $url;
+            } elseif (preg_match('/^\[{2}\+{2}([^[]*)\]{2}$/', $linkContent, $match)) {
+                // Link tag with settings, e.g., [[++setting-name]]
+                $targetContent = trim($this->parseContent());
+                if (empty($targetContent)) {
+                    $msg = $this->xpdo->lexicon(
+                        'resource_err_weblink_setting_empty',
+                        ['id' => $id, 'setting' => $match[1]]
+                    );
+                    $this->xpdo->log(modX::LOG_LEVEL_ERROR, $msg);
+                    return '';
+                }
+                if (strpos($targetContent, 'http') === 0) {
+                    return $targetContent;
+                } else {
+                    if (!$this->canPreviewResource($targetContent, $id)) {
+                        return '';
+                    }
+                    $urlArgs[0] = $targetContent;
+                }
             } else {
                 // Invalid link data
                 $msg = $this->xpdo->lexicon(


### PR DESCRIPTION
### What changed and why

Added condition in `getPreviewUrl` to take system settings (including ones created by Extras like ClientConfig) into account and parse them before checking validity. Previously, Weblinks with valid targets (Resource or static URLs) supplied by a setting tag would cause preview to fail and an error message to be logged.

### How to test

1. Create a system setting and store either the ID of an existing, viewable Resource or a static URL. 
2. Use this setting as the content value in a new Weblink.
3. Verify that the "View" button (as well as context menu item in the tree) is active and leads to the expected Resource or website.

### Related issue(s)/PR(s)

This PR addresses the issue raised in the [MODX Community forum](https://community.modx.com/t/clientconfig-setting-not-working-in-weblinks/8986) by @SnowCreative.

UPDATE: Resolves newly-posted issue #16979

### Compatibility notes

n/a

### Breaking change assessment

n/a

### Test coverage

No pre-existing tests for this method; none currently planned.

### Contributors

See related issues above.

### AI tool use

n/a
