### PR TITLE
fix(ci): run PHPCS only on PR-changed lines

### DIFF
--- a/.github/scripts/phpcs-pr-changes.sh
+++ b/.github/scripts/phpcs-pr-changes.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BASE_SHA="${1:?Base SHA is required}"
+HEAD_SHA="${2:?Head SHA is required}"
+PHPCS="${3:-core/vendor/bin/phpcs}"
+STANDARD="${4:-phpcs.xml}"
+
+if ! command -v jq >/dev/null 2>&1; then
+    echo "jq is required to filter PHPCS results to PR diff lines."
+    exit 1
+fi
+
+FILES=()
+while IFS= read -r file; do
+    [ -n "$file" ] && FILES+=("$file")
+done < <(git diff --name-only --diff-filter=ACMRT "${BASE_SHA}...${HEAD_SHA}" | grep -E '\.php$' || true)
+
+if [ ${#FILES[@]} -eq 0 ]; then
+    echo "No PHP files changed in this PR."
+    exit 0
+fi
+
+echo "PHP files in PR diff:"
+printf '  %s\n' "${FILES[@]}"
+
+get_changed_lines() {
+    local file="$1"
+
+    git diff -U0 "${BASE_SHA}...${HEAD_SHA}" -- "$file" | python3 -c '
+import re
+import sys
+
+for line in sys.stdin:
+    match = re.match(r"^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@", line)
+    if not match:
+        continue
+    start = int(match.group(1))
+    count = int(match.group(2) or 1)
+    for line_number in range(start, start + count):
+        print(line_number)
+'
+}
+
+line_is_changed() {
+    local line="$1"
+    shift
+
+    for changed_line in "$@"; do
+        if [ "$line" -eq "$changed_line" ]; then
+            return 0
+        fi
+    done
+
+    return 1
+}
+
+FAILED=0
+
+for file in "${FILES[@]}"; do
+    if [ ! -f "$file" ]; then
+        echo "Skipping missing file: ${file}"
+        continue
+    fi
+
+    CHANGED_LINES=()
+    while IFS= read -r changed_line; do
+        [ -n "$changed_line" ] && CHANGED_LINES+=("$changed_line")
+    done < <(get_changed_lines "$file")
+
+    if [ ${#CHANGED_LINES[@]} -eq 0 ]; then
+        echo "No changed lines detected for ${file}; skipping."
+        continue
+    fi
+
+    REPORT="$(mktemp)"
+    set +e
+    "$PHPCS" -q --standard="$STANDARD" --report=json "$file" >"$REPORT" 2>/dev/null
+    set -e
+
+    FILE_REPORT="$(jq -c --arg file "$file" '[.files | to_entries[] | select(.key | endswith("/" + $file) or . == $file) | .value][0] // empty' "$REPORT")"
+    rm -f "$REPORT"
+
+    if [ -z "$FILE_REPORT" ] || [ "$FILE_REPORT" = "null" ]; then
+        continue
+    fi
+
+    MESSAGE_COUNT="$(jq -r '.messages | length' <<<"$FILE_REPORT")"
+    if [ "$MESSAGE_COUNT" -eq 0 ]; then
+        continue
+    fi
+
+    while IFS= read -r message; do
+        [ -z "$message" ] && continue
+
+        line="$(jq -r '.line' <<<"$message")"
+        column="$(jq -r '.column' <<<"$message")"
+        type="$(jq -r '.type' <<<"$message")"
+        source="$(jq -r '.source' <<<"$message")"
+        text="$(jq -r '.message' <<<"$message")"
+
+        if line_is_changed "$line" "${CHANGED_LINES[@]}"; then
+            echo "${file}:${line}:${column}: ${type} - ${text} (${source})"
+            FAILED=1
+        fi
+    done < <(jq -c '.messages[]?' <<<"$FILE_REPORT")
+done
+
+if [ "$FAILED" -ne 0 ]; then
+    echo "PHPCS found violations in PR-changed lines."
+    exit 1
+fi
+
+echo "PHPCS passed for PR-changed lines."

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -6,6 +6,7 @@ on:
             - "**.php"
             - "phpcs.xml"
             - ".github/workflows/phpcs.yml"
+            - ".github/scripts/phpcs-pr-changes.sh"
 
 jobs:
     phpcs:
@@ -14,6 +15,8 @@ jobs:
             - uses: actions/checkout@v3
               with:
                   fetch-depth: 0
+                  ref: ${{ github.event.pull_request.head.sha }}
+                  repository: ${{ github.event.pull_request.head.repo.full_name }}
 
             - name: Get composer cache directory
               id: composer-cache
@@ -29,9 +32,5 @@ jobs:
             - name: Install dependencies
               run: composer install --no-progress --prefer-dist --optimize-autoloader
 
-            - uses: thenabeel/action-phpcs@v8
-              with:
-                files: "**.php"
-                phpcs_path: core/vendor/bin/phpcs
-                standard: phpcs.xml
-                fail_on_warnings: false
+            - name: Run PHPCS on PR-changed lines
+              run: bash .github/scripts/phpcs-pr-changes.sh "${{ github.event.pull_request.base.sha }}" "${{ github.event.pull_request.head.sha }}" core/vendor/bin/phpcs phpcs.xml


### PR DESCRIPTION
### What changed and why

Replaces `thenabeel/action-phpcs@v8` with a diff-scoped PHPCS step.

`thenabeel/action-phpcs` builds its file list with `git diff-tree ${base.sha}..` and no head ref. GitHub checks out the merge commit, so the diff can include upstream files the PR never touched. On #16865 CI linted `modX.php` and failed on PSR-12 violations from 2021, though that PR changed two files.

The new workflow checks out the PR head, lists PHP files with `git diff --name-only ${base}...${head}`, and fails only when PHPCS reports violations on lines the PR changed.

### How to test

1. Open a PR with a few clean edits in an otherwise non-compliant file. PHPCS should pass.
2. Add a deliberate PSR-12 violation on a changed line. The workflow should fail.
3. Re-run #16865 (or an equivalent two-file PR). Unrelated files like `modX.php` should stay out of the check.

### Related issue(s)/PR(s)

Related to #16865.

### Compatibility notes

Pull request `Code Quality` workflow only. No runtime or platform changes.

### Breaking change assessment

No public API or product behavior changes. Safe for a patch release.

### Test coverage

No automated tests added. Use the scenarios above.

### Contributors

@mkschell flagged the false positives on #16865; the CI log for that PR showed the merge-commit diff problem.

### AI tool use

AI helped analyze the failing workflow run, read `thenabeel/action-phpcs` source, and draft the replacement script.