### PR TITLE
Fix: Make search results and tree items display in consistent manner

### DIFF
--- a/_build/templates/default/sass/_uberbar.scss
+++ b/_build/templates/default/sass/_uberbar.scss
@@ -158,6 +158,27 @@
         color: $searchResultsColor;
       }
     }
+
+    &.disabled,
+    &.unpublished {
+      em {
+        opacity: 1;
+      }
+    }
+
+    &.disabled {
+      color: $unpublished;
+      i.icon {
+        color: $unpublished;
+      }
+    }
+
+    &.deleted {
+      a {
+        text-decoration: $delTextDeco;
+      }
+    }
+
   }
 
   .icon-user {

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -161,7 +161,7 @@ class Search extends Processor
                 'name' => $this->modx->hasPermission('tree_show_resource_ids')
                     ? $record->get('pagetitle') . ' (' . $record->get('id') . ')'
                     : $record->get('pagetitle'),
-                '_action' => 'resource/update&id=' . $record->get('id'),
+                'resultLinkAction' => 'resource/update&id=' . $record->get('id'),
                 'description' => $record->get('description'),
                 'type' => static::TYPE_RESOURCE . 's',
                 'class' => $record->get('class_key'),
@@ -214,7 +214,7 @@ class Search extends Processor
             $data = [
                 'name' => $record->get($nameField),
                 'description' => $record->get($descriptionField),
-                '_action' => 'element/' . $type . '/update&id=' . $record->get('id'),
+                'resultLinkAction' => 'element/' . $type . '/update&id=' . $record->get('id'),
                 'type' => $type . 's',
                 'class' => $class,
                 'attributes' => $attributes
@@ -265,7 +265,7 @@ class Search extends Processor
             $data = [
                 'name' => $record->get('username'),
                 'description' => $record->get('fullname') . ' / ' . $record->get('email'),
-                '_action' => 'security/user/update&id=' . $record->get('internalKey'),
+                'resultLinkAction' => 'security/user/update&id=' . $record->get('internalKey'),
                 'type' => static::TYPE_USER . 's',
                 'attributes' => $attributes
             ];

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -9,7 +10,6 @@
  */
 
 namespace MODX\Revolution\Processors\Search;
-
 
 use MODX\Revolution\modChunk;
 use MODX\Revolution\modContext;
@@ -117,14 +117,14 @@ class Search extends Processor
         $c->select('modTemplate.icon as icon');
 
         $querySearch = [
-            'modResource.pagetitle:LIKE' => '%' . $this->query .'%',
-            'OR:modResource.longtitle:LIKE' => '%' . $this->query .'%',
-            'OR:modResource.alias:LIKE' => '%' . $this->query .'%',
-            'OR:modResource.description:LIKE' => '%' . $this->query .'%',
-            'OR:modResource.introtext:LIKE' => '%' . $this->query .'%',
+            'modResource.pagetitle:LIKE' => '%' . $this->query . '%',
+            'OR:modResource.longtitle:LIKE' => '%' . $this->query . '%',
+            'OR:modResource.alias:LIKE' => '%' . $this->query . '%',
+            'OR:modResource.description:LIKE' => '%' . $this->query . '%',
+            'OR:modResource.introtext:LIKE' => '%' . $this->query . '%',
         ];
         if ($this->searchInContent()) {
-            $querySearch['OR:modResource.content:LIKE'] = '%' . $this->query .'%';
+            $querySearch['OR:modResource.content:LIKE'] = '%' . $this->query . '%';
         }
         $querySearch['OR:modResource.id:='] = $this->query;
         $queryContext = [
@@ -178,10 +178,10 @@ class Search extends Processor
         $c = $this->modx->newQuery($class);
         $querySearch = [
             $nameField . ':LIKE' => '%' . $this->query . '%',
-            'OR:' . $descriptionField . ':LIKE' => '%' . $this->query .'%',
+            'OR:' . $descriptionField . ':LIKE' => '%' . $this->query . '%',
         ];
         if ($this->searchInContent() && !empty($contentField)) {
-            $querySearch['OR:' . $contentField . ':LIKE'] = '%' . $this->query .'%';
+            $querySearch['OR:' . $contentField . ':LIKE'] = '%' . $this->query . '%';
         }
         $querySearch['OR:id:='] = $this->query;
         $c->where($querySearch);
@@ -235,8 +235,8 @@ class Search extends Processor
         $c->leftJoin(modUserProfile::class, 'Profile');
         $c->where([
             'username:LIKE' => '%' . $this->query . '%',
-            'OR:Profile.fullname:LIKE' => '%' . $this->query .'%',
-            'OR:Profile.email:LIKE' => '%' . $this->query .'%',
+            'OR:Profile.fullname:LIKE' => '%' . $this->query . '%',
+            'OR:Profile.email:LIKE' => '%' . $this->query . '%',
             'OR:id:=' => $this->query,
         ]);
 
@@ -257,7 +257,7 @@ class Search extends Processor
             ];
             $data = [
                 'name' => $record->get('username'),
-                'description' => $record->get('fullname') .' / '. $record->get('email'),
+                'description' => $record->get('fullname') . ' / ' . $record->get('email'),
                 '_action' => 'security/user/update&id=' . $record->get('internalKey'),
                 'type' => static::TYPE_USER . 's',
                 'attributes' => $attributes

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -17,6 +17,7 @@ use MODX\Revolution\modElement;
 use MODX\Revolution\modPlugin;
 use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modResource;
+use MODX\Revolution\modStaticResource;
 use MODX\Revolution\modSnippet;
 use MODX\Revolution\modTemplate;
 use MODX\Revolution\modTemplateVar;
@@ -137,9 +138,19 @@ class Search extends Processor
         $c->limit($this->getMaxResults());
 
         $collection = $this->modx->getIterator(modResource::class, $c);
+
         /** @var modResource $record */
         foreach ($collection as $record) {
-            $this->results[] = [
+            $attributes = [
+                'isFolder' => $record->get('isfolder'),
+                'isStatic' => $record->get('class_key') === modStaticResource::class,
+                'status' => [
+                    'published' => $record->get('published'),
+                    'deleted' => $record->get('deleted'),
+                    'hidemenu' => $record->get('hidemenu')
+                ]
+            ];
+            $data = [
                 'name' => $this->modx->hasPermission('tree_show_resource_ids')
                     ? $record->get('pagetitle') . ' (' . $record->get('id') . ')'
                     : $record->get('pagetitle'),
@@ -147,8 +158,10 @@ class Search extends Processor
                 'description' => $record->get('description'),
                 'type' => static::TYPE_RESOURCE . 's',
                 'class' => $record->get('class_key'),
-                'icon' => str_replace('icon-', '', $record->get('icon'))
+                'icon' => preg_replace('/^(fa-|icon-)/', '', $record->get('icon')),
+                'attributes' => $attributes
             ];
+            $this->results[] = $data;
         }
     }
 
@@ -179,14 +192,33 @@ class Search extends Processor
 
         $collection = $this->modx->getIterator($class, $c);
 
+        $isTemplate = $class === modTemplate::class;
+
         /** @var modElement $record */
         foreach ($collection as $record) {
-            $this->results[] = [
+            $attributes = [
+                'isElement' => true,
+                'isStatic' => $record->get('static'),
+                'status' => [
+                    'disabled' => $record->get('disabled') ?? false
+                ]
+            ];
+            $data = [
                 'name' => $record->get($nameField),
                 'description' => $record->get($descriptionField),
                 '_action' => 'element/' . $type . '/update&id=' . $record->get('id'),
-                'type' => $type . 's'
+                'type' => $type . 's',
+                'class' => $class,
+                'attributes' => $attributes
             ];
+            if ($isTemplate) {
+                $customIcon = $record->get('icon');
+                $data['icon'] = !empty($customIcon)
+                    ? preg_replace('/^(fa-|icon-)/', '', $customIcon)
+                    : ''
+                    ;
+            }
+            $this->results[] = $data;
         }
     }
 
@@ -216,12 +248,21 @@ class Search extends Processor
         $collection = $this->modx->getIterator(modUser::class, $c);
 
         foreach ($collection as $record) {
-            $this->results[] = [
+            $active = $record->get('active') ?? false;
+            $blocked = $record->get('blocked') ?? false;
+            $attributes = [
+                'status' => [
+                    'disabled' => $blocked || !$active
+                ]
+            ];
+            $data = [
                 'name' => $record->get('username'),
                 'description' => $record->get('fullname') .' / '. $record->get('email'),
                 '_action' => 'security/user/update&id=' . $record->get('internalKey'),
                 'type' => static::TYPE_USER . 's',
+                'attributes' => $attributes
             ];
+            $this->results[] = $data;
         }
     }
 }

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -11,6 +11,7 @@
 
 namespace MODX\Revolution\Processors\Search;
 
+use MODX\Revolution\modContentType;
 use MODX\Revolution\modChunk;
 use MODX\Revolution\modContext;
 use MODX\Revolution\modElement;
@@ -113,15 +114,20 @@ class Search extends Processor
 
         $c = $this->modx->newQuery(modResource::class);
         $c->leftJoin(modTemplate::class, 'modTemplate', 'modResource.template = modTemplate.id');
+        $c->leftJoin(modContentType::class, 'modContentType', 'modContentType.id = modResource.content_type');
+
         $c->select($this->modx->getSelectColumns(modResource::class, 'modResource'));
-        $c->select('modTemplate.icon as icon');
+        $c->select([
+            'icon' => 'modTemplate.icon',
+            'contentTypeIcon' => 'modContentType.icon'
+        ]);
 
         $querySearch = [
             'modResource.pagetitle:LIKE' => '%' . $this->query . '%',
             'OR:modResource.longtitle:LIKE' => '%' . $this->query . '%',
             'OR:modResource.alias:LIKE' => '%' . $this->query . '%',
             'OR:modResource.description:LIKE' => '%' . $this->query . '%',
-            'OR:modResource.introtext:LIKE' => '%' . $this->query . '%',
+            'OR:modResource.introtext:LIKE' => '%' . $this->query . '%'
         ];
         if ($this->searchInContent()) {
             $querySearch['OR:modResource.content:LIKE'] = '%' . $this->query . '%';
@@ -158,7 +164,7 @@ class Search extends Processor
                 'description' => $record->get('description'),
                 'type' => static::TYPE_RESOURCE . 's',
                 'class' => $record->get('class_key'),
-                'icon' => $record->get('icon'),
+                'icon' => $record->get('contentTypeIcon') ?? $record->get('icon'),
                 'attributes' => $attributes
             ];
             $this->results[] = $data;

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -158,7 +158,7 @@ class Search extends Processor
                 'description' => $record->get('description'),
                 'type' => static::TYPE_RESOURCE . 's',
                 'class' => $record->get('class_key'),
-                'icon' => preg_replace('/^(fa-|icon-)/', '', $record->get('icon')),
+                'icon' => $record->get('icon'),
                 'attributes' => $attributes
             ];
             $this->results[] = $data;
@@ -193,6 +193,7 @@ class Search extends Processor
         $collection = $this->modx->getIterator($class, $c);
 
         $isTemplate = $class === modTemplate::class;
+        $isPlugin = $class === modPlugin::class;
 
         /** @var modElement $record */
         foreach ($collection as $record) {
@@ -200,7 +201,7 @@ class Search extends Processor
                 'isElement' => true,
                 'isStatic' => $record->get('static'),
                 'status' => [
-                    'disabled' => $record->get('disabled') ?? false
+                    'disabled' => ($isPlugin && $record->get('disabled')) || false
                 ]
             ];
             $data = [
@@ -213,10 +214,9 @@ class Search extends Processor
             ];
             if ($isTemplate) {
                 $customIcon = $record->get('icon');
-                $data['icon'] = !empty($customIcon)
-                    ? preg_replace('/^(fa-|icon-)/', '', $customIcon)
-                    : ''
-                    ;
+                if (!empty($customIcon)) {
+                    $data['icon'] = $customIcon;
+                }
             }
             $this->results[] = $data;
         }

