### PR TITLE
Update ci to use mysql 8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,15 @@ jobs:
 
     services:
       mysql:
-        image: "mysql:5.6"
-
+        image: "mysql:8.0"
+        env:
+          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+          MYSQL_DATABASE: revo_test
         options: >-
-          --health-cmd "mysqladmin ping --silent"
-          -e MYSQL_ALLOW_EMPTY_PASSWORD=yes
-          -e MYSQL_DATABASE=revo_test
+          --health-cmd="mysqladmin ping --silent"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=5
         ports:
           - 3306:3306
 

--- a/_build/test/Tests/Processors/Resource/ResourceCreateTest.php
+++ b/_build/test/Tests/Processors/Resource/ResourceCreateTest.php
@@ -98,7 +98,7 @@ class ResourceCreateProcessorTest extends MODxTestCase {
         if ($shouldPass) {
             if ($s) {
                 /** @var modResource $resource */
-                $resource = $this->modx->getObject(modResource::class, ['pagetitle' => $pageTitle]);
+                $resource = $this->modx->getObject(modResource::class, ['pagetitle' => trim($pageTitle)]);
                 $this->assertNotEmpty($resource,'Resource not found, although processor returned true: `'.$pageTitle.'`: '.$result->getMessage());
                 if ($resource) {
                     foreach ($expectedFieldsToCheck as $k => $v) {


### PR DESCRIPTION
### What changed and why

Updates CI workflow to use MySQL 8.0 image because the MySQL 5.6  images are no longer being maintained and pulling them often fails.

### How to test

CI passes. No manual testing required.

### Related issue(s)/PR(s)

Resolves CI issues occurring across the project.

### Compatibility notes

N/A

### Breaking change assessment

N/A

### Test coverage

All tests are run against MySQL 8.0 now.

### Contributors

N/A

### AI tool use

None