### PR TITLE
Remove E_STRICT error handling

### DIFF
--- a/core/src/Revolution/Error/modErrorHandler.php
+++ b/core/src/Revolution/Error/modErrorHandler.php
@@ -110,13 +110,6 @@ class modErrorHandler
                 $this->modx->log(modX::LOG_LEVEL_WARN, $errmsg, '', '', $errfile, $errline);
                 break;
             default:
-                if (version_compare(PHP_VERSION, '8.4.0', '<') && $errno == E_STRICT) {
-                    $handled = true;
-                    $errmsg = 'E_STRICT information: ' . $errstr;
-                    $this->modx->log(modX::LOG_LEVEL_INFO, $errmsg, '', '', $errfile, $errline);
-                    break;
-                }
-
                 $handled = false;
                 $errmsg = 'Un-recoverable error ' . $errno . ': ' . $errstr;
                 $this->modx->log(modX::LOG_LEVEL_ERROR, $errmsg, '', '', $errfile, $errline);


### PR DESCRIPTION

### What changed and why

E_STRICT has no meaning since PHP 7 (https://wiki.php.net/rfc/reclassify_e_strict). So it can be safely removed. MODX 2 and 3 are using PHP 7+