--- a/core/src/Revolution/Processors/Search/Search.php
+++ b/core/src/Revolution/Processors/Search/Search.php
@@ -127,7 +127,8 @@ class Search extends Processor
             'OR:modResource.longtitle:LIKE' => '%' . $this->query . '%',
             'OR:modResource.alias:LIKE' => '%' . $this->query . '%',
             'OR:modResource.description:LIKE' => '%' . $this->query . '%',
-            'OR:modResource.introtext:LIKE' => '%' . $this->query . '%'
+            'OR:modResource.introtext:LIKE' => '%' . $this->query . '%',
+            'OR:modContentType.name:LIKE' => '%' . $this->query . '%'
         ];
         if ($this->searchInContent()) {
             $querySearch['OR:modResource.content:LIKE'] = '%' . $this->query . '%';

--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -27,7 +27,7 @@ MODx.SearchBar = function(config) {
         ,hasfocus:true
         ,minChars: 1
         ,displayField: 'name'
-        ,valueField: '_action'
+        ,valueField: 'resultLinkAction'
         ,width: 380
         ,itemSelector: '.x-combo-list-item'
         ,tpl: new Ext.XTemplate(
@@ -40,7 +40,7 @@ MODx.SearchBar = function(config) {
                 '<h3>{label:htmlEncode}</h3>',
             '</tpl>',
                 // Real result, make it use the default styles for a combobox dropdown with x-combo-list-item
-                '<p class="x-combo-list-item<tpl exec="values.statusClasses = this.getStatusClasses(values)">{values.statusClasses}</tpl>"><a href="?a={_action}"><tpl exec="values.icon = this.getClass(values)"><i class="icon icon-{icon:htmlEncode}"></i></tpl>{name:htmlEncode}<tpl if="description"><em> – {description:htmlEncode}</em></tpl></a></p>',
+                '<p class="x-combo-list-item<tpl exec="values.statusClasses = this.getStatusClasses(values)">{values.statusClasses}</tpl>"><a href="?a={resultLinkAction}"><tpl exec="values.icon = this.getClass(values)"><i class="icon icon-{icon:htmlEncode}"></i></tpl>{name:htmlEncode}<tpl if="description"><em> – {description:htmlEncode}</em></tpl></a></p>',
             '</div >',
             '</tpl>',
             {
@@ -135,7 +135,7 @@ MODx.SearchBar = function(config) {
             ,totalProperty: 'total'
             ,fields: [
                 'name',
-                '_action',
+                'resultLinkAction',
                 'description',
                 'type',
                 'icon',
@@ -145,7 +145,7 @@ MODx.SearchBar = function(config) {
             ]
             ,listeners: {
                 beforeload: function(store, options) {
-                    if (options.params._action) {
+                    if (options.params.resultLinkAction) {
                         // Prevent weird query on first combo box blur
                         return false;
                     }
@@ -294,7 +294,7 @@ Ext.extend(MODx.SearchBar, Ext.form.ComboBox, {
         e.stopPropagation();
         e.preventDefault();
 
-        var target = '?a=' + record.data._action;
+        var target = '?a=' + record.data.resultLinkAction;
 
         if (e.ctrlKey || e.metaKey || e.shiftKey) {
             return window.open(target);

--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -73,7 +73,8 @@ MODx.SearchBar = function(config) {
                  */
                 getClass: function(values) {
                     if (values.icon) {
-                        return values.icon;
+                        const preparedIcon = values.icon.replace(/^(fa-|icon-)/, '');
+                        return preparedIcon;
                     }
 
                     if (values.class) {

--- a/manager/assets/modext/widgets/core/modx.searchbar.js
+++ b/manager/assets/modext/widgets/core/modx.searchbar.js
@@ -40,10 +40,31 @@ MODx.SearchBar = function(config) {
                 '<h3>{label:htmlEncode}</h3>',
             '</tpl>',
                 // Real result, make it use the default styles for a combobox dropdown with x-combo-list-item
-                '<p class="x-combo-list-item"><a href="?a={_action}"><tpl exec="values.icon = this.getClass(values)"><i class="icon icon-{icon:htmlEncode}"></i></tpl>{name:htmlEncode}<tpl if="description"><em> – {description:htmlEncode}</em></tpl></a></p>',
+                '<p class="x-combo-list-item<tpl exec="values.statusClasses = this.getStatusClasses(values)">{values.statusClasses}</tpl>"><a href="?a={_action}"><tpl exec="values.icon = this.getClass(values)"><i class="icon icon-{icon:htmlEncode}"></i></tpl>{name:htmlEncode}<tpl if="description"><em> – {description:htmlEncode}</em></tpl></a></p>',
             '</div >',
-            '</tpl>'
-            ,{
+            '</tpl>',
+            {
+                getStatusClasses: function(values) {
+                    const status = values?.attributes?.status || null;
+                    let classes = '';
+                    if (status) {
+                        switch (values.type) {
+                            case 'resources':
+                                classes += !status.published ? ' unpublished' : '' ;
+                                classes += status.hidemenu ? ' hidemenu' : '' ;
+                                break;
+                            case 'plugins':
+                            case 'users':
+                                classes += status.disabled ? ' disabled' : '' ;
+                                break;
+                            // no default
+                        }
+                        classes += status.deleted ? ' deleted' : '' ;
+                        classes += values?.attributes?.isStatic ? ' static' : '' ;
+                    }
+                    return classes;
+                },
+
                 /**
                  * Get the appropriate CSS class based on the result type
                  *
@@ -58,7 +79,7 @@ MODx.SearchBar = function(config) {
                     if (values.class) {
                         switch (values.class) {
                             case 'MODX\\Revolution\\modDocument':
-                                return 'file';
+                                return values.attributes.isFolder ? 'folder' : 'file' ;
                             case 'MODX\\Revolution\\modSymLink':
                                 return 'files-o';
                             case 'MODX\\Revolution\\modWebLink':
@@ -111,7 +132,16 @@ MODx.SearchBar = function(config) {
             }
             ,root: 'results'
             ,totalProperty: 'total'
-            ,fields: ['name', '_action', 'description', 'type', 'icon', 'label', 'class']
+            ,fields: [
+                'name',
+                '_action',
+                'description',
+                'type',
+                'icon',
+                'attributes',
+                'label',
+                'class'
+            ]
             ,listeners: {
                 beforeload: function(store, options) {
                     if (options.params._action) {


### PR DESCRIPTION
### What changed and why

Added status information to search result data and a new method to the front end XTemplate to match how the tree displays the various states of Resources and Elements. Some specific updates of interest:

- Displays custom template icon when applicable
- Displays folder when Resource is a container

#### Design Note
I only touched css minimally here, but will propose a number of style enhancements in a separate PR.

### How to test

Test in an environment with many Resources and Elements, having various published/deleted/disabled states and compare the search display to the tree display. The two should match. 

Note that some Extras override the tree icon (_e.g._, Collections, Gallery), but do not override the search one; that disconnect would need to be addressed by the relevant Extras’ maintainers.

#### Example Screenshots
On the left are a couple clips of my tree; on the right, a few search result examples showing various states. You can spot where specific ones match up.

<img width="1016" height="837" alt="search and tree" src="https://github.com/user-attachments/assets/84563680-bba3-4fed-a877-4ff0d2ae6f9f" />


### Related issue(s)/PR(s)

This is a different approach than and supersedes the proposed change in #16659. 

### Compatibility notes

n/a

### Breaking change assessment

None

### Test coverage

n/a

### Contributors

n/a

### AI tool use

n/a
