### PR TITLE
fix(transport): Guard invalid XML in modTransportProvider

### DIFF
--- a/core/src/Revolution/Transport/modTransportProvider.php
+++ b/core/src/Revolution/Transport/modTransportProvider.php
@@ -243,7 +243,10 @@ class modTransportProvider extends xPDOSimpleObject
                 return $this->xpdo->lexicon('provider_err_blank_response');
             }
 
-            $parsed = $this->parseProviderXml($response, "Could not load latest versions for {$identifier} with constraint {$constraint}");
+            $parsed = $this->parseProviderXml(
+                $response,
+                "Could not load latest versions for {$identifier} with constraint {$constraint}"
+            );
             if (is_string($parsed)) {
                 return $parsed;
             }

--- a/core/src/Revolution/Transport/modTransportProvider.php
+++ b/core/src/Revolution/Transport/modTransportProvider.php
@@ -53,12 +53,11 @@ class modTransportProvider extends xPDOSimpleObject
             return $this->xpdo->lexicon('provider_err_blank_response');
         }
 
-        $body = $response->getBody()->getContents();
-        $xml = simplexml_load_string($body);
-        if (!$xml) {
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load repositories: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
-            return $this->xpdo->lexicon('provider_err_invalid_xml');
+        $parsed = $this->parseProviderXml($response, 'Could not load repositories');
+        if (is_string($parsed)) {
+            return $parsed;
         }
+        $xml = $parsed;
         if ($xml->getName() === 'error') {
             return $this->xpdo->lexicon('provider_err_connect', ['error' => (string)$xml->message]);
         }
@@ -98,12 +97,11 @@ class modTransportProvider extends xPDOSimpleObject
             return $this->xpdo->lexicon('provider_err_blank_response');
         }
 
-        $body = $response->getBody()->getContents();
-        $xml = simplexml_load_string($body);
-        if (!$xml) {
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load categories for {$node}: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
-            return $this->xpdo->lexicon('provider_err_invalid_xml');
+        $parsed = $this->parseProviderXml($response, "Could not load categories for {$node}");
+        if (is_string($parsed)) {
+            return $parsed;
         }
+        $xml = $parsed;
         if ($xml->getName() === 'error') {
             return $this->xpdo->lexicon('provider_err_connect', ['error' => (string)$xml->message]);
         }
@@ -146,12 +144,11 @@ class modTransportProvider extends xPDOSimpleObject
             return $this->xpdo->lexicon('provider_err_blank_response');
         }
 
