### PR TITLE
Add filename normalization for macOS

### DIFF
--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1138,14 +1138,17 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 continue;
             }
 
-            /* macOS sends multibyte filenames in NFD (decomposed) form; normalize to NFC
-               so accented characters match what the filesystem/DB/JS expect elsewhere */
-if (class_exists(\Normalizer::class, false)) {
-    $normalized = \Normalizer::normalize($file['name'], \Normalizer::FORM_C);
-    if ($normalized !== false) {
-        $file['name'] = $normalized;
-    }
-}
+            /* 
+            * macOS sends multibyte filenames in NFD (decomposed) form; normalize to NFC
+            * so accented characters match what the filesystem/DB/JS expect elsewhere
+            * 
+            */
+            if (class_exists(\Normalizer::class, false)) {
+                $normalized = \Normalizer::normalize($file['name'], \Normalizer::FORM_C);
+                if ($normalized !== false) {
+                    $file['name'] = $normalized;
+                }
+            }
 
             $size = filesize($file['tmp_name']);
             if ($size > $maxFileSize) {

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1140,9 +1140,12 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
 
             /* macOS sends multibyte filenames in NFD (decomposed) form; normalize to NFC
                so accented characters match what the filesystem/DB/JS expect elsewhere */
-            if (class_exists('Normalizer')) {
-                $file['name'] = \Normalizer::normalize($file['name'], \Normalizer::FORM_C);
-            }
+if (class_exists(\Normalizer::class, false)) {
+    $normalized = \Normalizer::normalize($file['name'], \Normalizer::FORM_C);
+    if ($normalized !== false) {
+        $file['name'] = $normalized;
+    }
+}
 
             $size = filesize($file['tmp_name']);
             if ($size > $maxFileSize) {

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -1138,6 +1138,12 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                 continue;
             }
 
+            /* macOS sends multibyte filenames in NFD (decomposed) form; normalize to NFC
+               so accented characters match what the filesystem/DB/JS expect elsewhere */
+            if (class_exists('Normalizer')) {
+                $file['name'] = \Normalizer::normalize($file['name'], \Normalizer::FORM_C);
+            }
+
             $size = filesize($file['tmp_name']);
             if ($size > $maxFileSize) {
                 $this->addError('path', $this->xpdo->lexicon('file_err_too_large', [


### PR DESCRIPTION
Normalize multibyte filenames to NFC for compatibility.

### What changed and why

- Names of files uploaded with Windows are transliterated correctly.
- Names of files uploaded with macOS are in NFD form and need to be normalized to NFC form first.

### How to test

- Create a file named jäöu.jpg on your computer
- Upload in media browser using drag&drop
- The file should be named jaeoeu.jpg if you have german transliteration active.

### Related issue(s)/PR(s)

n/a

### Compatibility notes

- Before this change, Windows worked. macOS did not.
- After this change, both operating systems work as expected.

### Breaking change assessment

No

### Test coverage

No automated unit test

### Contributors

n/a

### AI tool use

Claude Code