### PR TITLE
JS code quality, modernization for core modx and component classes

### DIFF
--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -72,7 +72,7 @@ Ext.extend(MODx.Component, Ext.Component, {
             count = this.config.components.length,
             contentPanel = Ext.getCmp('modx-content')
         ;
-        for (let i = 0; i < count; i = i + 1) {
+        for (let i = 0; i < count; i++) {
             const component = MODx.load(this.config.components[i]);
             if (contentPanel) {
                 contentPanel.add(component);
@@ -145,9 +145,9 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
             const
                 el = args[i],
                 id = el.id || Ext.id(),
-                ex = ['-', '->', '<-', '', ' ']
+                exclude = ['-', '->', '<-', '', ' ']
             ;
-            if (ex.indexOf(el) != -1 || (el.xtype && el.xtype == 'switch')) {
+            if (exclude.indexOf(el) !== -1 || (el.xtype && el.xtype === 'switch')) {
                 MODx.toolbar.ActionButtons.superclass.add.call(this, el);
                 continue;
             }
@@ -155,7 +155,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
                 xtype: 'button',
                 cls: (el.icon ? 'x-btn-icon bmenu' : 'x-btn-text bmenu'),
                 scope: this,
-                disabled: el.checkDirty ? true : false,
+                disabled: el?.checkDirty,
                 listeners: {},
                 id: id
             });
@@ -184,7 +184,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
             }
 
             /* if checkDirty, disable until field change */
-            if (el.xtype == 'button') {
+            if (el.xtype === 'button') {
                 el.listeners.render = {
                     fn: function(btn) {
                         if (el.checkDirty && btn) {
@@ -250,12 +250,11 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
         }
 
         Ext.Msg.confirm('', itm.confirm, function(e) {
-            /* if the user is okay with the action */
             if (e === 'yes') {
                 if (callback === null) {
                     return true;
                 }
-                if (typeof(callback) === 'function') { /* if callback is a function, run it, and pass Button */
+                if (typeof callback === 'function') {
                     Ext.callback(callback, scope || this, [itm]);
                 } else {
                     window.location.href = callback;
@@ -266,7 +265,9 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
         return true;
     },
 
+    /** @todo Remove? No usage found in core js */
     reloadPage: function() {
+        // eslint-disable-next-line no-restricted-globals, no-self-assign
         location.href = location.href;
     },
 
@@ -276,43 +277,42 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
             return false;
         }
 
-        if (itm.method === 'remote') { /* if using connectors */
+        if (itm.method === 'remote') {
             MODx.util.Progress.reset();
             o.form = Ext.getCmp(o.formpanel);
             if (!o.form) {
                 return false;
             }
 
-            const f = o.form.getForm ? o.form.getForm() : o.form;
-            let isv = true;
-            if (f.items && f.items.items) {
-                f.items.items.forEach(item => {
+            const form = o.form.getForm ? o.form.getForm() : o.form;
+            let isValid = true;
+            if (form.items && form.items.items) {
+                form.items.items.forEach(item => {
                     if (item && item.validate && !item.validate()) {
-                        isv = false;
+                        isValid = false;
                     }
                 });
             }
 
-            if (isv) {
+            if (isValid) {
                 Ext.applyIf(o.params, {
                     action: itm.process
                 });
 
-                Ext.apply(f.baseParams, o.params);
+                Ext.apply(form.baseParams, o.params);
 
                 o.form.on('success', function(r) {
                     if (o.form.clearDirty) {
                         o.form.clearDirty();
                     }
-                    /* allow for success messages */
                     MODx.msg.status({
                         title: _('success'),
                         message: r.result.message || _('save_successful'),
-                        dontHide: r.result.message != '' ? true : false
+                        dontHide: r.result.message !== ''
                     });
 
-                    if (itm.redirect != false) {
-                        let redirect = this.redirect;
+                    if (itm.redirect !== false) {
+                        let { redirect } = this;
 
                         if (typeof itm.redirect == 'function') {
                             redirect = itm.redirect;
@@ -338,13 +338,13 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
             // if just doing a URL redirect
             const params = itm.params || {};
             Ext.applyIf(params, o.baseParams || {});
-            MODx.loadPage('?' + Ext.urlEncode(params));
+            MODx.loadPage(`?${Ext.urlEncode(params)}`);
         }
         return false;
     },
 
     resetDirtyButtons: function(r) {
-        for (let i = 0; i < this.checkDirtyBtns.length; i = i + 1) {
+        for (let i = 0; i < this.checkDirtyBtns.length; i++) {
             const btn = this.checkDirtyBtns[i];
             btn.setDisabled(true);
         }
@@ -379,7 +379,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
         } else if (process === 'delete') {
             itm.params.a = o.actions.cancel;
             url = Ext.urlEncode(itm.params);
-            MODx.loadPage('?' + url);
+            MODx.loadPage(`?${url}`);
         }
     },
 
@@ -395,7 +395,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
         const fp = Ext.getCmp(f);
         if (fp) {
             fp.on('fieldChange', function(o) {
-                for (let i = 0; i < this.checkDirtyBtns.length; i = i + 1) {
+                for (let i = 0; i < this.checkDirtyBtns.length; i++) {
                     const btn = this.checkDirtyBtns[i];
                     btn.setDisabled(false);
                 }

--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -93,9 +93,9 @@ Ext.extend(MODx.Component, Ext.Component, {
         }
 
         Object.entries(listeners).forEach(([event, value]) => {
-            if (typeof typeof value === 'function') {
+            if (typeof value === 'function') {
                 formPanel.on(event, value, this);
-            } else if (typeof value === 'object' && value.fn) {
+            } else if (typeof value === 'object' && value?.fn) {
                 formPanel.on(event, value.fn, value.scope || this);
             }
         });
@@ -143,7 +143,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
         for (let i = 0; i < args.length; i++) {
             const
                 el = args[i],
-                hasHandler = ['function', 'object'].includes(typeof el.handler),
+                hasHandler = ['function', 'object'].includes(typeof el.handler) && el.handler !== null,
                 id = el.id || Ext.id(),
                 exclude = ['-', '->', '<-', '', ' ']
             ;
@@ -165,6 +165,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
 
             if (hasHandler) {
                 // Make adjustment to call handler after confirm
+                /** @todo Remove this el.confirm block, as it appears to be associated only with an old, usused view (context/view); further this was probably initial logic that was meant to be replaced by the checkConfirm method below */
                 if (el.confirm) {
                     el.handler = function() {
                         Ext.Msg.confirm(_('warning'), el.confirm, function(e) {

--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -1,5 +1,4 @@
-MODx.Component = function(config) {
-    config = config || {};
+MODx.Component = function(config = {}) {
     MODx.Component.superclass.constructor.call(this, config);
     this.config = config;
 
@@ -23,7 +22,7 @@ Ext.extend(MODx.Component, Ext.Component, {
         this.form = new Ext.form.BasicForm(Ext.get(this.config.form), { errorReader: MODx.util.JSONReader });
 
         if (this.config.fields) {
-            for (let i in this.config.fields) {
+            for (const i in this.config.fields) {
                 if (this.config.fields.hasOwnProperty(i)) {
                     let f = this.config.fields[i];
                     if (f.xtype) {
@@ -56,73 +55,70 @@ Ext.extend(MODx.Component, Ext.Component, {
         if (!this.config.tabs) {
             return false;
         }
-        let o = this.config.tabOptions || {};
-        Ext.applyIf(o, {
+        const { tabOptions } = this.config || {};
+        Ext.applyIf(tabOptions, {
             xtype: 'modx-tabs',
             renderTo: this.config.tabs_div || 'tabs_div',
             items: this.config.tabs
         });
-        return MODx.load(o);
+        return MODx.load(tabOptions);
     },
 
     _loadComponents: function() {
         if (!this.config.components) {
             return false;
         }
-        let l = this.config.components.length;
-
-        let cp = Ext.getCmp('modx-content');
-        for (let i = 0; i < l; i = i + 1) {
-            let a = MODx.load(this.config.components[i]);
-            if (cp) {
-                cp.add(a);
+        const
+            count = this.config.components.length,
+            contentPanel = Ext.getCmp('modx-content')
+        ;
+        for (let i = 0; i < count; i = i + 1) {
+            const component = MODx.load(this.config.components[i]);
+            if (contentPanel) {
+                contentPanel.add(component);
             }
         }
-        if (cp) {
-            cp.doLayout();
+        if (contentPanel) {
+            contentPanel.doLayout();
         }
         return true;
     },
 
-    submitForm: function(listeners, options, otherParams) {
-        listeners = listeners || {};
-        otherParams = otherParams || {};
+    submitForm: function(listeners = {}, options = {}, otherParams = {}) {
         if (!this.config.formpanel || !this.config.action) {
             return false;
         }
-        f = Ext.getCmp(this.config.formpanel);
-        if (!f) {
+        const formPanel = Ext.getCmp(this.config.formpanel);
+        if (!formPanel) {
             return false;
         }
 
-        for (let i in listeners) {
+        for (const i in listeners) {
             if (typeof listeners[i] == 'function') {
-                f.on(i, listeners[i], this);
+                formPanel.on(i, listeners[i], this);
             } else if (listeners[i] && typeof listeners[i] == 'object' && listeners[i].fn) {
-                f.on(i, listeners[i].fn, listeners[i].scope || this);
+                formPanel.on(i, listeners[i].fn, listeners[i].scope || this);
             }
         }
 
-        Ext.apply(f.baseParams, {
-            'action': this.config.action
+        Ext.apply(formPanel.baseParams, {
+            action: this.config.action
         });
-        Ext.apply(f.baseParams, otherParams);
-        options = options || {};
+        Ext.apply(formPanel.baseParams, otherParams);
         options.headers = {
             'Powered-By': 'MODx',
-            'modAuth': MODx.siteId
+            modAuth: MODx.siteId
         };
-        f.submit(options);
+        formPanel.submit(options);
         return true;
     }
 });
 Ext.reg('modx-component', MODx.Component);
 
-MODx.toolbar.ActionButtons = function(config) {
-    config = config || {};
+MODx.toolbar.ActionButtons = function(config = {}) {
     Ext.applyIf(config, {
         actions: {
-            'close': 'welcome'
+            close: 'welcome'
         },
         formpanel: false,
         id: 'modx-action-buttons',
@@ -144,17 +140,17 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
         a_close: 'welcome'
     },
 
-    add: function() {
-        let a = arguments, l = a.length;
-        for (let i = 0; i < l; i++) {
-            var el = a[i];
-            let ex = ['-', '->', '<-', '', ' '];
+    add: function(...args) {
+        for (let i = 0; i < args.length; i++) {
+            const
+                el = args[i],
+                id = el.id || Ext.id(),
+                ex = ['-', '->', '<-', '', ' ']
+            ;
             if (ex.indexOf(el) != -1 || (el.xtype && el.xtype == 'switch')) {
                 MODx.toolbar.ActionButtons.superclass.add.call(this, el);
                 continue;
             }
-
-            var id = el.id || Ext.id();
             Ext.applyIf(el, {
                 xtype: 'button',
                 cls: (el.icon ? 'x-btn-icon bmenu' : 'x-btn-text bmenu'),
@@ -181,7 +177,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
 
             /* if javascript is specified, run it when button is click, before this.checkConfirm is run */
             if (el.javascript) {
-                el.listeners['click'] = {
+                el.listeners.click = {
                     fn: this.evalJS,
                     scope: this
                 };
@@ -189,35 +185,38 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
 
             /* if checkDirty, disable until field change */
             if (el.xtype == 'button') {
-                el.listeners['render'] = {
+                el.listeners.render = {
                     fn: function(btn) {
                         if (el.checkDirty && btn) {
                             this.checkDirtyBtns.push(btn);
                         }
                     },
                     scope: this
-                }
+                };
             }
 
             if (el.keys) {
                 el.keyMap = new Ext.KeyMap(Ext.get(document));
                 for (let j = 0; j < el.keys.length; j++) {
-                    let key = el.keys[j];
+                    const key = el.keys[j];
                     Ext.applyIf(key, {
                         scope: this,
                         stopEvent: true,
                         fn: function(e) {
-                            let b = Ext.getCmp(id);
-                            if (b) this.checkConfirm(b, e);
+                            const button = Ext.getCmp(id);
+                            if (button) {
+                                this.checkConfirm(button, e);
+                            }
                         }
                     });
                     el.keyMap.addBinding(key);
                 }
-                el.listeners['destroy'] = {
+                el.listeners.destroy = {
                     fn: function(btn) {
                         btn.keyMap.disable();
-                    }, scope: this
-                }
+                    },
+                    scope: this
+                };
             }
 
             /* add button to toolbar */
@@ -226,6 +225,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
     },
 
     evalJS: function(itm, e) {
+        // eslint-disable-next-line no-eval
         if (!eval(itm.javascript)) {
             e.stopEvent();
             e.preventDefault();
@@ -237,7 +237,9 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
             this.confirm(itm, function() {
                 this.handleClick(itm, e);
             }, this);
-        } else { this.handleClick(itm, e); }
+        } else {
+            this.handleClick(itm, e);
+        }
         return false;
     },
 
@@ -250,11 +252,13 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
         Ext.Msg.confirm('', itm.confirm, function(e) {
             /* if the user is okay with the action */
             if (e === 'yes') {
-                if (callback === null) { return true; }
+                if (callback === null) {
+                    return true;
+                }
                 if (typeof(callback) === 'function') { /* if callback is a function, run it, and pass Button */
                     Ext.callback(callback, scope || this, [itm]);
                 } else {
-                    location.href = callback;
+                    window.location.href = callback;
                 }
             }
             return true;
@@ -267,7 +271,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
     },
 
     handleClick: function(itm, e) {
-        let o = this.config;
+        const o = this.config;
         if (o.formpanel === false || o.formpanel === undefined || o.formpanel === null) {
             return false;
         }
@@ -279,7 +283,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
                 return false;
             }
 
-            let f = o.form.getForm ? o.form.getForm() : o.form;
+            const f = o.form.getForm ? o.form.getForm() : o.form;
             let isv = true;
             if (f.items && f.items.items) {
                 f.items.items.forEach(item => {
@@ -322,7 +326,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
                 o.form.submit({
                     headers: {
                         'Powered-By': 'MODx',
-                        'modAuth': MODx.siteId
+                        modAuth: MODx.siteId
                     }
                 });
             } else {
@@ -332,7 +336,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
             }
         } else {
             // if just doing a URL redirect
-            let params = itm.params || {};
+            const params = itm.params || {};
             Ext.applyIf(params, o.baseParams || {});
             MODx.loadPage('?' + Ext.urlEncode(params));
         }
@@ -341,7 +345,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
 
     resetDirtyButtons: function(r) {
         for (let i = 0; i < this.checkDirtyBtns.length; i = i + 1) {
-            let btn = this.checkDirtyBtns[i];
+            const btn = this.checkDirtyBtns[i];
             btn.setDisabled(true);
         }
     },
@@ -350,9 +354,10 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
         o = this.config;
         itm.params = itm.params || {};
         Ext.applyIf(itm.params, o.baseParams);
-        let url;
 
-        let process = itm.process.substr(itm.process.lastIndexOf('/') + 1).toLowerCase();
+        let url;
+        const process = itm.process.substr(itm.process.lastIndexOf('/') + 1).toLowerCase();
+
         if ((process === 'create' || process === 'duplicate' || itm.reload) && res.object.id) {
             itm.params.id = res.object.id;
             if (MODx.request.parent) {
@@ -378,18 +383,20 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
         }
     },
 
+    /** @todo Remove, appears to be ununsed */
     refreshTreeNode: function(tree, node, self) {
-        let t = parent.Ext.getCmp(tree);
+        // eslint-disable-next-line no-restricted-globals
+        const t = parent.Ext.getCmp(tree);
         t.refreshNode(node, self || false);
         return false;
     },
 
     setupDirtyButtons: function(f) {
-        let fp = Ext.getCmp(f);
+        const fp = Ext.getCmp(f);
         if (fp) {
             fp.on('fieldChange', function(o) {
                 for (let i = 0; i < this.checkDirtyBtns.length; i = i + 1) {
-                    let btn = this.checkDirtyBtns[i];
+                    const btn = this.checkDirtyBtns[i];
                     btn.setDisabled(false);
                 }
             }, this);

--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -174,7 +174,9 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
                         }, el.scope || this);
                     };
                 }
+                // (unmodified handler) Buttons, i.e., Duplicate, Trash, Help, View, Refresh, Clear/Close
             } else if (el.menu !== null) {
+                // Buttons, i.e., Save, etc.
                 el.handler = this.handleClick;
             } else {
                 el.handler = this.checkConfirm;

--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -1,6 +1,6 @@
 MODx.Component = function(config) {
     config = config || {};
-    MODx.Component.superclass.constructor.call(this,config);
+    MODx.Component.superclass.constructor.call(this, config);
     this.config = config;
 
     this._loadForm();
@@ -11,19 +11,21 @@ MODx.Component = function(config) {
     this._loadActionButtons();
     MODx.activePage = this;
 };
-Ext.extend(MODx.Component,Ext.Component,{
-    fields: {}
-    ,form: null
-    ,action: false
+Ext.extend(MODx.Component, Ext.Component, {
+    fields: {},
+    form: null,
+    action: false,
 
-    ,_loadForm: function() {
-        if (!this.config.form) { return false; }
-        this.form = new Ext.form.BasicForm(Ext.get(this.config.form),{ errorReader : MODx.util.JSONReader });
+    _loadForm: function() {
+        if (!this.config.form) {
+            return false;
+        }
+        this.form = new Ext.form.BasicForm(Ext.get(this.config.form), { errorReader: MODx.util.JSONReader });
 
         if (this.config.fields) {
-            for (var i in this.config.fields) {
+            for (let i in this.config.fields) {
                 if (this.config.fields.hasOwnProperty(i)) {
-                    var f = this.config.fields[i];
+                    let f = this.config.fields[i];
                     if (f.xtype) {
                         f = Ext.ComponentMgr.create(f);
                     }
@@ -33,39 +35,45 @@ Ext.extend(MODx.Component,Ext.Component,{
             }
         }
         return this.form.render();
-    }
+    },
 
-    ,_loadActionButtons: function() {
-        if (!this.config.buttons) { return false; }
+    _loadActionButtons: function() {
+        if (!this.config.buttons) {
+            return false;
+        }
 
         this.ab = MODx.load({
-            xtype: 'modx-actionbuttons'
-            ,form: this.form || null
-            ,formpanel: this.config.formpanel || null
-            ,actions: this.config.actions || null
-            ,items: this.config.buttons || []
+            xtype: 'modx-actionbuttons',
+            form: this.form || null,
+            formpanel: this.config.formpanel || null,
+            actions: this.config.actions || null,
+            items: this.config.buttons || []
         });
         return this.ab;
-    }
+    },
 
-    ,_loadTabs: function() {
-        if (!this.config.tabs) { return false; }
-        var o = this.config.tabOptions || {};
-        Ext.applyIf(o,{
-            xtype: 'modx-tabs'
-            ,renderTo: this.config.tabs_div || 'tabs_div'
-            ,items: this.config.tabs
+    _loadTabs: function() {
+        if (!this.config.tabs) {
+            return false;
+        }
+        let o = this.config.tabOptions || {};
+        Ext.applyIf(o, {
+            xtype: 'modx-tabs',
+            renderTo: this.config.tabs_div || 'tabs_div',
+            items: this.config.tabs
         });
         return MODx.load(o);
-    }
+    },
 
-    ,_loadComponents: function() {
-        if (!this.config.components) { return false; }
-        var l = this.config.components.length;
+    _loadComponents: function() {
+        if (!this.config.components) {
+            return false;
+        }
+        let l = this.config.components.length;
 
-        var cp = Ext.getCmp('modx-content');
-        for (var i=0;i<l;i=i+1) {
-            var a = MODx.load(this.config.components[i]);
+        let cp = Ext.getCmp('modx-content');
+        for (let i = 0; i < l; i = i + 1) {
+            let a = MODx.load(this.config.components[i]);
             if (cp) {
                 cp.add(a);
             }
@@ -74,180 +82,205 @@ Ext.extend(MODx.Component,Ext.Component,{
             cp.doLayout();
         }
         return true;
-    }
+    },
 
-    ,submitForm: function(listeners,options,otherParams) {
+    submitForm: function(listeners, options, otherParams) {
         listeners = listeners || {};
         otherParams = otherParams || {};
-        if (!this.config.formpanel || !this.config.action) { return false; }
+        if (!this.config.formpanel || !this.config.action) {
+            return false;
+        }
         f = Ext.getCmp(this.config.formpanel);
-        if (!f) { return false; }
+        if (!f) {
+            return false;
+        }
 
-        for (var i in listeners) {
+        for (let i in listeners) {
             if (typeof listeners[i] == 'function') {
-                f.on(i,listeners[i],this);
+                f.on(i, listeners[i], this);
             } else if (listeners[i] && typeof listeners[i] == 'object' && listeners[i].fn) {
-                f.on(i,listeners[i].fn,listeners[i].scope || this);
+                f.on(i, listeners[i].fn, listeners[i].scope || this);
             }
         }
 
-        Ext.apply(f.baseParams,{
-            'action':this.config.action
+        Ext.apply(f.baseParams, {
+            'action': this.config.action
         });
-        Ext.apply(f.baseParams,otherParams);
+        Ext.apply(f.baseParams, otherParams);
         options = options || {};
         options.headers = {
-            'Powered-By': 'MODx'
-            ,'modAuth': MODx.siteId
+            'Powered-By': 'MODx',
+            'modAuth': MODx.siteId
         };
         f.submit(options);
         return true;
     }
 });
-Ext.reg('modx-component',MODx.Component);
-
+Ext.reg('modx-component', MODx.Component);
 
 MODx.toolbar.ActionButtons = function(config) {
     config = config || {};
-    Ext.applyIf(config,{
-        actions: { 'close': 'welcome' }
-        ,formpanel: false
-        ,id: 'modx-action-buttons'
-        ,params: {}
-        ,items: []
-        ,renderTo: Ext.get('modx-action-buttons-container') ? 'modx-action-buttons-container' : 'modx-container'
+    Ext.applyIf(config, {
+        actions: {
+            'close': 'welcome'
+        },
+        formpanel: false,
+        id: 'modx-action-buttons',
+        params: {},
+        items: [],
+        renderTo: Ext.get('modx-action-buttons-container') ? 'modx-action-buttons-container' : 'modx-container'
     });
     if (config.formpanel) {
         this.setupDirtyButtons(config.formpanel);
     }
     this.checkDirtyBtns = [];
-    MODx.toolbar.ActionButtons.superclass.constructor.call(this,config);
+    MODx.toolbar.ActionButtons.superclass.constructor.call(this, config);
     this.config = config;
 };
-Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
-    id: ''
-    ,buttons: []
-    ,options: { a_close: 'welcome' }
+Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
+    id: '',
+    buttons: [],
+    options: {
+        a_close: 'welcome'
+    },
 
-    ,add: function() {
-        var a = arguments, l = a.length;
-        for(var i = 0; i < l; i++) {
+    add: function() {
+        let a = arguments, l = a.length;
+        for (let i = 0; i < l; i++) {
             var el = a[i];
-            var ex = ['-','->','<-','',' '];
+            let ex = ['-', '->', '<-', '', ' '];
             if (ex.indexOf(el) != -1 || (el.xtype && el.xtype == 'switch')) {
-                MODx.toolbar.ActionButtons.superclass.add.call(this,el);
+                MODx.toolbar.ActionButtons.superclass.add.call(this, el);
                 continue;
             }
 
             var id = el.id || Ext.id();
-            Ext.applyIf(el,{
-                xtype: 'button'
-                ,cls: (el.icon ? 'x-btn-icon bmenu' : 'x-btn-text bmenu')
-                ,scope: this
-                ,disabled: el.checkDirty ? true : false
-                ,listeners: {}
-                ,id: id
+            Ext.applyIf(el, {
+                xtype: 'button',
+                cls: (el.icon ? 'x-btn-icon bmenu' : 'x-btn-text bmenu'),
+                scope: this,
+                disabled: el.checkDirty ? true : false,
+                listeners: {},
+                id: id
             });
             if (el.button) {
-                MODx.toolbar.ActionButtons.superclass.add.call(this,el);
+                MODx.toolbar.ActionButtons.superclass.add.call(this, el);
             }
 
             if (el.handler === null && el.menu === null) {
                 el.handler = this.checkConfirm;
             } else if (el.confirm && el.handler) {
                 el.handler = function() {
-                    Ext.Msg.confirm(_('warning'),el.confirm,function(e) {
-                      if (e === 'yes') { Ext.callback(el.handler,this); }
-                    },el.scope || this);
+                    Ext.Msg.confirm(_('warning'), el.confirm, function(e) {
+                        if (e === 'yes') {
+                            Ext.callback(el.handler, this);
+                        }
+                    }, el.scope || this);
                 };
             } else if (el.handler) {} else { el.handler = this.handleClick; }
 
             /* if javascript is specified, run it when button is click, before this.checkConfirm is run */
             if (el.javascript) {
-                el.listeners['click'] = {fn:this.evalJS,scope:this};
+                el.listeners['click'] = {
+                    fn: this.evalJS,
+                    scope: this
+                };
             }
 
             /* if checkDirty, disable until field change */
             if (el.xtype == 'button') {
-                el.listeners['render'] = {fn:function(btn) {
-                    if (el.checkDirty && btn) {
-                        this.checkDirtyBtns.push(btn);
-                    }
-                },scope:this}
+                el.listeners['render'] = {
+                    fn: function(btn) {
+                        if (el.checkDirty && btn) {
+                            this.checkDirtyBtns.push(btn);
+                        }
+                    },
+                    scope: this
+                }
             }
 
             if (el.keys) {
                 el.keyMap = new Ext.KeyMap(Ext.get(document));
-                for (var j = 0; j < el.keys.length; j++) {
-                    var key = el.keys[j];
-                    Ext.applyIf(key,{
-                        scope: this
-                        ,stopEvent: true
-                        ,fn: function(e) {
-                            var b = Ext.getCmp(id);
-                            if (b) this.checkConfirm(b,e);
+                for (let j = 0; j < el.keys.length; j++) {
+                    let key = el.keys[j];
+                    Ext.applyIf(key, {
+                        scope: this,
+                        stopEvent: true,
+                        fn: function(e) {
+                            let b = Ext.getCmp(id);
+                            if (b) this.checkConfirm(b, e);
                         }
                     });
                     el.keyMap.addBinding(key);
                 }
-                el.listeners['destroy'] = {fn:function(btn) {
-                    btn.keyMap.disable();
-                },scope:this}
+                el.listeners['destroy'] = {
+                    fn: function(btn) {
+                        btn.keyMap.disable();
+                    }, scope: this
+                }
             }
 
             /* add button to toolbar */
-            MODx.toolbar.ActionButtons.superclass.add.call(this,el);
+            MODx.toolbar.ActionButtons.superclass.add.call(this, el);
         }
-    }
+    },
 
-    ,evalJS: function(itm,e) {
+    evalJS: function(itm, e) {
         if (!eval(itm.javascript)) {
             e.stopEvent();
             e.preventDefault();
         }
-    }
+    },
 
-    ,checkConfirm: function(itm,e) {
+    checkConfirm: function(itm, e) {
         if (itm.confirm !== null && itm.confirm !== undefined) {
-            this.confirm(itm,function() {
-                this.handleClick(itm,e);
-            },this);
-        } else { this.handleClick(itm,e); }
+            this.confirm(itm, function() {
+                this.handleClick(itm, e);
+            }, this);
+        } else { this.handleClick(itm, e); }
         return false;
-    }
+    },
 
-    ,confirm: function(itm,callback,scope) {
+    confirm: function(itm, callback, scope) {
         /* if no message go ahead and redirect...we dont like blank questions */
-        if (itm.confirm === null) { return true; }
+        if (itm.confirm === null) {
+            return true;
+        }
 
-        Ext.Msg.confirm('',itm.confirm,function(e) {
+        Ext.Msg.confirm('', itm.confirm, function(e) {
             /* if the user is okay with the action */
             if (e === 'yes') {
                 if (callback === null) { return true; }
                 if (typeof(callback) === 'function') { /* if callback is a function, run it, and pass Button */
-                    Ext.callback(callback,scope || this,[itm]);
-                } else { location.href = callback; }
+                    Ext.callback(callback, scope || this, [itm]);
+                } else {
+                    location.href = callback;
+                }
             }
             return true;
-        },this);
+        }, this);
         return true;
-    }
+    },
 
-    ,reloadPage: function() {
+    reloadPage: function() {
         location.href = location.href;
-    }
+    },
 
-    ,handleClick: function(itm,e) {
-        var o = this.config;
-        if (o.formpanel === false || o.formpanel === undefined || o.formpanel === null) return false;
+    handleClick: function(itm, e) {
+        let o = this.config;
+        if (o.formpanel === false || o.formpanel === undefined || o.formpanel === null) {
+            return false;
+        }
 
         if (itm.method === 'remote') { /* if using connectors */
             MODx.util.Progress.reset();
             o.form = Ext.getCmp(o.formpanel);
-            if (!o.form) return false;
+            if (!o.form) {
+                return false;
+            }
 
-            var f = o.form.getForm ? o.form.getForm() : o.form;
-            var isv = true;
+            let f = o.form.getForm ? o.form.getForm() : o.form;
+            let isv = true;
             if (f.items && f.items.items) {
                 f.items.items.forEach(item => {
                     if (item && item.validate && !item.validate()) {
@@ -257,73 +290,79 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
             }
 
             if (isv) {
-                Ext.applyIf(o.params,{
+                Ext.applyIf(o.params, {
                     action: itm.process
                 });
 
-                Ext.apply(f.baseParams,o.params);
+                Ext.apply(f.baseParams, o.params);
 
-                o.form.on('success',function(r) {
-                    if (o.form.clearDirty) o.form.clearDirty();
+                o.form.on('success', function(r) {
+                    if (o.form.clearDirty) {
+                        o.form.clearDirty();
+                    }
                     /* allow for success messages */
                     MODx.msg.status({
-                        title: _('success')
-                        ,message: r.result.message || _('save_successful')
-                        ,dontHide: r.result.message != '' ? true : false
+                        title: _('success'),
+                        message: r.result.message || _('save_successful'),
+                        dontHide: r.result.message != '' ? true : false
                     });
 
                     if (itm.redirect != false) {
-                        var redirect = this.redirect;
+                        let redirect = this.redirect;
 
                         if (typeof itm.redirect == 'function') {
                             redirect = itm.redirect;
                         }
 
-                        Ext.callback(redirect,this,[o,itm,r.result],1000);
+                        Ext.callback(redirect, this, [o, itm, r.result], 1000);
                     }
 
                     this.resetDirtyButtons(r.result);
-                },this);
+                }, this);
                 o.form.submit({
                     headers: {
-                        'Powered-By': 'MODx'
-                        ,'modAuth': MODx.siteId
+                        'Powered-By': 'MODx',
+                        'modAuth': MODx.siteId
                     }
                 });
             } else {
                 o.form.fireEvent('failureSubmit');
 
-                Ext.Msg.alert(_('error'),_('correct_errors'));
+                Ext.Msg.alert(_('error'), _('correct_errors'));
             }
         } else {
             // if just doing a URL redirect
-            var params = itm.params || {};
+            let params = itm.params || {};
             Ext.applyIf(params, o.baseParams || {});
             MODx.loadPage('?' + Ext.urlEncode(params));
         }
         return false;
-    }
+    },
 
-    ,resetDirtyButtons: function(r) {
-        for (var i=0;i<this.checkDirtyBtns.length;i=i+1) {
-            var btn = this.checkDirtyBtns[i];
+    resetDirtyButtons: function(r) {
+        for (let i = 0; i < this.checkDirtyBtns.length; i = i + 1) {
+            let btn = this.checkDirtyBtns[i];
             btn.setDisabled(true);
         }
-    }
+    },
 
-    ,redirect: function(o,itm,res) {
+    redirect: function(o, itm, res) {
         o = this.config;
         itm.params = itm.params || {};
-        Ext.applyIf(itm.params,o.baseParams);
-        var url;
+        Ext.applyIf(itm.params, o.baseParams);
+        let url;
 
-        var process = itm.process.substr(itm.process.lastIndexOf('/') + 1).toLowerCase();
+        let process = itm.process.substr(itm.process.lastIndexOf('/') + 1).toLowerCase();
         if ((process === 'create' || process === 'duplicate' || itm.reload) && res.object.id) {
             itm.params.id = res.object.id;
-            if (MODx.request.parent) { itm.params.parent = MODx.request.parent; }
-            if (MODx.request.context_key) { itm.params.context_key = MODx.request.context_key; }
+            if (MODx.request.parent) {
+                itm.params.parent = MODx.request.parent;
+            }
+            if (MODx.request.context_key) {
+                itm.params.context_key = MODx.request.context_key;
+            }
             url = Ext.urlEncode(itm.params);
-            var action;
+            let action;
             if (o.actions && o.actions.edit) {
                 // If an edit action is given, use it (BC)
                 action = o.actions.edit;
@@ -332,30 +371,29 @@ Ext.extend(MODx.toolbar.ActionButtons,Ext.Toolbar,{
                 action = itm.process.replace('create', 'update').replace('Create', 'Update');
             }
             MODx.loadPage(action, url);
-
         } else if (process === 'delete') {
             itm.params.a = o.actions.cancel;
             url = Ext.urlEncode(itm.params);
-            MODx.loadPage('?'+url);
+            MODx.loadPage('?' + url);
         }
-    }
+    },
 
-    ,refreshTreeNode: function(tree,node,self) {
-        var t = parent.Ext.getCmp(tree);
-        t.refreshNode(node,self || false);
+    refreshTreeNode: function(tree, node, self) {
+        let t = parent.Ext.getCmp(tree);
+        t.refreshNode(node, self || false);
         return false;
-    }
+    },
 
-    ,setupDirtyButtons: function(f) {
-        var fp = Ext.getCmp(f);
+    setupDirtyButtons: function(f) {
+        let fp = Ext.getCmp(f);
         if (fp) {
-            fp.on('fieldChange',function(o) {
-               for (var i=0;i<this.checkDirtyBtns.length;i=i+1) {
-                    var btn = this.checkDirtyBtns[i];
+            fp.on('fieldChange', function(o) {
+                for (let i = 0; i < this.checkDirtyBtns.length; i = i + 1) {
+                    let btn = this.checkDirtyBtns[i];
                     btn.setDisabled(false);
-               }
-            },this);
+                }
+            }, this);
         }
     }
 });
-Ext.reg('modx-actionbuttons',MODx.toolbar.ActionButtons);
+Ext.reg('modx-actionbuttons', MODx.toolbar.ActionButtons);

--- a/manager/assets/modext/core/modx.component.js
+++ b/manager/assets/modext/core/modx.component.js
@@ -22,16 +22,14 @@ Ext.extend(MODx.Component, Ext.Component, {
         this.form = new Ext.form.BasicForm(Ext.get(this.config.form), { errorReader: MODx.util.JSONReader });
 
         if (this.config.fields) {
-            for (const i in this.config.fields) {
-                if (this.config.fields.hasOwnProperty(i)) {
-                    let f = this.config.fields[i];
-                    if (f.xtype) {
-                        f = Ext.ComponentMgr.create(f);
-                    }
-                    this.fields[i] = f;
-                    this.form.add(f);
+            Object.entries(this.config.fields).forEach(([property, value]) => {
+                let field = value;
+                if (field.xtype) {
+                    field = Ext.ComponentMgr.create(field);
                 }
-            }
+                this.fields[property] = field;
+                this.form.add(field);
+            });
         }
         return this.form.render();
     },
@@ -84,6 +82,7 @@ Ext.extend(MODx.Component, Ext.Component, {
         return true;
     },
 
+    // Note: In the context of the core, this is exclusively used when changing a resource template
     submitForm: function(listeners = {}, options = {}, otherParams = {}) {
         if (!this.config.formpanel || !this.config.action) {
             return false;
@@ -93,13 +92,13 @@ Ext.extend(MODx.Component, Ext.Component, {
             return false;
         }
 
-        for (const i in listeners) {
-            if (typeof listeners[i] == 'function') {
-                formPanel.on(i, listeners[i], this);
-            } else if (listeners[i] && typeof listeners[i] == 'object' && listeners[i].fn) {
-                formPanel.on(i, listeners[i].fn, listeners[i].scope || this);
+        Object.entries(listeners).forEach(([event, value]) => {
+            if (typeof typeof value === 'function') {
+                formPanel.on(event, value, this);
+            } else if (typeof value === 'object' && value.fn) {
+                formPanel.on(event, value.fn, value.scope || this);
             }
-        }
+        });
 
         Ext.apply(formPanel.baseParams, {
             action: this.config.action
@@ -144,6 +143,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
         for (let i = 0; i < args.length; i++) {
             const
                 el = args[i],
+                hasHandler = ['function', 'object'].includes(typeof el.handler),
                 id = el.id || Ext.id(),
                 exclude = ['-', '->', '<-', '', ' ']
             ;
@@ -153,7 +153,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
             }
             Ext.applyIf(el, {
                 xtype: 'button',
-                cls: (el.icon ? 'x-btn-icon bmenu' : 'x-btn-text bmenu'),
+                cls: el.icon ? 'x-btn-icon bmenu' : 'x-btn-text bmenu',
                 scope: this,
                 disabled: el?.checkDirty,
                 listeners: {},
@@ -163,17 +163,22 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
                 MODx.toolbar.ActionButtons.superclass.add.call(this, el);
             }
 
-            if (el.handler === null && el.menu === null) {
+            if (hasHandler) {
+                // Make adjustment to call handler after confirm
+                if (el.confirm) {
+                    el.handler = function() {
+                        Ext.Msg.confirm(_('warning'), el.confirm, function(e) {
+                            if (e === 'yes') {
+                                Ext.callback(el.handler, this);
+                            }
+                        }, el.scope || this);
+                    };
+                }
+            } else if (el.menu !== null) {
+                el.handler = this.handleClick;
+            } else {
                 el.handler = this.checkConfirm;
-            } else if (el.confirm && el.handler) {
-                el.handler = function() {
-                    Ext.Msg.confirm(_('warning'), el.confirm, function(e) {
-                        if (e === 'yes') {
-                            Ext.callback(el.handler, this);
-                        }
-                    }, el.scope || this);
-                };
-            } else if (el.handler) {} else { el.handler = this.handleClick; }
+            }
 
             /* if javascript is specified, run it when button is click, before this.checkConfirm is run */
             if (el.javascript) {
@@ -197,20 +202,23 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
 
             if (el.keys) {
                 el.keyMap = new Ext.KeyMap(Ext.get(document));
-                for (let j = 0; j < el.keys.length; j++) {
-                    const key = el.keys[j];
-                    Ext.applyIf(key, {
-                        scope: this,
-                        stopEvent: true,
-                        fn: function(e) {
-                            const button = Ext.getCmp(id);
-                            if (button) {
-                                this.checkConfirm(button, e);
+                // On first pass, el.keys might be a function; only loop on second pass/when value is an array
+                if (el.keys instanceof Array) {
+                    el.keys.forEach(keyConfig => {
+                        Ext.applyIf(keyConfig, {
+                            scope: this,
+                            stopEvent: true,
+                            fn: function(e) {
+                                const button = Ext.getCmp(id);
+                                if (button) {
+                                    this.checkConfirm(button, e);
+                                }
                             }
-                        }
+                        });
+                        el.keyMap.addBinding(keyConfig);
                     });
-                    el.keyMap.addBinding(key);
                 }
+
                 el.listeners.destroy = {
                     fn: function(btn) {
                         btn.keyMap.disable();
@@ -314,7 +322,7 @@ Ext.extend(MODx.toolbar.ActionButtons, Ext.Toolbar, {
                     if (itm.redirect !== false) {
                         let { redirect } = this;
 
-                        if (typeof itm.redirect == 'function') {
+                        if (typeof itm.redirect === 'function') {
                             redirect = itm.redirect;
                         }
 

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -1,5 +1,5 @@
 Ext.namespace('MODx');
-Ext.apply(Ext,{
+Ext.apply(Ext, {
     isFirebug: (window.console && window.console.firebug)
 });
 
@@ -17,16 +17,14 @@ const globalAutoCompleteSetting = 'off';
 /* work around IE9 createContextualFragment bug
    http://www.sencha.com/forum/showthread.php?125869-Menu-shadow-probolem-in-IE9
  */
-if ((typeof Range !== "undefined") && !Range.prototype.createContextualFragment)
-{
-	Range.prototype.createContextualFragment = function(html)
-	{
-		var frag = document.createDocumentFragment(),
-		div = document.createElement("div");
-		frag.appendChild(div);
-		div.outerHTML = html;
-		return frag;
-	};
+if ((typeof Range !== 'undefined') && !Range.prototype.createContextualFragment) {
+    Range.prototype.createContextualFragment = function(html) {
+        let frag = document.createDocumentFragment(),
+            div = document.createElement('div');
+        frag.appendChild(div);
+        div.outerHTML = html;
+        return frag;
+    };
 }
 /**
  * @class MODx
@@ -36,17 +34,26 @@ if ((typeof Range !== "undefined") && !Range.prototype.createContextualFragment)
  */
 MODx = function(config) {
     config = config || {};
-    MODx.superclass.constructor.call(this,config);
+    MODx.superclass.constructor.call(this, config);
     this.config = config;
     this.startup();
 };
-Ext.extend(MODx,Ext.Component,{
-    config: {}
-    ,util:{},window:{},panel:{},tree:{},form:{},grid:{},combo:{},toolbar:{},page:{},msg:{}
-    ,expandHelp: true
-    ,defaultState: []
+Ext.extend(MODx, Ext.Component, {
+    config: {},
+    util: {},
+    window: {},
+    panel: {},
+    tree: {},
+    form: {},
+    grid: {},
+    combo: {},
+    toolbar: {},
+    page: {},
+    msg: {},
+    expandHelp: true,
+    defaultState: [],
 
-    ,startup: function() {
+    startup: function() {
         this.initQuickTips();
         this.initMarkRequiredFields();
         this.request = this.getURLParameters();
@@ -60,9 +67,9 @@ Ext.extend(MODx,Ext.Component,{
                 msgTarget: 'under'
             }
         });
-        Ext.override(Ext.form.TextArea,{
+        Ext.override(Ext.form.TextArea, {
             onRender: function(ct, position) {
-                if (!this.el){
+                if (!this.el) {
                     this.defaultAutoCreate = {
                         tag: 'textarea',
                         style: 'width:100px;height:60px;',
@@ -70,11 +77,11 @@ Ext.extend(MODx,Ext.Component,{
                     };
                 }
                 Ext.form.TextArea.superclass.onRender.call(this, ct, position);
-                if (this.grow){
+                if (this.grow) {
                     this.textSizeEl = Ext.DomHelper.append(document.body, {
                         tag: 'pre', cls: 'x-form-grow-sizer'
                     });
-                    if(this.preventScrollbars){
+                    if (this.preventScrollbars) {
                         this.el.setStyle('overflow', 'hidden');
                     }
                     this.el.setHeight(this.growMin);
@@ -82,19 +89,19 @@ Ext.extend(MODx,Ext.Component,{
             }
         });
 
-        Ext.Ajax.on('requestexception',this.onAjaxException,this);
+        Ext.Ajax.on('requestexception', this.onAjaxException, this);
         Ext.menu.Menu.prototype.enableScrolling = false;
         this.addEvents({
-            beforeClearCache: true
-            ,beforeLogout: true
-            ,beforeReleaseLocks: true
-            ,beforeLoadPage: true
-            ,afterClearCache: true
-            ,afterLogout: true
-            ,afterReleaseLocks: true
-            ,ready: true
+            beforeClearCache: true,
+            beforeLogout: true,
+            beforeReleaseLocks: true,
+            beforeLoadPage: true,
+            afterClearCache: true,
+            afterLogout: true,
+            afterReleaseLocks: true,
+            ready: true
         });
-    }
+    },
 
     /**
      * Add the given component to the modx-content container
@@ -103,48 +110,46 @@ Ext.extend(MODx,Ext.Component,{
      *
      * @return void
      */
-    ,add: function(cmp) {
+    add: function(cmp) {
         if (typeof cmp === 'string') {
             cmp = { xtype: cmp }
         }
-        var ctr = Ext.getCmp('modx-content');
+        let ctr = Ext.getCmp('modx-content');
         if (ctr) {
             ctr.removeAll();
             ctr.add(cmp);
             ctr.doLayout();
         }
-    }
+    },
 
-    ,load: function() {
-        var a = arguments, l = a.length;
-        var os = [];
-        for(var i=0;i<l;i=i+1) {
+    load: function() {
+        let a = arguments, l = a.length;
+        let os = [];
+        for (let i = 0; i < l; i += 1) {
             if (!a[i].xtype || a[i].xtype === '') {
                 return false;
             }
             os.push(Ext.ComponentMgr.create(a[i]));
         }
         return (os.length === 1) ? os[0] : os;
-    }
+    },
 
-    ,initQuickTips: function() {
+    initQuickTips: function() {
         Ext.QuickTips.init();
         Ext.apply(Ext.QuickTips.getQuickTip(), {
-            dismissDelay: 2300
-            ,interceptTitles: true
+            dismissDelay: 2300,
+            interceptTitles: true
         });
-    }
+    },
 
-    ,initMarkRequiredFields: function() {
-
+    initMarkRequiredFields: function() {
         const markerEl = '<span class=\"field-required-mark\">*</span>';
 
-        const MarkRequiredFieldPlugin = function (config) {
+        const MarkRequiredFieldPlugin = function(config) {
             config = config || {};
             Ext.apply(config, {
                 init: function(cmp) {
-
-                    if (cmp.allowBlank !== false) return;
+                    if (cmp.allowBlank !== false) { return; }
 
                     const cmpLabel = cmp.fieldLabel;
 
@@ -161,7 +166,7 @@ Ext.extend(MODx,Ext.Component,{
                             }
                         }
                         if (labelEl) {
-                            labelEl.innerHTML = labelEl.innerHTML + markerEl;
+                            labelEl.innerHTML += markerEl;
                         }
                     }
                 }
@@ -169,231 +174,235 @@ Ext.extend(MODx,Ext.Component,{
             MarkRequiredFieldPlugin.superclass.constructor.call(this, config);
         }
         Ext.extend(MarkRequiredFieldPlugin, Ext.BoxComponent);
-        Ext.ComponentMgr.registerPlugin('markrequiredfields',MarkRequiredFieldPlugin);
+        Ext.ComponentMgr.registerPlugin('markrequiredfields', MarkRequiredFieldPlugin);
 
         if (!Array.isArray(Ext.form.Field.prototype.plugins)) {
             Ext.form.Field.prototype.plugins = [];
         }
-        var plugins = Ext.form.Field.prototype.plugins;
+        let plugins = Ext.form.Field.prototype.plugins;
         Ext.form.Field.prototype.plugins = Ext.form.Field.prototype.plugins.concat(['markrequiredfields'], plugins);
-    }
+    },
 
-    ,getURLParameters: function() {
-        var arg = {};
-        var href = window.location.search;
+    getURLParameters: function() {
+        let arg = {};
+        let href = window.location.search;
 
         if (href.indexOf('?') !== -1) {
-            var params = href.split('?')[1];
-            var param = params.split('&');
-            for (var i=0; i<param.length;i=i+1) {
+            let params = href.split('?')[1];
+            let param = params.split('&');
+            for (let i = 0; i < param.length; i += 1) {
                 arg[param[i].split('=')[0]] = param[i].split('=')[1];
             }
         }
         return arg;
-    }
+    },
 
-    ,onAjaxException: function(conn,r,opt,e) {
+    onAjaxException: function(conn, r, opt, e) {
         try {
             r = Ext.decode(r.responseText);
         } catch (e) {
-            var text, matched = r.responseText.match(/<body[^>]*>([\w|\W]*)<\/body>/im);
+            let text, matched = r.responseText.match(/<body[^>]*>([\w|\W]*)<\/body>/im);
             if (typeof(matched[1] !== 'undefined')) {
-                text = '<p>'+e.message+':</p>'+matched[1];
+                text = '<p>' + e.message + ':</p>' + matched[1];
             } else {
-                text = e.message+': '+ r.responseText;
+                text = e.message + ': ' + r.responseText;
             }
             Ext.MessageBox.show({
-                title: _('error')
-                ,msg: text
-                ,buttons: Ext.MessageBox.OK
-                ,cls: 'modx-js-parse-error'
-                ,minWidth: 600
-                ,maxWidth: 750
-                ,modal: false
-                ,width: 600
+                title: _('error'),
+                msg: text,
+                buttons: Ext.MessageBox.OK,
+                cls: 'modx-js-parse-error',
+                minWidth: 600,
+                maxWidth: 750,
+                modal: false,
+                width: 600
             });
         }
         if (r && (r.code == 401 || (r.object && r.object.code == 401))) {
             if (!MODx.loginWindow) {
                 MODx.loginWindow = MODx.load({
-                    xtype: 'modx-window-login'
-                    ,username: MODx.user.username
+                    xtype: 'modx-window-login',
+                    username: MODx.user.username
                 });
             }
             MODx.loginWindow.show();
         }
-    }
+    },
 
-    ,loadAccordionPanels: function() { return []; }
+    loadAccordionPanels: function() { return []; },
 
-    ,clearCache: function() {
+    clearCache: function() {
         if (!this.fireEvent('beforeClearCache')) { return false; }
 
-        var topic = '/clearcache/';
+        let topic = '/clearcache/';
         this.console = MODx.load({
-           xtype: 'modx-console'
-           ,register: 'mgr'
-           ,topic: topic
-           ,clear: true
-           ,show_filename: 0
-           ,listeners: {
-                'shutdown': {fn:function() {
+            xtype: 'modx-console',
+            register: 'mgr',
+            topic: topic,
+            clear: true,
+            show_filename: 0,
+            listeners: {
+                'shutdown': {fn: function() {
                     if (this.fireEvent('afterClearCache')) {
                         if (MODx.config.clear_cache_refresh_trees == 1) {
                             Ext.getCmp('modx-layout').refreshTrees();
                         }
                     }
-                },scope:this}
-           }
+                },
+                scope: this}
+            }
         });
 
         this.console.show(Ext.getBody());
 
         MODx.Ajax.request({
-            url: MODx.config.connector_url
-            ,params: {
-                action: 'System/ClearCache'
-                ,register: 'mgr'
-                ,topic: topic
-                ,media_sources: true
-                ,menu: true
-                ,action_map: true
-            }
-            ,listeners: {
-                'success':{fn:function() {
+            url: MODx.config.connector_url,
+            params: {
+                action: 'System/ClearCache',
+                register: 'mgr',
+                topic: topic,
+                media_sources: true,
+                menu: true,
+                action_map: true
+            },
+            listeners: {
+                'success': {fn: function() {
                     this.console.fireEvent('complete');
-                },scope:this}
+                },
+                scope: this}
             }
         });
         return true;
-    }
+    },
 
-    ,refreshURIs: function() {
-        var topic = '/refreshuris/';
+    refreshURIs: function() {
+        let topic = '/refreshuris/';
         MODx.msg.status({
             title: _('please_wait'),
             message: _('refreshuris_desc'),
             dontHide: true
         });
         MODx.Ajax.request({
-            url: MODx.config.connector_url
-            ,params: {
-                action: 'System/RefreshUris'
-                ,register: 'mgr'
-                ,topic: topic
-                ,menu: true
-            }
-            ,listeners: {
-                'success':{fn:function(r) {
+            url: MODx.config.connector_url,
+            params: {
+                action: 'System/RefreshUris',
+                register: 'mgr',
+                topic: topic,
+                menu: true
+            },
+            listeners: {
+                'success': {fn: function(r) {
                     MODx.msg.status({
-                        title: _('success')
-                        ,message: r.message || _('refresh_success')
-                        ,dontHide: false
+                        title: _('success'),
+                        message: r.message || _('refresh_success'),
+                        dontHide: false
                     });
                     this.clearCache();
-                },scope:this}
+                },
+                scope: this}
             }
         });
         return true;
-    }
-    ,releaseLock: function(id) {
+    },
+    releaseLock: function(id) {
         if (this.fireEvent('beforeReleaseLocks')) {
             MODx.Ajax.request({
-                url: MODx.config.connector_url
-                ,params: {
-                    action: 'Resource/Locks/Release'
-                    ,id: id
-                }
-                ,listeners: {
-                    'success':{fn:function(r) { this.fireEvent('afterReleaseLocks',r); },scope:this}
+                url: MODx.config.connector_url,
+                params: {
+                    action: 'Resource/Locks/Release',
+                    id: id
+                },
+                listeners: {
+                    'success': {fn: function(r) { this.fireEvent('afterReleaseLocks', r); }, scope: this}
                 }
             });
         }
-    }
-    ,removeLocks: function(id) {
-		MODx.msg.confirm({
-			title: _('remove_locks')
-			,text: _('confirm_remove_locks')
-			,url: MODx.config.connectors_url
-			,params: {
-				action: 'System/RemoveLocks'
-			}
-			,listeners: {
-				'success': {
-					fn:function() {
-						var tree = Ext.getCmp("modx-resource-tree");
+    },
+    removeLocks: function(id) {
+        MODx.msg.confirm({
+            title: _('remove_locks'),
+            text: _('confirm_remove_locks'),
+            url: MODx.config.connectors_url,
+            params: {
+                action: 'System/RemoveLocks'
+            },
+            listeners: {
+                'success': {
+                    fn: function() {
+                        let tree = Ext.getCmp('modx-resource-tree');
 
-						if (tree && tree.rendered) {
-							tree.refresh();
-						}
+                        if (tree && tree.rendered) {
+                            tree.refresh();
+                        }
 
-						var cmp = Ext.getCmp("modx-panel-resource");
+                        let cmp = Ext.getCmp('modx-panel-resource');
 
-						if (cmp) {
-							Ext.getCmp('modx-abtn-locked').hide();
-							Ext.getCmp('modx-abtn-save').show();
-						}
-					},
-					scope:this
-				}
-			}
-		});
-    }
+                        if (cmp) {
+                            Ext.getCmp('modx-abtn-locked').hide();
+                            Ext.getCmp('modx-abtn-save').show();
+                        }
+                    },
+                    scope: this
+                }
+            }
+        });
+    },
 
-    ,sleep: function(ms) {
-        var s = new Date().getTime();
-        for (var i=0;i < 1e7;i++) {
-            if ((new Date().getTime() - s) > ms){
+    sleep: function(ms) {
+        let s = new Date().getTime();
+        for (let i = 0; i < 1e7; i++) {
+            if ((new Date().getTime() - s) > ms) {
                 break;
             }
         }
-    }
+    },
 
-    ,logout: function() {
+    logout: function() {
         if (this.fireEvent('beforeLogout')) {
             MODx.msg.confirm({
-                title: _('logout')
-                ,text: _('logout_confirm')
-                ,url: MODx.config.connector_url
-                ,params: {
-                    action: 'Security/Logout'
-                    ,login_context: 'mgr'
-                }
-                ,listeners: {
-                    'success': {fn:function(r) {
-                        if (this.fireEvent('afterLogout',r)) {
+                title: _('logout'),
+                text: _('logout_confirm'),
+                url: MODx.config.connector_url,
+                params: {
+                    action: 'Security/Logout',
+                    login_context: 'mgr'
+                },
+                listeners: {
+                    'success': {fn: function(r) {
+                        if (this.fireEvent('afterLogout', r)) {
                             location.href = './';
                         }
-                    },scope:this}
+                    },
+                    scope: this}
                 }
             });
         }
-    }
+    },
 
-    ,getPageStructure: function(v,c) {
+    getPageStructure: function(v, c) {
         c = c || {};
-        Ext.applyIf(c,{
-            xtype: 'modx-tabs'
-            ,itemId: 'tabs'
-            ,items: v
-			,cls: 'structure-tabs'
+        Ext.applyIf(c, {
+            xtype: 'modx-tabs',
+            itemId: 'tabs',
+            items: v,
+            cls: 'structure-tabs'
         });
         return c;
-    }
+    },
 
-    ,setStaticElementPath: function(type) {
-        var category   = '',
-            path       = '',
-            name       = '',
-            nameField  = 'name',
-            typePlural = type + "s";
+    setStaticElementPath: function(type) {
+        let category = '',
+            path = '',
+            name = '',
+            nameField = 'name',
+            typePlural = type + 's';
 
-        if (type === "template") {
+        if (type === 'template') {
             nameField = 'templatename';
         }
 
-        if (MODx.config["static_elements_automate_" + typePlural] == 1) {
-            category = Ext.getCmp("modx-" + type + "-category").getValue();
+        if (MODx.config['static_elements_automate_' + typePlural] == 1) {
+            category = Ext.getCmp('modx-' + type + '-category').getValue();
             if (category > 0) {
                 Ext.Ajax.request({
                     url: MODx.config.connector_url,
@@ -402,26 +411,26 @@ Ext.extend(MODx,Ext.Component,{
                         id: category,
                         limit: 0,
                     },
-                    success: function (response) {
-                        var data = Ext.decode(response.responseText);
+                    success: function(response) {
+                        let data = Ext.decode(response.responseText);
                         categoryText = (data && data.success && data.results) ? data.results[0].name : '';
                         if (categoryText) {
-                            name = Ext.getCmp("modx-" + type + "-" + nameField).getValue();
+                            name = Ext.getCmp('modx-' + type + '-' + nameField).getValue();
                             path = MODx.getStaticElementsPath(name, categoryText, typePlural);
-                            Ext.getCmp("modx-" + type + "-static-file").setValue(path);
+                            Ext.getCmp('modx-' + type + '-static-file').setValue(path);
                         }
                     },
                 });
             } else {
-                name = Ext.getCmp("modx-" + type + "-" + nameField).getValue();
+                name = Ext.getCmp('modx-' + type + '-' + nameField).getValue();
                 path = MODx.getStaticElementsPath(name, '', typePlural);
-                Ext.getCmp("modx-" + type + "-static-file").setValue(path);
+                Ext.getCmp('modx-' + type + '-static-file').setValue(path);
             }
         }
-    }
+    },
 
-    ,setStaticElementsConfig: function (config, type) {
-        var typePlural = type + 's';
+    setStaticElementsConfig: function(config, type) {
+        let typePlural = type + 's';
 
         if (MODx.request.a === 'element/' + type + '/create' && MODx.config['static_elements_automate_' + typePlural] == 1) {
             config.record['static'] = 1;
@@ -434,40 +443,40 @@ Ext.extend(MODx,Ext.Component,{
         }
 
         return config;
-    }
+    },
 
-    ,getStaticElementsPath: function(name, category, type) {
-        var path = MODx.config.static_elements_basepath,
-            ext  = '';
+    getStaticElementsPath: function(name, category, type) {
+        let path = MODx.config.static_elements_basepath,
+            ext = '';
 
         if (category.length > 0) {
-            category = category.replace(/[^\w\s-]/gi, "");
+            category = category.replace(/[^\w\s-]/gi, '');
             category = category.replace(/\s/g, '-').toLowerCase();
             // Convert nested elements to nested directory structure.
             category = category.replace(/--/gi, '/');
-            category = "/" + category + "/";
+            category = '/' + category + '/';
         } else {
-            category = "/";
+            category = '/';
         }
 
         // Remove trailing slash.
-        path = path.replace(/\/$/, "");
+        path = path.replace(/\/$/, '');
 
-        switch(type) {
-            case "templates":
-                ext = ".template" + (MODx.config.static_elements_html_extension || ".tpl");
+        switch (type) {
+            case 'templates':
+                ext = '.template' + (MODx.config.static_elements_html_extension || '.tpl');
                 break;
-            case "tvs":
-                ext = ".tv" + (MODx.config.static_elements_html_extension || ".tpl");
+            case 'tvs':
+                ext = '.tv' + (MODx.config.static_elements_html_extension || '.tpl');
                 break;
-            case "chunks":
-                ext = ".chunk" + (MODx.config.static_elements_html_extension || ".tpl");
+            case 'chunks':
+                ext = '.chunk' + (MODx.config.static_elements_html_extension || '.tpl');
                 break;
-            case "snippets":
-                ext = ".snippet.php";
+            case 'snippets':
+                ext = '.snippet.php';
                 break;
-            case "plugins":
-                ext = ".plugin.php";
+            case 'plugins':
+                ext = '.plugin.php';
                 break;
         }
 
@@ -476,18 +485,18 @@ Ext.extend(MODx,Ext.Component,{
         name = name.replace(/\s/g, '-').toLowerCase();
 
         if (name.length > 0) {
-            path += "/" + type + category + name + ext;
+            path += '/' + type + category + name + ext;
         } else {
-            path += "/" + type + category;
+            path += '/' + type + category;
         }
 
         return path;
-    }
+    },
 
-    ,helpUrl: false
+    helpUrl: false,
 
-    ,loadHelpPane: function(b) {
-        var url = MODx.helpUrl || MODx.config.help_url || '';
+    loadHelpPane: function(b) {
+        let url = MODx.helpUrl || MODx.config.help_url || '';
         if (!url || !url.length) { return false; }
 
         if (url.substring(0, 4) !== 'http') {
@@ -495,36 +504,36 @@ Ext.extend(MODx,Ext.Component,{
         }
 
         MODx.helpWindow = new Ext.Window({
-            title: _('help')
-            ,width: 850
-            ,height: 500
-            ,resizable: true
-            ,maximizable: true
-            ,modal: false
-            ,layout: 'fit'
-			,bodyStyle : 'padding: 0;'
-            ,items: [{
-	        	xtype: 'container',
-				layout: {
-	            	type: 'vbox',
-					align: 'stretch'
-				},
-				width: '100%',
-				height: '100%',
-				items:[{
-					autoEl: {
-		                tag: 'iframe',
-		                src: url,
-		                width: '100%',
-						height: '100%',
-						frameBorder: 0
-					}
-				}]
-			}]
+            title: _('help'),
+            width: 850,
+            height: 500,
+            resizable: true,
+            maximizable: true,
+            modal: false,
+            layout: 'fit',
+            bodyStyle: 'padding: 0;',
+            items: [{
+                xtype: 'container',
+                layout: {
+                    type: 'vbox',
+                    align: 'stretch'
+                },
+                width: '100%',
+                height: '100%',
+                items: [{
+                    autoEl: {
+                        tag: 'iframe',
+                        src: url,
+                        width: '100%',
+                        height: '100%',
+                        frameBorder: 0
+                    }
+                }]
+            }]
         });
         MODx.helpWindow.show(b);
         return true;
-    }
+    },
 
     /**
      * Adds a new tab to the specified panel; method called from code inserted via modActionDom (modactiondom.class.php)
@@ -533,31 +542,31 @@ Ext.extend(MODx,Ext.Component,{
      * @param {Object} newTabConfig - The base configuration for the new tab
      * @return {void}
      */
-    ,addTab: function(panelId, newTabConfig) {
+    addTab: function(panelId, newTabConfig) {
         const tabPanel = Ext.getCmp(panelId);
         if (tabPanel) {
-            Ext.applyIf(newTabConfig,{
-                id: 'modx-' + Ext.id() + '-tab'
-                ,layout: 'form'
-                ,labelAlign: 'top'
-                ,cls: 'modx-resource-tab'
-                ,bodyStyle: 'padding: 15px;'
-                ,autoHeight: true
-                ,defaults: {
-                    border: false
-                    ,msgTarget: 'side'
-                    ,width: 400
+            Ext.applyIf(newTabConfig, {
+                id: 'modx-' + Ext.id() + '-tab',
+                layout: 'form',
+                labelAlign: 'top',
+                cls: 'modx-resource-tab',
+                bodyStyle: 'padding: 15px;',
+                autoHeight: true,
+                defaults: {
+                    border: false,
+                    msgTarget: 'side',
+                    width: 400
                 }
             });
             tabPanel.add(newTabConfig);
             tabPanel.doLayout();
         }
-    }
-    ,hiddenTabs: []
+    },
+    hiddenTabs: [],
 
-    ,hideTab: function(ct, tab) {
+    hideTab: function(ct, tab) {
         this.hideRegion(ct, tab);
-    }
+    },
 
     /**
      * Hides a region or tab; method called from code inserted via modActionDom (modactiondom.class.php)
@@ -567,7 +576,7 @@ Ext.extend(MODx,Ext.Component,{
      * @param {String} regionId - Text id of the region/tab to hide
      * @return {void}
      */
-    ,hideRegion: function(containerId, regionId) {
+    hideRegion: function(containerId, regionId) {
         const tabPanel = Ext.getCmp(containerId);
         if (tabPanel) {
             const tabObj = tabPanel.getItem(regionId);
@@ -582,18 +591,18 @@ Ext.extend(MODx,Ext.Component,{
                 }
             }
         }
-    }
+    },
 
-    ,_getNextActiveTab: function(tp,tab) {
+    _getNextActiveTab: function(tp, tab) {
         let id;
         if (MODx.hiddenTabs.indexOf(tab) != -1) {
-            for (var i=0;i<tp.items.items.length;i++) {
-                 id = tp.items.items[i].id;
+            for (let i = 0; i < tp.items.items.length; i++) {
+                id = tp.items.items[i].id;
                 if (MODx.hiddenTabs.indexOf(id) == -1) { break; }
             }
         } else { id = tab; }
         return id;
-    }
+    },
 
     /**
      * Moves a TV to the specified a region or tab; method called from code inserted via modActionDom (modactiondom.class.php)
@@ -603,10 +612,10 @@ Ext.extend(MODx,Ext.Component,{
      * @param {String} targetId - Text id of the TV's destination (region/tab)
      * @return {void}
      */
-    ,moveTV: function(tvId, targetId) {
-        const   sourcePanel = Ext.getCmp('modx-panel-resource-tv'),
-                sourceItem = Ext.get(tvId + '-tr'),
-                target = Ext.getCmp(targetId)
+    moveTV: function(tvId, targetId) {
+        const sourcePanel = Ext.getCmp('modx-panel-resource-tv'),
+              sourceItem = Ext.get(tvId + '-tr'),
+              target = Ext.getCmp(targetId)
         ;
         if (!sourcePanel || !sourceItem || !target) {
             return;
@@ -631,28 +640,28 @@ Ext.extend(MODx,Ext.Component,{
                 + 'It is likely a conflicting customization rule has already tried to move this TV.'
             );
         }
-    }
+    },
 
-    ,hideTV: function(tvs) {
+    hideTV: function(tvs) {
         if (!Ext.isArray(tvs)) {
             tvs = [tvs];
         }
         this.hideTVs(tvs);
-    }
+    },
 
-    ,hideTVs: function(tvs) {
+    hideTVs: function(tvs) {
         if (!Ext.isArray(tvs)) {
             tvs = [tvs];
         }
         let el;
-        for (let i=0; i<tvs.length; i++) {
-            el = Ext.get(tvs[i]+'-tr');
+        for (let i = 0; i < tvs.length; i++) {
+            el = Ext.get(tvs[i] + '-tr');
             if (el) {
                 el.setVisibilityMode(Ext.Element.DISPLAY);
                 el.hide();
             }
         }
-    }
+    },
 
     /**
      * Changes the label of the specified field; method called from code inserted via modActionDom (modactiondom.class.php)
@@ -662,7 +671,7 @@ Ext.extend(MODx,Ext.Component,{
      * @param {String} newLabel - The replacement label text
      * @return {void}
      */
-    ,renameLabel: function(containerId, fieldId, newLabel) {
+    renameLabel: function(containerId, fieldId, newLabel) {
         if (fieldId.indexOf('modx-resource-content') !== -1) {
             const contentCmp = Ext.getCmp('ta');
             if (contentCmp) {
@@ -674,7 +683,7 @@ Ext.extend(MODx,Ext.Component,{
                 container.setLabel(fieldId, newLabel);
             }
         }
-    }
+    },
 
     /**
      * Renames a form tab; method called from code inserted via modActionDom (modactiondom.class.php)
@@ -683,12 +692,12 @@ Ext.extend(MODx,Ext.Component,{
      * @param {String} newTitle - The replacement title text
      * @return {void}
      */
-    ,renameTab: function(tabId, newTitle) {
+    renameTab: function(tabId, newTitle) {
         const tab = Ext.getCmp(tabId);
         if (tab) {
             tab.setTitle(newTitle);
         }
-    }
+    },
 
     /**
      * Hides a field in the specified container; method called from code inserted via modActionDom (modactiondom.class.php)
@@ -697,22 +706,24 @@ Ext.extend(MODx,Ext.Component,{
      * @param {String} fieldId - Text id or name of field being hidden
      * @return {void}
      */
-    ,hideField: function(containerId, fieldId) {
+    hideField: function(containerId, fieldId) {
         const container = Ext.getCmp(containerId);
         if (container) {
             container.hideField(fieldId);
         }
-    }
+    },
 
-    ,preview: function() {
-        var url = MODx.config.site_url;
+    preview: function() {
+        let url = MODx.config.site_url;
         if (MODx.config.default_site_url) {
             url = MODx.config.default_site_url;
         }
         window.open(url);
-    }
-    ,makeDroppable: function(fld,h,p) {
-        if (!fld) return false;
+    },
+    makeDroppable: function(fld, h, p) {
+        if (!fld) {
+            return false;
+        }
         h = h || Ext.emptyFn;
         if (fld.getEl) {
             var el = fld.getEl();
@@ -721,26 +732,26 @@ Ext.extend(MODx,Ext.Component,{
         }
         if (el) {
             new MODx.load({
-                xtype: 'modx-treedrop'
-                ,target: fld
-                ,targetEl: el.dom
-                ,onInsert: h
-                ,panel: p || 'modx-panel-resource'
+                xtype: 'modx-treedrop',
+                target: fld,
+                targetEl: el.dom,
+                onInsert: h,
+                panel: p || 'modx-panel-resource'
             });
         }
         return true;
-    }
-    ,debug: function(msg) {
+    },
+    debug: function(msg) {
         if (MODx.config.ui_debug_mode == 1) {
             console.log(msg);
         }
-    }
+    },
 
-    ,isEmpty: function(v) {
+    isEmpty: function(v) {
         return Ext.isEmpty(v) || v === false || v === 'false' || v === 'FALSE' || v === '0' || v === 0;
-    }
+    },
 
-    ,createResource: function(record) {
+    createResource: function(record) {
         if (MODx.createResourceWindow) {
             MODx.createResourceWindow.destroy();
         }
@@ -769,19 +780,19 @@ Ext.extend(MODx,Ext.Component,{
 
         MODx.createResourceWindow.setValues(record);
         MODx.createResourceWindow.show();
-    }
+    },
 
-    ,switchLanguage: function(lang) {
-        var params = {
+    switchLanguage: function(lang) {
+        let params = {
             switch: lang
         };
-        Ext.iterate(MODx.request, function (key, value) {
+        Ext.iterate(MODx.request, function(key, value) {
             params['target_' + key] = value;
         });
         MODx.loadPage('language', params);
     }
 });
-Ext.reg('modx',MODx);
+Ext.reg('modx', MODx);
 
 /**
  * An override class for Ext.Ajax, which adds success/failure events.
@@ -795,10 +806,10 @@ MODx.Ajax = function(config) {
     config = config || {};
     MODx.Ajax.superclass.constructor.call(this, config);
 };
-Ext.extend(MODx.Ajax,Ext.Component,{
+Ext.extend(MODx.Ajax, Ext.Component, {
     request: function(config) {
-        Ext.apply(config,{
-            success: function(r,o) {
+        Ext.apply(config, {
+            success: function(r, o) {
                 r = Ext.decode(r.responseText);
                 if (!r) {
                     return false;
@@ -813,8 +824,8 @@ Ext.extend(MODx.Ajax,Ext.Component,{
                     MODx.form.Handler.errorJSON(r);
                 }
                 return true;
-            }
-            ,failure: function(r, o) {
+            },
+            failure: function(r, o) {
                 r = Ext.decode(r.responseText);
                 if (!r) {
                     return false;
@@ -825,24 +836,24 @@ Ext.extend(MODx.Ajax,Ext.Component,{
                     MODx.form.Handler.errorJSON(r);
                 }
                 return true;
-            }
-            ,scope: this
-            ,headers: {
-                'Powered-By': 'MODx'
-                ,'modAuth': config.auth
+            },
+            scope: this,
+            headers: {
+                'Powered-By': 'MODx',
+                'modAuth': config.auth
             }
         });
         Ext.Ajax.request(config);
-    }
+    },
     /**
      * Execute the listener callback
      *
      * @param {Object} config - The listener configuration (ie.failure/success)
      * @param {Array} args - An array of arguments to pass to the callback
      */
-    ,_runCallback: function(config, args) {
-        var scope = window
-            ,fn = config.fn;
+    _runCallback: function(config, args) {
+        let scope = window,
+            fn = config.fn;
 
         if (config.scope) {
             scope = config.scope;
@@ -850,62 +861,62 @@ Ext.extend(MODx.Ajax,Ext.Component,{
         fn.apply(scope || window, args);
     }
 });
-Ext.reg('modx-ajax',MODx.Ajax);
-
+Ext.reg('modx-ajax', MODx.Ajax);
 
 MODx = new MODx();
 
-
 MODx.form.Handler = function(config) {
     config = config || {};
-    MODx.form.Handler.superclass.constructor.call(this,config);
+    MODx.form.Handler.superclass.constructor.call(this, config);
 };
-Ext.extend(MODx.form.Handler,Ext.Component,{
-    fields: []
+Ext.extend(MODx.form.Handler, Ext.Component, {
+    fields: [],
 
-    ,handle: function(o,s,r) {
+    handle: function(o, s, r) {
         r = Ext.decode(r.responseText);
         if (!r.success) {
             this.showError(r.message);
             return false;
         }
         return true;
-    }
+    },
 
-    ,highlightField: function(f) {
+    highlightField: function(f) {
         if (f.id !== undefined && f.id !== 'forEach' && f.id !== '') {
-            var fld = Ext.get(f.id);
+            let fld = Ext.get(f.id);
             if (fld && fld.dom) {
                 fld.dom.style.border = '1px solid red';
             }
-            var ef = Ext.get(f.id+'_error');
+            let ef = Ext.get(f.id + '_error');
             if (ef) { ef.innerHTML = f.msg; }
             this.fields.push(f.id);
         }
-    }
+    },
 
-    ,unhighlightFields: function() {
-        for (var i=0;i<this.fields.length;i=i+1) {
+    unhighlightFields: function() {
+        for (let i = 0; i < this.fields.length; i += 1) {
             Ext.get(this.fields[i]).dom.style.border = '';
-            var ef = Ext.get(this.fields[i]+'_error');
-            if (ef) { ef.innerHTML = ''; }
+            let ef = Ext.get(this.fields[i] + '_error');
+            if (ef) {
+                ef.innerHTML = '';
+            }
         }
         this.fields = [];
-    }
+    },
 
-    ,errorJSON: function(e) {
+    errorJSON: function(e) {
         if (e === '') { return this.showError(e); }
         if (e.data && e.data !== null) {
-            for (var p=0;p<e.data.length;p=p+1) {
+            for (let p = 0; p < e.data.length; p += 1) {
                 this.highlightField(e.data[p]);
             }
         }
 
         this.showError(e.message);
         return false;
-    }
+    },
 
-    ,errorExt: function(r,frm) {
+    errorExt: function(r, frm) {
         this.unhighlightFields();
         if (r && r.errors !== null && frm) {
             frm.markInvalid(r.errors);
@@ -916,103 +927,108 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
             MODx.msg.hide();
         }
         return false;
-    }
+    },
 
-    ,showError: function(e) {
+    showError: function(e) {
         if (e === '') {
             MODx.msg.hide();
         } else {
-            MODx.msg.alert(_('error'),e,Ext.emptyFn);
+            MODx.msg.alert(_('error'), e, Ext.emptyFn);
         }
-    }
+    },
 
-    ,closeError: function() { MODx.msg.hide(); }
+    closeError: function() { MODx.msg.hide(); }
 });
-Ext.reg('modx-form-handler',MODx.form.Handler);
+Ext.reg('modx-form-handler', MODx.form.Handler);
 
 MODx.Msg = function(config) {
     config = config || {};
-    MODx.Msg.superclass.constructor.call(this,config);
+    MODx.Msg.superclass.constructor.call(this, config);
     this.addEvents({
-        'success': true
-        ,'failure': true
-        ,'cancel': true
+        'success': true,
+        'failure': true,
+        'cancel': true
     });
     Ext.MessageBox.minWidth = 200;
 };
-Ext.extend(MODx.Msg,Ext.Component,{
+Ext.extend(MODx.Msg, Ext.Component, {
     confirm: function(config) {
         this.purgeListeners();
         if (config.listeners) {
-            for (var i in config.listeners) {
-              var l = config.listeners[i];
-              this.addListener(i,l.fn,l.scope || this,l.options || {});
+            for (let i in config.listeners) {
+                let l = config.listeners[i];
+                this.addListener(i, l.fn, l.scope || this, l.options || {});
             }
         }
         Ext.MessageBox.minWidth = config.minWidth || 200;
-        Ext.Msg.confirm(config.title || _('warning'),config.text,function(e) {
+        Ext.Msg.confirm(config.title || _('warning'), config.text, function(e) {
             if (e == 'yes') {
                 MODx.Ajax.request({
-                    url: config.url
-                    ,params: config.params || {}
-                    ,method: 'post'
-                    ,scope: this
-                    ,listeners: {
-                        'success':{fn:function(r) {
-                            this.fireEvent('success',r);
-                        },scope:this}
-                        ,'failure':{fn:function(r) {
-                            return this.fireEvent('failure',r);
-                        },scope:this}
+                    url: config.url,
+                    params: config.params || {},
+                    method: 'post',
+                    scope: this,
+                    listeners: {
+                        'success': {fn: function(r) {
+                            this.fireEvent('success', r);
+                        },
+                        scope: this},
+                        'failure': {fn: function(r) {
+                            return this.fireEvent('failure', r);
+                        },
+                        scope: this}
                     }
                 });
             } else {
-                this.fireEvent('cancel',config);
+                this.fireEvent('cancel', config);
             }
-        },this);
-    }
+        }, this);
+    },
 
-    ,getWindow: function() {
+    getWindow: function() {
         return Ext.Msg.getDialog();
-    }
+    },
 
-    ,alert: function(title,text,fn,scope) {
+    alert: function(title, text, fn, scope) {
         fn = fn || Ext.emptyFn;
         scope = scope || this;
-        Ext.Msg.alert(title,text,fn,scope);
-    }
+        Ext.Msg.alert(title, text, fn, scope);
+    },
 
-    ,status: function(opt) {
+    status: function(opt) {
         if (!MODx.stMsgCt) {
-            MODx.stMsgCt = Ext.DomHelper.insertFirst(document.body, {id:'modx-status-message-ct'}, true);
+            MODx.stMsgCt = Ext.DomHelper.insertFirst(document.body, {id: 'modx-status-message-ct'}, true);
         }
         MODx.stMsgCt.alignTo(document, 't-t');
-        var markup = this.getStatusMarkup(opt);
-        var m = Ext.DomHelper.overwrite(MODx.stMsgCt, {html:markup}, true);
+        let markup = this.getStatusMarkup(opt);
+        let m = Ext.DomHelper.overwrite(MODx.stMsgCt, {html: markup}, true);
 
-        var fadeOpts = {remove:true,useDisplay:true};
+        let fadeOpts = {remove: true, useDisplay: true};
         if (!opt.dontHide) {
-            if(!Ext.isIE8) {
-                m.pause(opt.delay || 1.5).ghost("t",fadeOpts);
+            if (!Ext.isIE8) {
+                m.pause(opt.delay || 1.5).ghost('t', fadeOpts);
             } else {
                 fadeOpts.duration = (opt.delay || 1.5);
-                m.ghost("t",fadeOpts);
+                m.ghost('t', fadeOpts);
             }
         } else {
-            m.on('click',function() {
-                m.ghost('t',fadeOpts);
+            m.on('click', function() {
+                m.ghost('t', fadeOpts);
             });
         }
-
-    }
-    ,getStatusMarkup: function(opt) {
-        var mk = '<div class="modx-status-msg">';
-        if (opt.title) { mk += '<h3>'+opt.title+'</h3>'; }
-        if (opt.message) { mk += '<span class="modx-smsg-message">'+opt.message+'</span>'; }
-        return mk+'</div>';
+    },
+    getStatusMarkup: function(opt) {
+        let mk = '<div class="modx-status-msg">';
+        if (opt.title) {
+            mk += '<h3>' + opt.title + '</h3>';
+        }
+        if (opt.message) {
+            mk += '<span class="modx-smsg-message">' + opt.message + '</span>';
+        }
+        return mk + '</div>';
     }
 });
-Ext.reg('modx-msg',MODx.Msg);
+Ext.reg('modx-msg', MODx.Msg);
 
 /**
  * Server-side state provider for MODx
@@ -1025,52 +1041,52 @@ Ext.reg('modx-msg',MODx.Msg);
 MODx.HttpProvider = function(config) {
     config = config || {};
     this.addEvents(
-        'readsuccess'
-        ,'readfailure'
-        ,'writesuccess'
-        ,'writefailure'
+        'readsuccess',
+        'readfailure',
+        'writesuccess',
+        'writefailure'
     );
-    MODx.HttpProvider.superclass.constructor.call(this,config);
+    MODx.HttpProvider.superclass.constructor.call(this, config);
     Ext.apply(this, config, {
-        delay: 500
-        ,dirty: false
-        ,started: false
-        ,autoStart: true
-        ,autoRead: true
-        ,queue: {}
-        ,readUrl: MODx.config.connector_url
-        ,writeUrl: MODx.config.connector_url
-        ,method: 'post'
-        ,baseParams: {
-            register: 'state'
-            ,topic: ''
-        }
-        ,writeBaseParams: {
-            action: 'System/Registry/Register/Send'
-            ,message: ''
-            ,message_key: ''
-            ,message_format: 'json'
-            ,delay: 0
-            ,ttl: 0
-            ,kill: 0
-        }
-        ,readBaseParams: {
-            action: 'System/Registry/Register/Read'
-            ,format: 'json'
-            ,poll_limit: 1
-            ,poll_interval: 1
-            ,time_limit: 10
-            ,message_limit: 1000
-            ,remove_read: 0
-            ,show_filename: 0
-            ,include_keys: 1
-        }
-        ,paramNames: {
-            topic: 'topic'
-            ,name: 'name'
-            ,value: 'value'
-            ,message: 'message'
-            ,message_key: 'message_key'
+        delay: 500,
+        dirty: false,
+        started: false,
+        autoStart: true,
+        autoRead: true,
+        queue: {},
+        readUrl: MODx.config.connector_url,
+        writeUrl: MODx.config.connector_url,
+        method: 'post',
+        baseParams: {
+            register: 'state',
+            topic: ''
+        },
+        writeBaseParams: {
+            action: 'System/Registry/Register/Send',
+            message: '',
+            message_key: '',
+            message_format: 'json',
+            delay: 0,
+            ttl: 0,
+            kill: 0
+        },
+        readBaseParams: {
+            action: 'System/Registry/Register/Read',
+            format: 'json',
+            poll_limit: 1,
+            poll_interval: 1,
+            time_limit: 10,
+            message_limit: 1000,
+            remove_read: 0,
+            show_filename: 0,
+            include_keys: 1
+        },
+        paramNames: {
+            topic: 'topic',
+            name: 'name',
+            value: 'value',
+            message: 'message',
+            message_key: 'message_key'
         }
     });
     this.config = config;
@@ -1091,32 +1107,32 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
         } else {
             this.state = {};
         }
-    }
-    ,set: function(name, value) {
+    },
+    set: function(name, value) {
         if (!name) {
             return;
         }
         this.queueChange(name, value);
-    }
-    ,get : function(name, defaultValue){
-        return typeof this.state[name] == "undefined" ?
+    },
+    get: function(name, defaultValue) {
+        return typeof this.state[name] == 'undefined' ?
             defaultValue : this.state[name];
-    }
-    ,start: function() {
+    },
+    start: function() {
         this.dt.delay(this.delay);
         this.started = true;
-    }
-    ,stop: function() {
+    },
+    stop: function() {
         this.dt.cancel();
         this.started = false;
-    }
-    ,queueChange:function(name, value) {
-        var lastValue = this.state[name];
-        var found = this.queue[name] !== undefined;
+    },
+    queueChange: function(name, value) {
+        let lastValue = this.state[name];
+        let found = this.queue[name] !== undefined;
         if (found) {
             lastValue = this.queue[name];
         }
-        var changed = undefined === lastValue || lastValue !== value;
+        let changed = undefined === lastValue || lastValue !== value;
         if (changed) {
             this.queue[name] = value;
             this.dirty = true;
@@ -1125,24 +1141,24 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
             this.start();
         }
         return changed;
-    }
-    ,submitState: function() {
+    },
+    submitState: function() {
         if (!this.dirty) {
             this.dt.delay(this.delay);
             return;
         }
         this.dt.cancel();
 
-        var o = {
-             url: this.writeUrl
-            ,method: this.method
-            ,scope: this
-            ,success: this.onWriteSuccess
-            ,failure: this.onWriteFailure
-            ,queue: Ext.apply({}, this.queue)
-            ,params: {}
+        let o = {
+            url: this.writeUrl,
+            method: this.method,
+            scope: this,
+            success: this.onWriteSuccess,
+            failure: this.onWriteFailure,
+            queue: Ext.apply({}, this.queue),
+            params: {}
         };
-        var params = Ext.apply({}, this.baseParams, this.writeBaseParams);
+        let params = Ext.apply({}, this.baseParams, this.writeBaseParams);
         params[this.paramNames.topic] = '/ys/user-' + MODx.user.id + '/';
         params[this.paramNames.message] = Ext.encode(this.queue);
 
@@ -1151,17 +1167,17 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
         this.dirty = false;
 
         Ext.Ajax.request(o);
-    }
-    ,clear: function(name) {
+    },
+    clear: function(name) {
         this.set(name, undefined);
-    }
-    ,onWriteSuccess: function(r,o) {
+    },
+    onWriteSuccess: function(r, o) {
         r = Ext.decode(r.responseText);
         if (true !== r.success) {
             this.dirty = true;
         } else {
             Ext.iterate(o.queue, function(name, value) {
-                if(!name) {
+                if (!name) {
                     return;
                 }
                 if (undefined === value || null === value) {
@@ -1175,7 +1191,7 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
                 this.queue = {};
             } else {
                 Ext.iterate(o.queue, function(name, value) {
-                    var found = this.queue[name] !== undefined;
+                    let found = this.queue[name] !== undefined;
                     if (true === found && value === this.queue[name]) {
                         delete this.queue[name];
                     }
@@ -1183,19 +1199,19 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
             }
             this.fireEvent('writesuccess', this);
         }
-    }
-    ,onWriteFailure: function(r) {
+    },
+    onWriteFailure: function(r) {
         r = Ext.decode(r.responseText);
         this.dirty = true;
         this.fireEvent('writefailure', this);
-    }
-    ,onReadFailure: function(r) {
+    },
+    onReadFailure: function(r) {
         r = Ext.decode(r.responseText);
         this.fireEvent('readfailure', this);
-    }
-    ,onReadSuccess: function(r) {
+    },
+    onReadSuccess: function(r) {
         r = Ext.decode(r.responseText);
-        var state;
+        let state;
         if (true === r.success && r.message) {
             state = Ext.decode(r.message);
             if (!(state instanceof Object)) {
@@ -1208,18 +1224,18 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
             this.dirty = false;
             this.fireEvent('readsuccess', this);
         }
-    }
-    ,readState: function() {
-        var o = {
-             url: this.readUrl
-            ,method: this.method
-            ,scope: this
-            ,success: this.onReadSuccess
-            ,failure: this.onReadFailure
-            ,params: {}
+    },
+    readState: function() {
+        let o = {
+            url: this.readUrl,
+            method: this.method,
+            scope: this,
+            success: this.onReadSuccess,
+            failure: this.onReadFailure,
+            params: {}
         };
 
-        var params = Ext.apply({}, this.baseParams, this.readBaseParams);
+        let params = Ext.apply({}, this.baseParams, this.readBaseParams);
         params[this.paramNames.topic] = '/ys/user-' + MODx.user.id + '/';
 
         Ext.apply(o.params, params);
@@ -1231,11 +1247,11 @@ MODx.Header = function(config) {
     config = config || {};
 
     Ext.applyIf(config, {
-        cls: 'modx-page-header'
-        ,autoEl: {
+        cls: 'modx-page-header',
+        autoEl: {
             tag: 'h2'
-        }
-        ,itemId: 'header'
+        },
+        itemId: 'header'
     });
     MODx.Header.superclass.constructor.call(this, config);
 };
@@ -1246,8 +1262,8 @@ MODx.Description = function(config) {
     config = config || {};
 
     Ext.applyIf(config, {
-        cls: 'panel-desc'
-        ,itemId: 'description'
+        cls: 'panel-desc',
+        itemId: 'description'
     });
     MODx.Description.superclass.constructor.call(this, config);
 };

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -209,8 +209,8 @@ Ext.extend(MODx, Ext.Component, {
             const
                 matched = r.responseText.match(/<body[^>]*>([\w|\W]*)<\/body>/im),
                 text = typeof matched[1] !== 'undefined'
-                    ? '<p>' + e.message + ':</p>' + matched[1]
-                    : e.message + ': ' + r.responseText
+                    ? `<p>${e.message}:</p>${matched[1]}`
+                    : `${e.message}: ${r.responseText}`
             ;
             Ext.MessageBox.show({
                 title: _('error'),
@@ -223,7 +223,7 @@ Ext.extend(MODx, Ext.Component, {
                 width: 600
             });
         }
-        if (r && (r.code == 401 || (r.object && r.object.code == 401))) {
+        if (r && (r.code === 401 || (r.object && r.object.code === 401))) {
             if (!MODx.loginWindow) {
                 MODx.loginWindow = MODx.load({
                     xtype: 'modx-window-login',
@@ -255,7 +255,7 @@ Ext.extend(MODx, Ext.Component, {
                 shutdown: {
                     fn: function() {
                         if (this.fireEvent('afterClearCache')) {
-                            if (MODx.config.clear_cache_refresh_trees == 1) {
+                            if (parseInt(MODx.config.clear_cache_refresh_trees, 10) === 1) {
                                 Ext.getCmp('modx-layout').refreshTrees();
                             }
                         }
@@ -413,7 +413,7 @@ Ext.extend(MODx, Ext.Component, {
 
     setStaticElementPath: function(type) {
         const
-            typePlural = type + 's',
+            typePlural = `${type}s`,
             nameField = type === 'template' ? 'templatename' : 'name'
         ;
         let
@@ -421,8 +421,8 @@ Ext.extend(MODx, Ext.Component, {
             path = '',
             name = ''
         ;
-        if (MODx.config['static_elements_automate_' + typePlural] == 1) {
-            category = Ext.getCmp('modx-' + type + '-category').getValue();
+        if (parseInt(MODx.config[`static_elements_automate_${typePlural}`], 10) === 1) {
+            category = Ext.getCmp(`modx-${type}-category`).getValue();
             if (category > 0) {
                 Ext.Ajax.request({
                     url: MODx.config.connector_url,
@@ -437,26 +437,26 @@ Ext.extend(MODx, Ext.Component, {
                             categoryText = (data && data.success && data.results) ? data.results[0].name : ''
                         ;
                         if (categoryText) {
-                            name = Ext.getCmp('modx-' + type + '-' + nameField).getValue();
+                            name = Ext.getCmp(`modx-${type}-${nameField}`).getValue();
                             path = MODx.getStaticElementsPath(name, categoryText, typePlural);
-                            Ext.getCmp('modx-' + type + '-static-file').setValue(path);
+                            Ext.getCmp(`modx-${type}-static-file`).setValue(path);
                         }
                     }
                 });
             } else {
-                name = Ext.getCmp('modx-' + type + '-' + nameField).getValue();
+                name = Ext.getCmp(`modx-${type}-${nameField}`).getValue();
                 path = MODx.getStaticElementsPath(name, '', typePlural);
-                Ext.getCmp('modx-' + type + '-static-file').setValue(path);
+                Ext.getCmp(`modx-${type}-static-file`).setValue(path);
             }
         }
     },
 
     setStaticElementsConfig: function(config, type) {
-        const typePlural = type + 's';
+        const typePlural = `${type}s`;
 
-        if (MODx.request.a === 'element/' + type + '/create' && MODx.config['static_elements_automate_' + typePlural] == 1) {
+        if (MODx.request.a === `element/${type}/create` && parseInt(MODx.config[`static_elements_automate_${typePlural}`], 10) === 1) {
             config.record.static = 1;
-            config.record.static_file = MODx.config.static_elements_basepath + typePlural + '/';
+            config.record.static_file = `${MODx.config.static_elements_basepath + typePlural}/`;
             config.record.category = MODx.config.static_elements_default_category;
 
             if (MODx.config.static_elements_default_mediasource) {
@@ -474,11 +474,13 @@ Ext.extend(MODx, Ext.Component, {
         ;
 
         if (category.length > 0) {
-            category = category.replace(/[^\w\s-]/gi, '');
-            category = category.replace(/\s/g, '-').toLowerCase();
-            // Convert nested elements to nested directory structure.
-            category = category.replace(/--/gi, '/');
-            category = '/' + category + '/';
+            category = category
+                .replace(/[^\w\s-]/gi, '')
+                .replace(/\s/g, '-')
+                .toLowerCase()
+                .replace(/--/gi, '/') // Convert nested elements to nested directory structure
+            ;
+            category = `/${category}/`;
         } else {
             category = '/';
         }
@@ -488,13 +490,13 @@ Ext.extend(MODx, Ext.Component, {
 
         switch (type) {
             case 'templates':
-                ext = '.template' + (MODx.config.static_elements_html_extension || '.tpl');
+                ext = `.template${MODx.config.static_elements_html_extension || '.tpl'}`;
                 break;
             case 'tvs':
-                ext = '.tv' + (MODx.config.static_elements_html_extension || '.tpl');
+                ext = `.tv${MODx.config.static_elements_html_extension || '.tpl'}`;
                 break;
             case 'chunks':
-                ext = '.chunk' + (MODx.config.static_elements_html_extension || '.tpl');
+                ext = `.chunk${MODx.config.static_elements_html_extension || '.tpl'}`;
                 break;
             case 'snippets':
                 ext = '.snippet.php';
@@ -502,13 +504,16 @@ Ext.extend(MODx, Ext.Component, {
             case 'plugins':
                 ext = '.plugin.php';
                 break;
+            // no default
         }
 
         // Remove special characters and spaces.
-        name = name.replace(/[^\w\s-]/gi, '');
-        name = name.replace(/\s/g, '-').toLowerCase();
-
-        path += name.length > 0 ? '/' + type + category + name + ext : '/' + type + category ;
+        name = name
+            .replace(/[^\w\s-]/gi, '')
+            .replace(/\s/g, '-')
+            .toLowerCase()
+        ;
+        path += name.length > 0 ? `/${type}${category}${name}${ext}` : `/${type}${category}` ;
 
         return path;
     },
@@ -567,7 +572,7 @@ Ext.extend(MODx, Ext.Component, {
         const tabPanel = Ext.getCmp(panelId);
         if (tabPanel) {
             Ext.applyIf(newTabConfig, {
-                id: 'modx-' + Ext.id() + '-tab',
+                id: `modx-${Ext.id()}-tab`,
                 layout: 'form',
                 labelAlign: 'top',
                 cls: 'modx-resource-tab',
@@ -616,10 +621,10 @@ Ext.extend(MODx, Ext.Component, {
 
     _getNextActiveTab: function(tp, tab) {
         let id;
-        if (MODx.hiddenTabs.indexOf(tab) != -1) {
+        if (MODx.hiddenTabs.indexOf(tab) !== -1) {
             for (let i = 0; i < tp.items.items.length; i++) {
                 id = tp.items.items[i].id;
-                if (MODx.hiddenTabs.indexOf(id) == -1) {
+                if (MODx.hiddenTabs.indexOf(id) === -1) {
                     break;
                 }
             }
@@ -640,7 +645,7 @@ Ext.extend(MODx, Ext.Component, {
     moveTV: function(tvId, targetId) {
         const
             sourcePanel = Ext.getCmp('modx-panel-resource-tv'),
-            sourceItem = Ext.get(tvId + '-tr'),
+            sourceItem = Ext.get(`${tvId}-tr`),
             target = Ext.getCmp(targetId)
         ;
         if (!sourcePanel || !sourceItem || !target) {
@@ -650,21 +655,23 @@ Ext.extend(MODx, Ext.Component, {
         target.add({
             html: '',
             width: '100%',
-            id: 'tv-tr-out-' + tvId,
+            id: `tv-tr-out-${tvId}`,
             cls: 'modx-tv-out'
         });
         target.doLayout();
 
-        const targetItem = Ext.get('tv-tr-out-' + tvId);
+        const targetItem = Ext.get(`tv-tr-out-${tvId}`);
         if (targetItem) {
             targetItem.replaceWith(sourceItem);
         } else {
             const id = tvId.replace('tv', '');
-            console.warn('Attempted to move the TV named "'
-                + sourceItem.dom.innerText + '" (id #' + id + ') to the panel with the id "'
-                + target.id + '" but the original TV field could not be found. '
-                + 'It is likely a conflicting customization rule has already tried to move this TV.'
-            );
+            // eslint-disable-next-line no-console
+            console.warn(`
+                Attempted to move the TV named "${sourceItem.dom.innerText}" (id #${id}) 
+                to the panel with the id "${target.id}" but the original TV field could not be found.
+
+                It is likely a conflicting customization rule has already tried to move this TV.
+            `);
         }
     },
 
@@ -681,7 +688,7 @@ Ext.extend(MODx, Ext.Component, {
         }
         let el;
         for (let i = 0; i < tvs.length; i++) {
-            el = Ext.get(tvs[i] + '-tr');
+            el = Ext.get(`${tvs[i]}-tr`);
             if (el) {
                 el.setVisibilityMode(Ext.Element.DISPLAY);
                 el.hide();
@@ -766,7 +773,7 @@ Ext.extend(MODx, Ext.Component, {
     },
 
     debug: function(msg) {
-        if (MODx.config.ui_debug_mode == 1) {
+        if (parseInt(MODx.config.ui_debug_mode, 10) === 1) {
             console.log(msg);
         }
     },
@@ -787,7 +794,7 @@ Ext.extend(MODx, Ext.Component, {
             listeners: {
                 success: {
                     fn: function(r) {
-                        MODx.loadPage('?a=resource/update&id=' + r.a.result.object.id);
+                        MODx.loadPage(`?a=resource/update&id=${r.a.result.object.id}`);
                     },
                     scope: this
                 },
@@ -811,7 +818,7 @@ Ext.extend(MODx, Ext.Component, {
             switch: lang
         };
         Ext.iterate(MODx.request, function(key, value) {
-            params['target_' + key] = value;
+            params[`target_${key}`] = value;
         });
         MODx.loadPage('language', params);
     }
@@ -909,7 +916,7 @@ Ext.extend(MODx.form.Handler, Ext.Component, {
             if (fld && fld.dom) {
                 fld.dom.style.border = '1px solid red';
             }
-            const ef = Ext.get(f.id + '_error');
+            const ef = Ext.get(`${f.id}_error`);
             if (ef) {
                 ef.innerHTML = f.msg;
             }
@@ -920,7 +927,7 @@ Ext.extend(MODx.form.Handler, Ext.Component, {
     unhighlightFields: function() {
         for (let i = 0; i < this.fields.length; i += 1) {
             Ext.get(this.fields[i]).dom.style.border = '';
-            const ef = Ext.get(this.fields[i] + '_error');
+            const ef = Ext.get(`${this.fields[i]}_error`);
             if (ef) {
                 ef.innerHTML = '';
             }
@@ -988,7 +995,7 @@ Ext.extend(MODx.Msg, Ext.Component, {
         }
         Ext.MessageBox.minWidth = config.minWidth || 200;
         Ext.Msg.confirm(config.title || _('warning'), config.text, function(e) {
-            if (e == 'yes') {
+            if (e === 'yes') {
                 MODx.Ajax.request({
                     url: config.url,
                     params: config.params || {},
@@ -1054,12 +1061,12 @@ Ext.extend(MODx.Msg, Ext.Component, {
     getStatusMarkup: function(opt) {
         let mk = '<div class="modx-status-msg">';
         if (opt.title) {
-            mk += '<h3>' + opt.title + '</h3>';
+            mk += `<h3>${opt.title}</h3>`;
         }
         if (opt.message) {
-            mk += '<span class="modx-smsg-message">' + opt.message + '</span>';
+            mk += `<span class="modx-smsg-message">${opt.message}</span>`;
         }
-        return mk + '</div>';
+        return `${mk}</div>`;
     }
 });
 Ext.reg('modx-msg', MODx.Msg);
@@ -1199,7 +1206,7 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
             },
             params = Ext.apply({}, this.baseParams, this.writeBaseParams)
         ;
-        params[this.paramNames.topic] = '/ys/user-' + MODx.user.id + '/';
+        params[this.paramNames.topic] = `/ys/user-${MODx.user.id}/`;
         params[this.paramNames.message] = Ext.encode(this.queue);
 
         Ext.apply(o.params, params);
@@ -1213,26 +1220,26 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
 
     onWriteSuccess: function(r, o) {
         r = Ext.decode(r.responseText);
-        if (true !== r.success) {
+        if (r.success !== true) {
             this.dirty = true;
         } else {
             Ext.iterate(o.queue, function(name, value) {
                 if (!name) {
                     return;
                 }
-                if (undefined === value || null === value) {
+                if (value === undefined || value === null) {
                     MODx.HttpProvider.superclass.clear.call(this, name);
                 } else {
                     // parent sets value and fires event
                     MODx.HttpProvider.superclass.set.call(this, name, value);
                 }
             }, this);
-            if (false === this.dirty) {
+            if (this.dirty === false) {
                 this.queue = {};
             } else {
                 Ext.iterate(o.queue, function(name, value) {
                     const found = this.queue[name] !== undefined;
-                    if (true === found && value === this.queue[name]) {
+                    if (found === true && value === this.queue[name]) {
                         delete this.queue[name];
                     }
                 }, this);
@@ -1255,7 +1262,7 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
     onReadSuccess: function(r) {
         r = Ext.decode(r.responseText);
         let state;
-        if (true === r.success && r.message) {
+        if (r.success === true && r.message) {
             state = Ext.decode(r.message);
             if (!(state instanceof Object)) {
                 return;
@@ -1281,7 +1288,7 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
             },
             params = Ext.apply({}, this.baseParams, this.readBaseParams)
         ;
-        params[this.paramNames.topic] = '/ys/user-' + MODx.user.id + '/';
+        params[this.paramNames.topic] = `/ys/user-${MODx.user.id}/`;
 
         Ext.apply(o.params, params);
         Ext.Ajax.request(o);

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -19,8 +19,10 @@ const globalAutoCompleteSetting = 'off';
  */
 if ((typeof Range !== 'undefined') && !Range.prototype.createContextualFragment) {
     Range.prototype.createContextualFragment = function(html) {
-        let frag = document.createDocumentFragment(),
-            div = document.createElement('div');
+        const
+            frag = document.createDocumentFragment(),
+            div = document.createElement('div')
+        ;
         frag.appendChild(div);
         div.outerHTML = html;
         return frag;
@@ -32,8 +34,7 @@ if ((typeof Range !== 'undefined') && !Range.prototype.createContextualFragment)
  * @param {Object} config An object of config properties
  * @xtype modx
  */
-MODx = function(config) {
-    config = config || {};
+MODx = function(config = {}) {
     MODx.superclass.constructor.call(this, config);
     this.config = config;
     this.startup();
@@ -112,24 +113,25 @@ Ext.extend(MODx, Ext.Component, {
      */
     add: function(cmp) {
         if (typeof cmp === 'string') {
-            cmp = { xtype: cmp }
+            cmp = {
+                xtype: cmp
+            };
         }
-        let ctr = Ext.getCmp('modx-content');
-        if (ctr) {
-            ctr.removeAll();
-            ctr.add(cmp);
-            ctr.doLayout();
+        const contentPanel = Ext.getCmp('modx-content');
+        if (contentPanel) {
+            contentPanel.removeAll();
+            contentPanel.add(cmp);
+            contentPanel.doLayout();
         }
     },
 
-    load: function() {
-        let a = arguments, l = a.length;
-        let os = [];
-        for (let i = 0; i < l; i += 1) {
-            if (!a[i].xtype || a[i].xtype === '') {
+    load: function(...args) {
+        const os = [];
+        for (let i = 0; i < args.length; i += 1) {
+            if (!args[i].xtype || args[i].xtype === '') {
                 return false;
             }
-            os.push(Ext.ComponentMgr.create(a[i]));
+            os.push(Ext.ComponentMgr.create(args[i]));
         }
         return (os.length === 1) ? os[0] : os;
     },
@@ -143,53 +145,56 @@ Ext.extend(MODx, Ext.Component, {
     },
 
     initMarkRequiredFields: function() {
-        const markerEl = '<span class=\"field-required-mark\">*</span>';
+        const
+            markerEl = '<span class="field-required-mark">*</span>',
+            MarkRequiredFieldPlugin = function(config = {}) {
+                Ext.apply(config, {
+                    init: function(cmp) {
+                        if (cmp.allowBlank !== false) {
+                            return;
+                        }
+                        const cmpLabel = cmp.fieldLabel;
 
-        const MarkRequiredFieldPlugin = function(config) {
-            config = config || {};
-            Ext.apply(config, {
-                init: function(cmp) {
-                    if (cmp.allowBlank !== false) { return; }
-
-                    const cmpLabel = cmp.fieldLabel;
-
-                    if (cmpLabel) {
-                        cmp.fieldLabel = cmpLabel + markerEl;
-                    } else {
-                        let labelEl = null;
-                        if (cmp.caption && document.getElementById(cmp.caption)) {
-                            labelEl = document.getElementById(cmp.caption);
+                        if (cmpLabel) {
+                            cmp.fieldLabel = cmpLabel + markerEl;
                         } else {
-                            const id = cmp.itemId;
-                            if (id && id.match(/^tv[\d]*$/i)) {
-                                labelEl = document.getElementById(`${id}-caption`);
+                            let labelEl = null;
+                            if (cmp.caption && document.getElementById(cmp.caption)) {
+                                labelEl = document.getElementById(cmp.caption);
+                            } else {
+                                const id = cmp.itemId;
+                                if (id && id.match(/^tv[\d]*$/i)) {
+                                    labelEl = document.getElementById(`${id}-caption`);
+                                }
+                            }
+                            if (labelEl) {
+                                labelEl.innerHTML += markerEl;
                             }
                         }
-                        if (labelEl) {
-                            labelEl.innerHTML += markerEl;
-                        }
                     }
-                }
-            });
-            MarkRequiredFieldPlugin.superclass.constructor.call(this, config);
-        }
+                });
+                MarkRequiredFieldPlugin.superclass.constructor.call(this, config);
+            };
         Ext.extend(MarkRequiredFieldPlugin, Ext.BoxComponent);
         Ext.ComponentMgr.registerPlugin('markrequiredfields', MarkRequiredFieldPlugin);
 
         if (!Array.isArray(Ext.form.Field.prototype.plugins)) {
             Ext.form.Field.prototype.plugins = [];
         }
-        let plugins = Ext.form.Field.prototype.plugins;
+        const { plugins } = Ext.form.Field.prototype;
         Ext.form.Field.prototype.plugins = Ext.form.Field.prototype.plugins.concat(['markrequiredfields'], plugins);
     },
 
     getURLParameters: function() {
-        let arg = {};
-        let href = window.location.search;
-
+        const
+            arg = {},
+            href = window.location.search
+        ;
         if (href.indexOf('?') !== -1) {
-            let params = href.split('?')[1];
-            let param = params.split('&');
+            const
+                params = href.split('?')[1],
+                param = params.split('&')
+            ;
             for (let i = 0; i < param.length; i += 1) {
                 arg[param[i].split('=')[0]] = param[i].split('=')[1];
             }
@@ -201,12 +206,12 @@ Ext.extend(MODx, Ext.Component, {
         try {
             r = Ext.decode(r.responseText);
         } catch (e) {
-            let text, matched = r.responseText.match(/<body[^>]*>([\w|\W]*)<\/body>/im);
-            if (typeof(matched[1] !== 'undefined')) {
-                text = '<p>' + e.message + ':</p>' + matched[1];
-            } else {
-                text = e.message + ': ' + r.responseText;
-            }
+            const
+                matched = r.responseText.match(/<body[^>]*>([\w|\W]*)<\/body>/im),
+                text = typeof matched[1] !== 'undefined'
+                    ? '<p>' + e.message + ':</p>' + matched[1]
+                    : e.message + ': ' + r.responseText
+            ;
             Ext.MessageBox.show({
                 title: _('error'),
                 msg: text,
@@ -229,12 +234,17 @@ Ext.extend(MODx, Ext.Component, {
         }
     },
 
-    loadAccordionPanels: function() { return []; },
+    loadAccordionPanels: function() {
+        return [];
+    },
 
     clearCache: function() {
-        if (!this.fireEvent('beforeClearCache')) { return false; }
+        if (!this.fireEvent('beforeClearCache')) {
+            return false;
+        }
 
-        let topic = '/clearcache/';
+        const topic = '/clearcache/';
+
         this.console = MODx.load({
             xtype: 'modx-console',
             register: 'mgr',
@@ -242,14 +252,16 @@ Ext.extend(MODx, Ext.Component, {
             clear: true,
             show_filename: 0,
             listeners: {
-                'shutdown': {fn: function() {
-                    if (this.fireEvent('afterClearCache')) {
-                        if (MODx.config.clear_cache_refresh_trees == 1) {
-                            Ext.getCmp('modx-layout').refreshTrees();
+                shutdown: {
+                    fn: function() {
+                        if (this.fireEvent('afterClearCache')) {
+                            if (MODx.config.clear_cache_refresh_trees == 1) {
+                                Ext.getCmp('modx-layout').refreshTrees();
+                            }
                         }
-                    }
-                },
-                scope: this}
+                    },
+                    scope: this
+                }
             }
         });
 
@@ -266,17 +278,19 @@ Ext.extend(MODx, Ext.Component, {
                 action_map: true
             },
             listeners: {
-                'success': {fn: function() {
-                    this.console.fireEvent('complete');
-                },
-                scope: this}
+                success: {
+                    fn: function() {
+                        this.console.fireEvent('complete');
+                    },
+                    scope: this
+                }
             }
         });
         return true;
     },
 
     refreshURIs: function() {
-        let topic = '/refreshuris/';
+        const topic = '/refreshuris/';
         MODx.msg.status({
             title: _('please_wait'),
             message: _('refreshuris_desc'),
@@ -291,15 +305,17 @@ Ext.extend(MODx, Ext.Component, {
                 menu: true
             },
             listeners: {
-                'success': {fn: function(r) {
-                    MODx.msg.status({
-                        title: _('success'),
-                        message: r.message || _('refresh_success'),
-                        dontHide: false
-                    });
-                    this.clearCache();
-                },
-                scope: this}
+                success: {
+                    fn: function(response) {
+                        MODx.msg.status({
+                            title: _('success'),
+                            message: response.message || _('refresh_success'),
+                            dontHide: false
+                        });
+                        this.clearCache();
+                    },
+                    scope: this
+                }
             }
         });
         return true;
@@ -313,7 +329,12 @@ Ext.extend(MODx, Ext.Component, {
                     id: id
                 },
                 listeners: {
-                    'success': {fn: function(r) { this.fireEvent('afterReleaseLocks', r); }, scope: this}
+                    success: {
+                        fn: function(response) {
+                            this.fireEvent('afterReleaseLocks', response);
+                        },
+                        scope: this
+                    }
                 }
             });
         }
@@ -327,16 +348,15 @@ Ext.extend(MODx, Ext.Component, {
                 action: 'System/RemoveLocks'
             },
             listeners: {
-                'success': {
+                success: {
                     fn: function() {
-                        let tree = Ext.getCmp('modx-resource-tree');
-
+                        const
+                            tree = Ext.getCmp('modx-resource-tree'),
+                            cmp = Ext.getCmp('modx-panel-resource')
+                        ;
                         if (tree && tree.rendered) {
                             tree.refresh();
                         }
-
-                        let cmp = Ext.getCmp('modx-panel-resource');
-
                         if (cmp) {
                             Ext.getCmp('modx-abtn-locked').hide();
                             Ext.getCmp('modx-abtn-save').show();
@@ -349,7 +369,7 @@ Ext.extend(MODx, Ext.Component, {
     },
 
     sleep: function(ms) {
-        let s = new Date().getTime();
+        const s = new Date().getTime();
         for (let i = 0; i < 1e7; i++) {
             if ((new Date().getTime() - s) > ms) {
                 break;
@@ -368,19 +388,20 @@ Ext.extend(MODx, Ext.Component, {
                     login_context: 'mgr'
                 },
                 listeners: {
-                    'success': {fn: function(r) {
-                        if (this.fireEvent('afterLogout', r)) {
-                            location.href = './';
-                        }
-                    },
-                    scope: this}
+                    success: {
+                        fn: function(response) {
+                            if (this.fireEvent('afterLogout', response)) {
+                                window.location.href = './';
+                            }
+                        },
+                        scope: this
+                    }
                 }
             });
         }
     },
 
-    getPageStructure: function(v, c) {
-        c = c || {};
+    getPageStructure: function(v, c = {}) {
         Ext.applyIf(c, {
             xtype: 'modx-tabs',
             itemId: 'tabs',
@@ -391,16 +412,15 @@ Ext.extend(MODx, Ext.Component, {
     },
 
     setStaticElementPath: function(type) {
-        let category = '',
+        const
+            typePlural = type + 's',
+            nameField = type === 'template' ? 'templatename' : 'name'
+        ;
+        let
+            category = '',
             path = '',
-            name = '',
-            nameField = 'name',
-            typePlural = type + 's';
-
-        if (type === 'template') {
-            nameField = 'templatename';
-        }
-
+            name = ''
+        ;
         if (MODx.config['static_elements_automate_' + typePlural] == 1) {
             category = Ext.getCmp('modx-' + type + '-category').getValue();
             if (category > 0) {
@@ -409,17 +429,19 @@ Ext.extend(MODx, Ext.Component, {
                     params: {
                         action: 'Element/Category/GetList',
                         id: category,
-                        limit: 0,
+                        limit: 0
                     },
                     success: function(response) {
-                        let data = Ext.decode(response.responseText);
-                        categoryText = (data && data.success && data.results) ? data.results[0].name : '';
+                        const
+                            data = Ext.decode(response.responseText),
+                            categoryText = (data && data.success && data.results) ? data.results[0].name : ''
+                        ;
                         if (categoryText) {
                             name = Ext.getCmp('modx-' + type + '-' + nameField).getValue();
                             path = MODx.getStaticElementsPath(name, categoryText, typePlural);
                             Ext.getCmp('modx-' + type + '-static-file').setValue(path);
                         }
-                    },
+                    }
                 });
             } else {
                 name = Ext.getCmp('modx-' + type + '-' + nameField).getValue();
@@ -430,15 +452,15 @@ Ext.extend(MODx, Ext.Component, {
     },
 
     setStaticElementsConfig: function(config, type) {
-        let typePlural = type + 's';
+        const typePlural = type + 's';
 
         if (MODx.request.a === 'element/' + type + '/create' && MODx.config['static_elements_automate_' + typePlural] == 1) {
-            config.record['static'] = 1;
-            config.record['static_file'] = MODx.config.static_elements_basepath + typePlural + '/';
-            config.record['category'] = MODx.config.static_elements_default_category;
+            config.record.static = 1;
+            config.record.static_file = MODx.config.static_elements_basepath + typePlural + '/';
+            config.record.category = MODx.config.static_elements_default_category;
 
             if (MODx.config.static_elements_default_mediasource) {
-                config.record['source'] = MODx.config.static_elements_default_mediasource;
+                config.record.source = MODx.config.static_elements_default_mediasource;
             }
         }
 
@@ -446,8 +468,10 @@ Ext.extend(MODx, Ext.Component, {
     },
 
     getStaticElementsPath: function(name, category, type) {
-        let path = MODx.config.static_elements_basepath,
-            ext = '';
+        let
+            path = MODx.config.static_elements_basepath,
+            ext = ''
+        ;
 
         if (category.length > 0) {
             category = category.replace(/[^\w\s-]/gi, '');
@@ -484,21 +508,18 @@ Ext.extend(MODx, Ext.Component, {
         name = name.replace(/[^\w\s-]/gi, '');
         name = name.replace(/\s/g, '-').toLowerCase();
 
-        if (name.length > 0) {
-            path += '/' + type + category + name + ext;
-        } else {
-            path += '/' + type + category;
-        }
+        path += name.length > 0 ? '/' + type + category + name + ext : '/' + type + category ;
 
         return path;
     },
 
     helpUrl: false,
 
-    loadHelpPane: function(b) {
+    loadHelpPane: function(button) {
         let url = MODx.helpUrl || MODx.config.help_url || '';
-        if (!url || !url.length) { return false; }
-
+        if (!url || !url.length) {
+            return false;
+        }
         if (url.substring(0, 4) !== 'http') {
             url = MODx.config.base_help_url + url;
         }
@@ -531,7 +552,7 @@ Ext.extend(MODx, Ext.Component, {
                 }]
             }]
         });
-        MODx.helpWindow.show(b);
+        MODx.helpWindow.show(button);
         return true;
     },
 
@@ -598,9 +619,13 @@ Ext.extend(MODx, Ext.Component, {
         if (MODx.hiddenTabs.indexOf(tab) != -1) {
             for (let i = 0; i < tp.items.items.length; i++) {
                 id = tp.items.items[i].id;
-                if (MODx.hiddenTabs.indexOf(id) == -1) { break; }
+                if (MODx.hiddenTabs.indexOf(id) == -1) {
+                    break;
+                }
             }
-        } else { id = tab; }
+        } else {
+            id = tab;
+        }
         return id;
     },
 
@@ -613,9 +638,10 @@ Ext.extend(MODx, Ext.Component, {
      * @return {void}
      */
     moveTV: function(tvId, targetId) {
-        const sourcePanel = Ext.getCmp('modx-panel-resource-tv'),
-              sourceItem = Ext.get(tvId + '-tr'),
-              target = Ext.getCmp(targetId)
+        const
+            sourcePanel = Ext.getCmp('modx-panel-resource-tv'),
+            sourceItem = Ext.get(tvId + '-tr'),
+            target = Ext.getCmp(targetId)
         ;
         if (!sourcePanel || !sourceItem || !target) {
             return;
@@ -720,16 +746,13 @@ Ext.extend(MODx, Ext.Component, {
         }
         window.open(url);
     },
+
     makeDroppable: function(fld, h, p) {
         if (!fld) {
             return false;
         }
+        const el = fld.getEl ? fld.getEl() : fld ;
         h = h || Ext.emptyFn;
-        if (fld.getEl) {
-            var el = fld.getEl();
-        } else if (fld) {
-            el = fld;
-        }
         if (el) {
             new MODx.load({
                 xtype: 'modx-treedrop',
@@ -741,6 +764,7 @@ Ext.extend(MODx, Ext.Component, {
         }
         return true;
     },
+
     debug: function(msg) {
         if (MODx.config.ui_debug_mode == 1) {
             console.log(msg);
@@ -761,13 +785,13 @@ Ext.extend(MODx, Ext.Component, {
             record: record,
             closeAction: 'close',
             listeners: {
-                'success': {
+                success: {
                     fn: function(r) {
                         MODx.loadPage('?a=resource/update&id=' + r.a.result.object.id);
                     },
                     scope: this
                 },
-                'failure': {
+                failure: {
                     fn: function(data, data2) {
                         console.log('failure');
                         console.log(data);
@@ -783,7 +807,7 @@ Ext.extend(MODx, Ext.Component, {
     },
 
     switchLanguage: function(lang) {
-        let params = {
+        const params = {
             switch: lang
         };
         Ext.iterate(MODx.request, function(key, value) {
@@ -802,8 +826,7 @@ Ext.reg('modx', MODx);
  * @param {Object} config An object of config properties
  * @xtype modx-ajax
  */
-MODx.Ajax = function(config) {
-    config = config || {};
+MODx.Ajax = function(config = {}) {
     MODx.Ajax.superclass.constructor.call(this, config);
 };
 Ext.extend(MODx.Ajax, Ext.Component, {
@@ -840,7 +863,7 @@ Ext.extend(MODx.Ajax, Ext.Component, {
             scope: this,
             headers: {
                 'Powered-By': 'MODx',
-                'modAuth': config.auth
+                modAuth: config.auth
             }
         });
         Ext.Ajax.request(config);
@@ -852,8 +875,8 @@ Ext.extend(MODx.Ajax, Ext.Component, {
      * @param {Array} args - An array of arguments to pass to the callback
      */
     _runCallback: function(config, args) {
-        let scope = window,
-            fn = config.fn;
+        const { fn } = config;
+        let scope = window;
 
         if (config.scope) {
             scope = config.scope;
@@ -865,8 +888,7 @@ Ext.reg('modx-ajax', MODx.Ajax);
 
 MODx = new MODx();
 
-MODx.form.Handler = function(config) {
-    config = config || {};
+MODx.form.Handler = function(config = {}) {
     MODx.form.Handler.superclass.constructor.call(this, config);
 };
 Ext.extend(MODx.form.Handler, Ext.Component, {
@@ -883,12 +905,14 @@ Ext.extend(MODx.form.Handler, Ext.Component, {
 
     highlightField: function(f) {
         if (f.id !== undefined && f.id !== 'forEach' && f.id !== '') {
-            let fld = Ext.get(f.id);
+            const fld = Ext.get(f.id);
             if (fld && fld.dom) {
                 fld.dom.style.border = '1px solid red';
             }
-            let ef = Ext.get(f.id + '_error');
-            if (ef) { ef.innerHTML = f.msg; }
+            const ef = Ext.get(f.id + '_error');
+            if (ef) {
+                ef.innerHTML = f.msg;
+            }
             this.fields.push(f.id);
         }
     },
@@ -896,7 +920,7 @@ Ext.extend(MODx.form.Handler, Ext.Component, {
     unhighlightFields: function() {
         for (let i = 0; i < this.fields.length; i += 1) {
             Ext.get(this.fields[i]).dom.style.border = '';
-            let ef = Ext.get(this.fields[i] + '_error');
+            const ef = Ext.get(this.fields[i] + '_error');
             if (ef) {
                 ef.innerHTML = '';
             }
@@ -905,13 +929,14 @@ Ext.extend(MODx.form.Handler, Ext.Component, {
     },
 
     errorJSON: function(e) {
-        if (e === '') { return this.showError(e); }
+        if (e === '') {
+            return this.showError(e);
+        }
         if (e.data && e.data !== null) {
             for (let p = 0; p < e.data.length; p += 1) {
                 this.highlightField(e.data[p]);
             }
         }
-
         this.showError(e.message);
         return false;
     },
@@ -937,17 +962,18 @@ Ext.extend(MODx.form.Handler, Ext.Component, {
         }
     },
 
-    closeError: function() { MODx.msg.hide(); }
+    closeError: function() {
+        MODx.msg.hide();
+    }
 });
 Ext.reg('modx-form-handler', MODx.form.Handler);
 
-MODx.Msg = function(config) {
-    config = config || {};
+MODx.Msg = function(config = {}) {
     MODx.Msg.superclass.constructor.call(this, config);
     this.addEvents({
-        'success': true,
-        'failure': true,
-        'cancel': true
+        success: true,
+        failure: true,
+        cancel: true
     });
     Ext.MessageBox.minWidth = 200;
 };
@@ -955,8 +981,8 @@ Ext.extend(MODx.Msg, Ext.Component, {
     confirm: function(config) {
         this.purgeListeners();
         if (config.listeners) {
-            for (let i in config.listeners) {
-                let l = config.listeners[i];
+            for (const i in config.listeners) {
+                const l = config.listeners[i];
                 this.addListener(i, l.fn, l.scope || this, l.options || {});
             }
         }
@@ -969,14 +995,18 @@ Ext.extend(MODx.Msg, Ext.Component, {
                     method: 'post',
                     scope: this,
                     listeners: {
-                        'success': {fn: function(r) {
-                            this.fireEvent('success', r);
+                        success: {
+                            fn: function(response) {
+                                this.fireEvent('success', response);
+                            },
+                            scope: this
                         },
-                        scope: this},
-                        'failure': {fn: function(r) {
-                            return this.fireEvent('failure', r);
-                        },
-                        scope: this}
+                        failure: {
+                            fn: function(response) {
+                                return this.fireEvent('failure', response);
+                            },
+                            scope: this
+                        }
                     }
                 });
             } else {
@@ -989,21 +1019,24 @@ Ext.extend(MODx.Msg, Ext.Component, {
         return Ext.Msg.getDialog();
     },
 
-    alert: function(title, text, fn, scope) {
-        fn = fn || Ext.emptyFn;
-        scope = scope || this;
+    alert: function(title, text, fn = Ext.emptyFn, scope = this) {
         Ext.Msg.alert(title, text, fn, scope);
     },
 
     status: function(opt) {
+        const
+            markup = this.getStatusMarkup(opt),
+            m = Ext.DomHelper.overwrite(MODx.stMsgCt, { html: markup }, true),
+            fadeOpts = {
+                remove: true,
+                useDisplay: true
+            }
+        ;
         if (!MODx.stMsgCt) {
-            MODx.stMsgCt = Ext.DomHelper.insertFirst(document.body, {id: 'modx-status-message-ct'}, true);
+            MODx.stMsgCt = Ext.DomHelper.insertFirst(document.body, { id: 'modx-status-message-ct' }, true);
         }
         MODx.stMsgCt.alignTo(document, 't-t');
-        let markup = this.getStatusMarkup(opt);
-        let m = Ext.DomHelper.overwrite(MODx.stMsgCt, {html: markup}, true);
 
-        let fadeOpts = {remove: true, useDisplay: true};
         if (!opt.dontHide) {
             if (!Ext.isIE8) {
                 m.pause(opt.delay || 1.5).ghost('t', fadeOpts);
@@ -1017,6 +1050,7 @@ Ext.extend(MODx.Msg, Ext.Component, {
             });
         }
     },
+
     getStatusMarkup: function(opt) {
         let mk = '<div class="modx-status-msg">';
         if (opt.title) {
@@ -1038,8 +1072,7 @@ Ext.reg('modx-msg', MODx.Msg);
  * @constructor
  * @param {Object} config Configuration object.
  */
-MODx.HttpProvider = function(config) {
-    config = config || {};
+MODx.HttpProvider = function(config = {}) {
     this.addEvents(
         'readsuccess',
         'readfailure',
@@ -1103,36 +1136,40 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
         if (state instanceof Object) {
             Ext.iterate(state, function(name, value, o) {
                 this.state[name] = value;
-            }, this)
+            }, this);
         } else {
             this.state = {};
         }
     },
+
     set: function(name, value) {
         if (!name) {
             return;
         }
         this.queueChange(name, value);
     },
+
     get: function(name, defaultValue) {
-        return typeof this.state[name] == 'undefined' ?
-            defaultValue : this.state[name];
+        return typeof this.state[name] == 'undefined' ? defaultValue : this.state[name];
     },
+
     start: function() {
         this.dt.delay(this.delay);
         this.started = true;
     },
+
     stop: function() {
         this.dt.cancel();
         this.started = false;
     },
+
     queueChange: function(name, value) {
         let lastValue = this.state[name];
-        let found = this.queue[name] !== undefined;
+        const found = this.queue[name] !== undefined;
         if (found) {
             lastValue = this.queue[name];
         }
-        let changed = undefined === lastValue || lastValue !== value;
+        const changed = undefined === lastValue || lastValue !== value;
         if (changed) {
             this.queue[name] = value;
             this.dirty = true;
@@ -1142,6 +1179,7 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
         }
         return changed;
     },
+
     submitState: function() {
         if (!this.dirty) {
             this.dt.delay(this.delay);
@@ -1149,21 +1187,22 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
         }
         this.dt.cancel();
 
-        let o = {
-            url: this.writeUrl,
-            method: this.method,
-            scope: this,
-            success: this.onWriteSuccess,
-            failure: this.onWriteFailure,
-            queue: Ext.apply({}, this.queue),
-            params: {}
-        };
-        let params = Ext.apply({}, this.baseParams, this.writeBaseParams);
+        const
+            o = {
+                url: this.writeUrl,
+                method: this.method,
+                scope: this,
+                success: this.onWriteSuccess,
+                failure: this.onWriteFailure,
+                queue: Ext.apply({}, this.queue),
+                params: {}
+            },
+            params = Ext.apply({}, this.baseParams, this.writeBaseParams)
+        ;
         params[this.paramNames.topic] = '/ys/user-' + MODx.user.id + '/';
         params[this.paramNames.message] = Ext.encode(this.queue);
 
         Ext.apply(o.params, params);
-        // be optimistic
         this.dirty = false;
 
         Ext.Ajax.request(o);
@@ -1171,6 +1210,7 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
     clear: function(name) {
         this.set(name, undefined);
     },
+
     onWriteSuccess: function(r, o) {
         r = Ext.decode(r.responseText);
         if (true !== r.success) {
@@ -1191,7 +1231,7 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
                 this.queue = {};
             } else {
                 Ext.iterate(o.queue, function(name, value) {
-                    let found = this.queue[name] !== undefined;
+                    const found = this.queue[name] !== undefined;
                     if (true === found && value === this.queue[name]) {
                         delete this.queue[name];
                     }
@@ -1200,15 +1240,18 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
             this.fireEvent('writesuccess', this);
         }
     },
+
     onWriteFailure: function(r) {
         r = Ext.decode(r.responseText);
         this.dirty = true;
         this.fireEvent('writefailure', this);
     },
+
     onReadFailure: function(r) {
         r = Ext.decode(r.responseText);
         this.fireEvent('readfailure', this);
     },
+
     onReadSuccess: function(r) {
         r = Ext.decode(r.responseText);
         let state;
@@ -1225,17 +1268,19 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
             this.fireEvent('readsuccess', this);
         }
     },
-    readState: function() {
-        let o = {
-            url: this.readUrl,
-            method: this.method,
-            scope: this,
-            success: this.onReadSuccess,
-            failure: this.onReadFailure,
-            params: {}
-        };
 
-        let params = Ext.apply({}, this.baseParams, this.readBaseParams);
+    readState: function() {
+        const
+            o = {
+                url: this.readUrl,
+                method: this.method,
+                scope: this,
+                success: this.onReadSuccess,
+                failure: this.onReadFailure,
+                params: {}
+            },
+            params = Ext.apply({}, this.baseParams, this.readBaseParams)
+        ;
         params[this.paramNames.topic] = '/ys/user-' + MODx.user.id + '/';
 
         Ext.apply(o.params, params);
@@ -1243,9 +1288,7 @@ Ext.extend(MODx.HttpProvider, Ext.state.Provider, {
     }
 });
 
-MODx.Header = function(config) {
-    config = config || {};
-
+MODx.Header = function(config = {}) {
     Ext.applyIf(config, {
         cls: 'modx-page-header',
         autoEl: {
@@ -1258,9 +1301,7 @@ MODx.Header = function(config) {
 Ext.extend(MODx.Header, Ext.BoxComponent, {});
 Ext.reg('modx-header', MODx.Header);
 
-MODx.Description = function(config) {
-    config = config || {};
-
+MODx.Description = function(config = {}) {
     Ext.applyIf(config, {
         cls: 'panel-desc',
         itemId: 'description'

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -1033,7 +1033,6 @@ Ext.extend(MODx.Msg, Ext.Component, {
     status: function(opt) {
         const
             markup = this.getStatusMarkup(opt),
-            m = Ext.DomHelper.overwrite(MODx.stMsgCt, { html: markup }, true),
             fadeOpts = {
                 remove: true,
                 useDisplay: true
@@ -1044,29 +1043,28 @@ Ext.extend(MODx.Msg, Ext.Component, {
         }
         MODx.stMsgCt.alignTo(document, 't-t');
 
+        const toast = Ext.DomHelper.overwrite(MODx.stMsgCt, { html: markup }, true);
+
         if (!opt.dontHide) {
-            if (!Ext.isIE8) {
-                m.pause(opt.delay || 1.5).ghost('t', fadeOpts);
-            } else {
-                fadeOpts.duration = (opt.delay || 1.5);
-                m.ghost('t', fadeOpts);
-            }
+            toast.pause(opt.delay || 1.5).ghost('t', fadeOpts);
         } else {
-            m.on('click', function() {
-                m.ghost('t', fadeOpts);
+            toast.on('click', () => {
+                toast.ghost('t', fadeOpts);
             });
         }
     },
 
     getStatusMarkup: function(opt) {
-        let mk = '<div class="modx-status-msg">';
-        if (opt.title) {
-            mk += `<h3>${opt.title}</h3>`;
-        }
-        if (opt.message) {
-            mk += `<span class="modx-smsg-message">${opt.message}</span>`;
-        }
-        return `${mk}</div>`;
+        const
+            title = opt.title ? `<h3>${opt.title}</h3>` : '',
+            message = opt.message ? `<span class="modx-smsg-message">${opt.message}</span>` : ''
+        ;
+        return `
+            <div class="modx-status-msg">
+                ${title}
+                ${message}
+            </div>
+        `;
     }
 });
 Ext.reg('modx-msg', MODx.Msg);

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -187,19 +187,17 @@ Ext.extend(MODx, Ext.Component, {
 
     getURLParameters: function() {
         const
-            arg = {},
-            href = window.location.search
+            paramsObject = {},
+            params = new URLSearchParams(window.location.search)
         ;
-        if (href.indexOf('?') !== -1) {
-            const
-                params = href.split('?')[1],
-                param = params.split('&')
-            ;
-            for (let i = 0; i < param.length; i += 1) {
-                arg[param[i].split('=')[0]] = param[i].split('=')[1];
+        params.forEach((value, key) => {
+            if (key.indexOf('[]') !== -1) {
+                paramsObject[key.replace('[]', '')] = params.getAll(key);
+            } else {
+                paramsObject[key] = value;
             }
-        }
-        return arg;
+        });
+        return paramsObject;
     },
 
     onAjaxException: function(conn, r, opt, e) {


### PR DESCRIPTION
### What changed and why

This is a formatting/style/syntax only set of changes to bring these JS classes up to par with coding standards and our linting rules. As with my previous merged update (#16963) a majority of lines changed are due to whitespace and comma placement changes.

I'm doing this ahead of working on a few issue-related PRs that touch these areas.

### How to test

Navigate around the manager and view and edit various items; all should work as expected and throw no errors in the console. Requires a `grunt/build` if you are reviewing with `compress_js` on.

### Related issue(s)/PR(s)

n/a

### Compatibility notes

n/a

### Breaking change assessment

Strictly-speaking, the update to the `getURLParameters` method (modx.js) could have BC implications due to:

1. Shallow array values are now collected in an array instead of being kept in string form, and
2. The URL API is now being used, which natively decodes string values. Previously, encoded strings were left as-is.

However, I'm highly confident that there are no issues core-wise. I reviewed the nature of the request variables used and tested the specific places where the encoding could come into play (namely the trees and the file browser).

On the array value handling, I don't anticipate any Extras issues as the method's current handling is broken anyway: a flaw in the logic results in only the last array value being retained. Because this bug exists already and we've not been getting complaints about it, it's reasonable to assume that either Extras are handling URL params on their own or they aren't making use of arrays (shallow ones specifically) in their request values. 

Note that, for complex arrays, the output before and after is the same, e.g.:
```javascript
?param4[0][item1]=Item1&param4[0][item2]=Item2
```
would yield:
```javascript
{
    'param4[0][item1]': 'Item1',
    'param4[0][item2]': 'Item2'
}
```

### Test coverage

While we don't have a mechanism to unit test our legacy ext js code, more sensitive changes like converting for-ins to forEach and re-organization/optimization of a couple methods were all manually tested to ensure correct scope and output was maintained.

To examine these changes more easily, take a look at the individual commits.

### Contributors

n/a

### AI tool use

None