-        $body = $response->getBody()->getContents();
-        $xml = simplexml_load_string($body);
-        if (!$xml) {
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load package provider statistics: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
-            return $this->xpdo->lexicon('provider_err_invalid_xml');
+        $parsed = $this->parseProviderXml($response, 'Could not load package provider statistics');
+        if (is_string($parsed)) {
+            return $parsed;
         }
+        $xml = $parsed;
         if ($xml->getName() === 'error') {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load package provider statistics: " . $xml->message, '', __METHOD__, __FILE__, __LINE__);
             return $this->xpdo->lexicon('provider_err_connect', ['error' => (string)$xml->message]);
@@ -195,12 +192,11 @@ class modTransportProvider extends xPDOSimpleObject
                 return $this->xpdo->lexicon('provider_err_blank_response');
             }
 
-            $body = $response->getBody()->getContents();
-            $xml = simplexml_load_string($body);
-            if (!$xml) {
-                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load package info for {$identifier}: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
-                return $this->xpdo->lexicon('provider_err_invalid_xml');
+            $parsed = $this->parseProviderXml($response, "Could not load package info for {$identifier}");
+            if (is_string($parsed)) {
+                return $parsed;
             }
+            $xml = $parsed;
             if ($xml->getName() === 'error') {
                 $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load package info for {$identifier}: {$xml->message}", '', __METHOD__, __FILE__, __LINE__);
                 return $this->xpdo->lexicon('provider_err_connect', ['error' => (string)$xml->message]);
@@ -247,12 +243,11 @@ class modTransportProvider extends xPDOSimpleObject
                 return $this->xpdo->lexicon('provider_err_blank_response');
             }
 
-            $body = $response->getBody()->getContents();
-            $xml = simplexml_load_string($body);
-            if (!$xml) {
-                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load latest versions for {$identifier} with constraint {$constraint}: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
-                return $this->xpdo->lexicon('provider_err_invalid_xml');
+            $parsed = $this->parseProviderXml($response, "Could not load latest versions for {$identifier} with constraint {$constraint}");
+            if (is_string($parsed)) {
+                return $parsed;
             }
+            $xml = $parsed;
             if ($xml->getName() === 'error') {
                 $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load latest versions for {$identifier} with constraint {$constraint}: {$xml->message}", '', __METHOD__, __FILE__, __LINE__);
                 return $this->xpdo->lexicon('provider_err_connect', ['error' => (string)$xml->message]);
@@ -284,12 +279,11 @@ class modTransportProvider extends xPDOSimpleObject
             return $this->xpdo->lexicon('provider_err_blank_response');
         }
 
-        $body = $response->getBody()->getContents();
-        $xml = simplexml_load_string($body);
-        if (!$xml) {
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load updates for {$identifier}: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
-            return $this->xpdo->lexicon('provider_err_invalid_xml');
+        $parsed = $this->parseProviderXml($response, "Could not load updates for {$identifier}");
+        if (is_string($parsed)) {
+            return $parsed;
         }
+        $xml = $parsed;
 
         if ($xml->getName() === 'error') {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load updates for {$identifier}: {$xml->message}", '', __METHOD__, __FILE__, __LINE__);
@@ -378,12 +372,11 @@ class modTransportProvider extends xPDOSimpleObject
             return $this->xpdo->lexicon('provider_err_blank_response');
         }
 
-        $body = $response->getBody()->getContents();
-        $xml = simplexml_load_string($body);
-        if (!$xml) {
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load packages for search " . json_encode($where) . ": received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
-            return $this->xpdo->lexicon('provider_err_invalid_xml');
+        $parsed = $this->parseProviderXml($response, 'Could not load packages for search ' . json_encode($where));
+        if (is_string($parsed)) {
+            return $parsed;
         }
+        $xml = $parsed;
         if ($xml->getName() === 'error') {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load packages for search " . json_encode($where) . ": {$xml->message}", '', __METHOD__, __FILE__, __LINE__);
             return $this->xpdo->lexicon('provider_err_connect', ['error' => (string)$xml->message]);
@@ -465,6 +458,30 @@ class modTransportProvider extends xPDOSimpleObject
         }
 
         return $response->getBody()->getContents();
+    }
+
+    /**
+     * @param ResponseInterface $response
+     * @param string $context Message prefix for error logging
+     * @return SimpleXMLElement|string Parsed XML, or a lexicon error string
+     */
+    protected function parseProviderXml(ResponseInterface $response, string $context)
+    {
+        $body = $response->getBody()->getContents();
+        $xml = simplexml_load_string($body);
+        if (!$xml instanceof SimpleXMLElement) {
+            $this->xpdo->log(
+                xPDO::LOG_LEVEL_ERROR,
+                "{$context}: received non-XML response from provider: {$body}",
+                '',
+                __METHOD__,
+                __FILE__,
+                __LINE__
+            );
+            return $this->xpdo->lexicon('provider_err_invalid_xml');
+        }
+
+        return $xml;
     }
 
     protected function fromXML(SimpleXMLElement $xml, array &$array, $level = 0)
@@ -583,12 +600,11 @@ class modTransportProvider extends xPDOSimpleObject
             return $this->xpdo->lexicon('provider_err_blank_response');
         }
 
-        $body = $response->getBody()->getContents();
-        $xml = simplexml_load_string($body);
-        if (!$xml) {
-            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not verify provider: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
-            return $this->xpdo->lexicon('provider_err_invalid_xml');
+        $parsed = $this->parseProviderXml($response, 'Could not verify provider');
+        if (is_string($parsed)) {
+            return $parsed;
         }
+        $xml = $parsed;
 
         return (bool)$xml->verified;
     }

--- a/core/src/Revolution/Transport/modTransportProvider.php
+++ b/core/src/Revolution/Transport/modTransportProvider.php
@@ -53,7 +53,12 @@ class modTransportProvider extends xPDOSimpleObject
             return $this->xpdo->lexicon('provider_err_blank_response');
         }
 
-        $xml = simplexml_load_string($response->getBody()->getContents());
+        $body = $response->getBody()->getContents();
+        $xml = simplexml_load_string($body);
+        if (!$xml) {
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load repositories: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
+            return $this->xpdo->lexicon('provider_err_invalid_xml');
+        }
         if ($xml->getName() === 'error') {
             return $this->xpdo->lexicon('provider_err_connect', ['error' => (string)$xml->message]);
         }
@@ -93,7 +98,12 @@ class modTransportProvider extends xPDOSimpleObject
             return $this->xpdo->lexicon('provider_err_blank_response');
         }
 
-        $xml = simplexml_load_string($response->getBody()->getContents());
+        $body = $response->getBody()->getContents();
+        $xml = simplexml_load_string($body);
+        if (!$xml) {
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load categories for {$node}: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
+            return $this->xpdo->lexicon('provider_err_invalid_xml');
+        }
         if ($xml->getName() === 'error') {
             return $this->xpdo->lexicon('provider_err_connect', ['error' => (string)$xml->message]);
         }
@@ -136,7 +146,12 @@ class modTransportProvider extends xPDOSimpleObject
             return $this->xpdo->lexicon('provider_err_blank_response');
         }
 
