### PR TITLE
chore(ci): bump checkout and cache actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install PHP
         uses: shivammathur/setup-php@v2
@@ -53,7 +53,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
       - name: Cache composer dependencies
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -11,7 +11,7 @@ jobs:
     phpcs:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/checkout@v3
+            - uses: actions/checkout@v4
               with:
                   fetch-depth: 0
 
@@ -20,7 +20,7 @@ jobs:
               run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
 
             - name: Cache composer dependencies
-              uses: actions/cache@v3
+              uses: actions/cache@v4
               with:
                   path: ${{ steps.composer-cache.outputs.dir }}
                   key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}


### PR DESCRIPTION
### What changed and why

GitHub Actions warns that `actions/checkout@v3` and `actions/cache@v3` run on deprecated Node.js 20. This PR bumps both to v4 in `ci.yml` and `phpcs.yml`.

`thenabeel/action-phpcs@v8` stays as-is. It may still emit a Node.js deprecation notice until upstream replaces that action.

### How to test

Open or re-run a pull request that triggers CI or Code Quality. Both workflows should complete as before.

### Related issue(s)/PR(s)

None.

### Compatibility notes

Pull request and push CI only. No runtime or product changes.

### Breaking change assessment

No public API or default behavior changes. Safe for a patch release.

### Test coverage

No automated tests added.

### Contributors

None.

### AI tool use

Cursor helped apply the version bumps and update this description.