### PR TITLE
Remove E_STRICT error handling

### DIFF
--- a/core/model/modx/error/moderrorhandler.class.php
+++ b/core/model/modx/error/moderrorhandler.class.php
@@ -92,12 +92,6 @@ class modErrorHandler {
                 $errmsg= 'User notice: ' . $errstr;
                 $this->modx->log(modX::LOG_LEVEL_WARN, $errmsg, '', '', $errfile, $errline);
                 break;
-            case E_STRICT:
-                $handled= true;
-                $errmsg= 'E_STRICT information: ' . $errstr;
-                $this->modx->log(modX::LOG_LEVEL_INFO, $errmsg, '','',$errfile,$errline);
-                return $handled;
-                break;
             case E_RECOVERABLE_ERROR:
                 $handled= true;
                 $errmsg= 'Recoverable error: ' . $errstr;


### PR DESCRIPTION
### What changed and why

E_STRICT has no meaning since PHP 7 (https://wiki.php.net/rfc/reclassify_e_strict). So it can be safely removed. MODX 2 and 3 are using PHP 7+