-        $xml = simplexml_load_string($response->getBody()->getContents());
+        $body = $response->getBody()->getContents();
+        $xml = simplexml_load_string($body);
+        if (!$xml) {
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load package provider statistics: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
+            return $this->xpdo->lexicon('provider_err_invalid_xml');
+        }
         if ($xml->getName() === 'error') {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load package provider statistics: " . $xml->message, '', __METHOD__, __FILE__, __LINE__);
             return $this->xpdo->lexicon('provider_err_connect', ['error' => (string)$xml->message]);
@@ -180,7 +195,12 @@ class modTransportProvider extends xPDOSimpleObject
                 return $this->xpdo->lexicon('provider_err_blank_response');
             }
 
-            $xml = simplexml_load_string($response->getBody()->getContents());
+            $body = $response->getBody()->getContents();
+            $xml = simplexml_load_string($body);
+            if (!$xml) {
+                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load package info for {$identifier}: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
+                return $this->xpdo->lexicon('provider_err_invalid_xml');
+            }
             if ($xml->getName() === 'error') {
                 $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load package info for {$identifier}: {$xml->message}", '', __METHOD__, __FILE__, __LINE__);
                 return $this->xpdo->lexicon('provider_err_connect', ['error' => (string)$xml->message]);
@@ -227,7 +247,12 @@ class modTransportProvider extends xPDOSimpleObject
                 return $this->xpdo->lexicon('provider_err_blank_response');
             }
 
-            $xml = simplexml_load_string($response->getBody()->getContents());
+            $body = $response->getBody()->getContents();
+            $xml = simplexml_load_string($body);
+            if (!$xml) {
+                $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load latest versions for {$identifier} with constraint {$constraint}: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
+                return $this->xpdo->lexicon('provider_err_invalid_xml');
+            }
             if ($xml->getName() === 'error') {
                 $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load latest versions for {$identifier} with constraint {$constraint}: {$xml->message}", '', __METHOD__, __FILE__, __LINE__);
                 return $this->xpdo->lexicon('provider_err_connect', ['error' => (string)$xml->message]);
@@ -353,7 +378,12 @@ class modTransportProvider extends xPDOSimpleObject
             return $this->xpdo->lexicon('provider_err_blank_response');
         }
 
-        $xml = simplexml_load_string($response->getBody()->getContents());
+        $body = $response->getBody()->getContents();
+        $xml = simplexml_load_string($body);
+        if (!$xml) {
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load packages for search " . json_encode($where) . ": received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
+            return $this->xpdo->lexicon('provider_err_invalid_xml');
+        }
         if ($xml->getName() === 'error') {
             $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not load packages for search " . json_encode($where) . ": {$xml->message}", '', __METHOD__, __FILE__, __LINE__);
             return $this->xpdo->lexicon('provider_err_connect', ['error' => (string)$xml->message]);
@@ -553,8 +583,14 @@ class modTransportProvider extends xPDOSimpleObject
             return $this->xpdo->lexicon('provider_err_blank_response');
         }
 
-        $body = simplexml_load_string($response->getBody()->getContents());
-        return (bool)$body->verified;
+        $body = $response->getBody()->getContents();
+        $xml = simplexml_load_string($body);
+        if (!$xml) {
+            $this->xpdo->log(xPDO::LOG_LEVEL_ERROR, "Could not verify provider: received non-XML response from provider: {$body}", '', __METHOD__, __FILE__, __LINE__);
+            return $this->xpdo->lexicon('provider_err_invalid_xml');
+        }
+
+        return (bool)$xml->verified;
     }
 
     /**


### PR DESCRIPTION
### What changed and why

Seven methods in `modTransportProvider` called `simplexml_load_string()` and used the result without checking for parse failure. When a transport provider returns empty, HTML, or truncated content, PHP 8 fatals on `$xml->getName()`.

This PR adds the same guard already in the second branch of `latest()` (#16326) to `repositories()`, `categories()`, `stats()`, `info()`, `latest()` (package name branch), `find()`, and `verify()`. Failed parses log the raw body and return `provider_err_invalid_xml`. The connector keeps returning JSON, so the Package Browser grid no longer hits ExtJS decode errors.

### How to test

Point a transport provider at a URL that returns HTML or an empty body, then open Manager → Extras → Installer. You should see a provider error message, not a PHP fatal. The error log should contain the raw response body.

### Related issue(s)/PR(s)

Resolves #16974

Refs #16326

### Compatibility notes

Universal. No config or platform dependency. Uses existing lexicon key `provider_err_invalid_xml`.

### Breaking change assessment

No signature or return type changes. Methods that already returned error strings on provider `<error>` XML now also return a string on invalid XML. `verify()` can return the lexicon string instead of `(bool)false` when the response is non-XML; `Create.php` and `Update.php` already handle non-boolean results via `is_bool($verified)`.

### Test coverage

No automated tests added. Same pattern as #16326. Manual verification against a misconfigured provider URL is sufficient.

### Contributors

@Ibochkarev

### AI tool use

Cursor AI assisted with implementation and PR preparation.