### PR TITLE
Add label for property sets dropdown (grid filter) field

### DIFF
--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -381,7 +381,7 @@ Ext.extend(MODx.grid.ElementProperties, MODx.grid.LocalProperty, {
             layout: 'form',
             itemId: 'filter-propset-container',
             cls: 'grid-filter',
-            width: 150,
+            width: 180,
             defaults: {
                 anchor: '100%'
             },

--- a/manager/assets/modext/widgets/element/modx.grid.element.properties.js
+++ b/manager/assets/modext/widgets/element/modx.grid.element.properties.js
@@ -120,50 +120,36 @@ MODx.grid.ElementProperties = function(config = {}) {
             sortable: true,
             hidden: true
         }],
-        tbar: [{
-            text: _('property_create'),
-            id: 'modx-btn-property-create',
-            handler: this.create,
-            scope: this,
-            disabled: true
-        }, {
-            text: _('properties_default_locked'),
-            id: 'modx-btn-propset-lock',
-            handler: this.togglePropertiesLock,
-            enableToggle: true,
-            pressed: true,
-            disabled: !MODx.perm.unlock_element_properties,
-            scope: this
-        }, '->', {
-            xtype: 'modx-combo-property-set',
-            id: 'modx-combo-property-set',
-            baseParams: {
-                action: 'Element/PropertySet/GetList',
-                showAssociated: true,
-                elementId: config.elementId,
-                elementType: config.elementType,
-                combo: true
-            },
-            value: 0,
-            listeners: {
-                select: {
-                    fn: this.changePropertySet,
+        tbar: {
+            cls: 'has-nested-filters',
+            items: [
+                this.getCreateButton('property'),
+                {
+                    text: _('properties_default_locked'),
+                    id: 'modx-btn-propset-lock',
+                    handler: this.togglePropertiesLock,
+                    enableToggle: true,
+                    pressed: true,
+                    disabled: !MODx.perm.unlock_element_properties,
                     scope: this
+                },
+                '->',
+                this.getPropertySetsCombo(config, 'Element'),
+                {
+                    text: _('propertyset_add'),
+                    id: 'modx-btn-property-set-add',
+                    handler: this.addPropertySet,
+                    scope: this
+                }, {
+                    text: _('propertyset_save'),
+                    id: 'modx-btn-property-set-save',
+                    cls: 'primary-button',
+                    handler: this.save,
+                    scope: this,
+                    hidden: !MODx.request.id
                 }
-            }
-        }, {
-            text: _('propertyset_add'),
-            id: 'modx-btn-property-set-add',
-            handler: this.addPropertySet,
-            scope: this
-        }, {
-            text: _('propertyset_save'),
-            id: 'modx-btn-property-set-save',
-            cls: 'primary-button',
-            handler: this.save,
-            scope: this,
-            hidden: !MODx.request.id
-        }],
+            ]
+        },
         bbar: [{
             text: _('property_revert_all'),
             id: 'modx-btn-property-revert-all',
@@ -368,6 +354,56 @@ Ext.extend(MODx.grid.ElementProperties, MODx.grid.LocalProperty, {
             this.lockMask.toggle();
             this.toggleButtons(this.lockMask.locked);
         }
+    },
+
+    /**
+     * Get the combo configuration for the Property Sets dropdown menu
+     * @param {Object} config This grid's configuration
+     * @param {String} parentObjectType The base object type that includes this combo (usually as a grid filter/chooser); currently only Elements and Properties are applicable
+     * @returns {Object}
+     */
+    getPropertySetsCombo: function(config = {}, parentObjectType = 'Properties') {
+        const startingValue = parentObjectType === 'Element' ? 0 : '';
+        let params = {
+            action: 'Element/PropertySet/GetList',
+            combo: true
+        };
+        if (parentObjectType === 'Element') {
+            params = {
+                ...params,
+                showAssociated: true,
+                elementId: config?.elementId,
+                elementType: config?.elementType
+            };
+        }
+        return {
+            xtype: 'container',
+            layout: 'form',
+            itemId: 'filter-propset-container',
+            cls: 'grid-filter',
+            width: 150,
+            defaults: {
+                anchor: '100%'
+            },
+            items: [
+                {
+                    xtype: 'label',
+                    html: _('propertysets')
+                }, {
+                    xtype: 'modx-combo-property-set',
+                    id: 'modx-combo-property-set',
+                    hideLabel: true,
+                    baseParams: params,
+                    value: startingValue,
+                    listeners: {
+                        select: {
+                            fn: this.changePropertySet,
+                            scope: this
+                        }
+                    }
+                }
+            ]
+        };
     },
 
     toggleButtons: function(value) {

--- a/manager/assets/modext/widgets/element/modx.panel.property.set.js
+++ b/manager/assets/modext/widgets/element/modx.panel.property.set.js
@@ -68,40 +68,21 @@ MODx.grid.PropertySetProperties = function(config = {}) {
     Ext.applyIf(config, {
         autoHeight: true,
         lockProperties: false,
-        tbar: [{
-            xtype: 'modx-combo-property-set',
-            id: 'modx-combo-property-set',
-            baseParams: {
-                action: 'Element/PropertySet/GetList',
-                combo: true
-            },
-            listeners: {
-                select: {
-                    fn: function(cb) {
-                        Ext.getCmp('modx-grid-element-properties').changePropertySet(cb);
-                    },
+        tbar: {
+            cls: 'has-nested-filters',
+            items: [
+                this.getCreateButton('property'),
+                '->',
+                this.getPropertySetsCombo(),
+                {
+                    text: _('propertyset_save'),
+                    id: 'modx-btn-property-set-save',
+                    cls: 'primary-button',
+                    handler: this.save,
                     scope: this
                 }
-            },
-            value: ''
-        }, {
-            text: _('property_create'),
-            id: 'modx-btn-property-create',
-            handler: function(btn, e) {
-                if (Ext.getCmp('modx-combo-property-set').value !== '') {
-                    Ext.getCmp('modx-grid-element-properties').create(btn, e);
-                } else {
-                    MODx.msg.alert('', _('propertyset_err_ns'));
-                }
-            },
-            scope: this
-        }, '->', {
-            text: _('propertyset_save'),
-            id: 'modx-btn-property-set-save',
-            cls: 'primary-button',
-            handler: function() { Ext.getCmp('modx-grid-element-properties').save(); },
-            scope: this
-        }]
+            ]
+        }
     });
     Ext.getCmp('right-column').disable();
     MODx.grid.PropertySetProperties.superclass.constructor.call(this, config);


### PR DESCRIPTION
### What changed and why

See also #16896. This replacement PR uses the relatively new way of placing dropdown labels for grid toolbars (see the current Lexicons manager page)—putting them above the combo rather than beside it. This provides a cleaner appearance and conserves space in the toolbar. Since this same combo is also used in the Property Sets grid, a new method was added to the common base class to generate the combo there as well as in the Element Properties grids.

Note also that the arrangement of top toolbar buttons for the Property Sets grid now matches that of the Elements' Properties grids (with the dropdown on the right).

### How to test

1. Create/edit various Elements, creating a property set or two in each (using Properties tab). 
2. Visit the main Property Sets page and experiment with adding and selecting prop sets there.
3. In both cases, the prop set dropdown should have a label above and behave as expected.

### Related issue(s)/PR(s)

Replacement for PR #16896, which resolves #13901.

### Compatibility notes

n/a

### Breaking change assessment

n/a

### Test coverage

n/a

### Contributors

@Ibochkarev authored the initial solution.

### AI tool use

None
