### PR TITLE
fix(error): return HTTP 500 for uncaught frontend errors

### DIFF
--- a/_build/test/Tests/Model/Error/modErrorHandlerTest.php
+++ b/_build/test/Tests/Model/Error/modErrorHandlerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *

--- a/_build/test/Tests/Model/Error/modErrorHandlerTest.php
+++ b/_build/test/Tests/Model/Error/modErrorHandlerTest.php
@@ -8,11 +8,14 @@
  * files found in the top-level directory of this distribution.
  *
  * @package modx-test
-*/
+ */
 namespace MODX\Revolution\Tests\Model\Error;
 
-
+use MODX\Revolution\Error\modErrorHandler;
+use MODX\Revolution\Error\modUncaughtErrorHandler;
+use MODX\Revolution\modX;
 use MODX\Revolution\MODxTestCase;
+use RuntimeException;
 
 /**
  * Tests related to the modErrorHandler class.
@@ -23,8 +26,58 @@ use MODX\Revolution\MODxTestCase;
  * @group Error
  * @group modErrorHandler
  */
-class modErrorHandlerTest extends MODxTestCase {
-    public function testExample() {
-        $this->assertTrue(true);
+class modErrorHandlerTest extends MODxTestCase
+{
+    /** @var modErrorHandler */
+    public $handler;
+
+    /**
+     * @before
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+        $this->handler = new modErrorHandler($this->modx);
+    }
+
+    /**
+     * @after
+     */
+    public function tearDownHandlerState()
+    {
+        modUncaughtErrorHandler::resetForTesting();
+        restore_error_handler();
+    }
+
+    public function testHandleErrorUserErrorTriggersFatalResponseWhenEnabled()
+    {
+        if (defined('XPDO_CLI_MODE') && XPDO_CLI_MODE) {
+            $this->markTestSkipped('HTTP fatal handling is disabled in CLI mode.');
+        }
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Fatal log invoked');
+
+        $modx = $this->getMockBuilder(modX::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getOption', 'log'])
+            ->getMock();
+        $modx->method('getOption')->willReturnMap([
+            ['send_http_500_on_error', null, true, true],
+        ]);
+        $modx->expects($this->once())
+            ->method('log')
+            ->with(
+                modX::LOG_LEVEL_FATAL,
+                $this->stringContains('User error: simulated user error'),
+                '',
+                '',
+                '/tmp/test.php',
+                10
+            )
+            ->willThrowException(new RuntimeException('Fatal log invoked'));
+
+        $handler = new modErrorHandler($modx);
+        $handler->handleError(E_USER_ERROR, 'simulated user error', '/tmp/test.php', 10);
     }
 }

--- a/_build/test/Tests/Model/Error/modUncaughtErrorHandlerTest.php
+++ b/_build/test/Tests/Model/Error/modUncaughtErrorHandlerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *

--- a/_build/test/Tests/Model/Error/modUncaughtErrorHandlerTest.php
+++ b/_build/test/Tests/Model/Error/modUncaughtErrorHandlerTest.php
@@ -1,0 +1,137 @@
+<?php
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+namespace MODX\Revolution\Tests\Model\Error;
+
+use MODX\Revolution\Error\modUncaughtErrorHandler;
+use MODX\Revolution\modX;
+use MODX\Revolution\MODxTestCase;
+
+/**
+ * Tests related to the modUncaughtErrorHandler class.
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Model
+ * @group Error
+ * @group modUncaughtErrorHandler
+ */
+class modUncaughtErrorHandlerTest extends MODxTestCase
+{
+    /**
+     * @after
+     */
+    public function tearDownHandlerState()
+    {
+        modUncaughtErrorHandler::resetForTesting();
+        restore_exception_handler();
+        restore_error_handler();
+    }
+
+    /**
+     * @param int  $type
+     * @param bool $expected
+     * @dataProvider providerIsFatalErrorType
+     */
+    public function testIsFatalErrorType($type, $expected)
+    {
+        $this->assertSame($expected, modUncaughtErrorHandler::isFatalErrorType($type));
+    }
+
+    /**
+     * @return array
+     */
+    public function providerIsFatalErrorType()
+    {
+        return [
+            [E_ERROR, true],
+            [E_PARSE, true],
+            [E_CORE_ERROR, true],
+            [E_COMPILE_ERROR, true],
+            [E_WARNING, false],
+            [E_NOTICE, false],
+            [E_USER_ERROR, false],
+            [E_USER_WARNING, false],
+        ];
+    }
+
+    public function testFormatPhpError()
+    {
+        $formatted = modUncaughtErrorHandler::formatPhpError([
+            'message' => 'Division by zero',
+            'file' => '/tmp/example.php',
+            'line' => 12,
+        ]);
+
+        $this->assertSame(
+            'Fatal error: Division by zero in /tmp/example.php on line 12',
+            $formatted
+        );
+    }
+
+    public function testIsEnabledDefaultsToTrue()
+    {
+        $this->assertTrue(modUncaughtErrorHandler::isEnabled($this->modx));
+    }
+
+    public function testHandleExceptionLogsFatal()
+    {
+        $modx = $this->getMockBuilder(modX::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['log'])
+            ->getMock();
+        $modx->expects($this->once())
+            ->method('log')
+            ->with(
+                modX::LOG_LEVEL_FATAL,
+                $this->stringContains('TypeError: Invalid argument type'),
+                '',
+                '',
+                $this->anything(),
+                $this->anything()
+            );
+
+        $handler = new modUncaughtErrorHandler($modx);
+        $handler->handleException(new \TypeError('Invalid argument type'));
+    }
+
+    public function testHandleShutdownIgnoresNonFatalErrors()
+    {
+        $modx = $this->getMockBuilder(modX::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['log'])
+            ->getMock();
+        $modx->expects($this->never())->method('log');
+
+        $handler = new modUncaughtErrorHandler($modx);
+
+        $original = set_error_handler(function () {
+            return true;
+        });
+        trigger_error('notice level', E_USER_NOTICE);
+        restore_error_handler();
+
+        $handler->handleShutdown();
+    }
+
+    public function testRegisterInstallsExceptionHandler()
+    {
+        if (defined('XPDO_CLI_MODE') && XPDO_CLI_MODE) {
+            $this->markTestSkipped('HTTP fatal handling is disabled in CLI mode.');
+        }
+
+        modUncaughtErrorHandler::register($this->modx);
+        $previous = set_exception_handler(null);
+        $this->assertIsArray($previous);
+        $this->assertSame('handleException', $previous[1]);
+        restore_exception_handler();
+    }
+}

--- a/_build/test/Tests/Model/Error/modUncaughtErrorHandlerTest.php
+++ b/_build/test/Tests/Model/Error/modUncaughtErrorHandlerTest.php
@@ -83,6 +83,10 @@ class modUncaughtErrorHandlerTest extends MODxTestCase
         $this->assertTrue(modUncaughtErrorHandler::isEnabled($this->modx));
     }
 
+    /**
+     * @runInSeparateProcess
+     * @preserveGlobalState disabled
+     */
     public function testHandleExceptionLogsFatal()
     {
         $modx = $this->getMockBuilder(modX::class)

--- a/core/error/fatal.include.php
+++ b/core/error/fatal.include.php
@@ -1,5 +1,10 @@
 <?php
-header($_SERVER['SERVER_PROTOCOL'] . ' 500 Internal Server Error');
+$protocol = isset($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.1';
+header($protocol . ' 500 Internal Server Error');
+header('Cache-Control: no-store, no-cache, must-revalidate');
+header('Pragma: no-cache');
+header('Expires: 0');
+header('X-Accel-Expires: 0');
 ?>
 <html>
 <head>

--- a/core/src/Revolution/Error/modErrorHandler.php
+++ b/core/src/Revolution/Error/modErrorHandler.php
@@ -72,6 +72,10 @@ class modErrorHandler
             case E_USER_ERROR:
                 $handled = true;
                 $errmsg = 'User error: ' . $errstr;
+                if ((!defined('XPDO_CLI_MODE') || !XPDO_CLI_MODE) && modUncaughtErrorHandler::isEnabled($this->modx)) {
+                    $this->modx->log(modX::LOG_LEVEL_FATAL, $errmsg, '', '', $errfile, $errline);
+                    break;
+                }
                 $this->modx->log(modX::LOG_LEVEL_ERROR, $errmsg, '', '', $errfile, $errline);
                 break;
             case E_WARNING:

--- a/core/src/Revolution/Error/modErrorHandler.php
+++ b/core/src/Revolution/Error/modErrorHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -9,7 +10,6 @@
  */
 
 namespace MODX\Revolution\Error;
-
 
 use MODX\Revolution\modX;
 

--- a/core/src/Revolution/Error/modUncaughtErrorHandler.php
+++ b/core/src/Revolution/Error/modUncaughtErrorHandler.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *

--- a/core/src/Revolution/Error/modUncaughtErrorHandler.php
+++ b/core/src/Revolution/Error/modUncaughtErrorHandler.php
@@ -1,0 +1,169 @@
+<?php
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MODX\Revolution\Error;
+
+use MODX\Revolution\modX;
+use Throwable;
+
+/**
+ * Catches uncaught exceptions and fatal PHP errors during web requests and
+ * responds with an HTTP 500 via modX::sendError('fatal').
+ *
+ * @package MODX\Revolution\Error
+ */
+class modUncaughtErrorHandler
+{
+    /** @var modX */
+    private $modx;
+
+    /** @var bool */
+    private static $responded = false;
+
+    /** @var self|null */
+    private static $instance = null;
+
+    /**
+     * @param modX $modx
+     */
+    private function __construct(modX $modx)
+    {
+        $this->modx = $modx;
+    }
+
+    /**
+     * Register exception and shutdown handlers for the current web request.
+     *
+     * @param modX $modx
+     */
+    public static function register(modX $modx)
+    {
+        if ((defined('XPDO_CLI_MODE') && XPDO_CLI_MODE) || !self::isEnabled($modx)) {
+            return;
+        }
+        if (self::$instance !== null) {
+            return;
+        }
+
+        self::$instance = new self($modx);
+        set_exception_handler([self::$instance, 'handleException']);
+        register_shutdown_function([self::$instance, 'handleShutdown']);
+    }
+
+    /**
+     * @param modX $modx
+     *
+     * @return bool
+     */
+    public static function isEnabled(modX $modx)
+    {
+        return (bool)$modx->getOption('send_http_500_on_error', null, true);
+    }
+
+    /**
+     * @param int $type
+     *
+     * @return bool
+     */
+    public static function isFatalErrorType($type)
+    {
+        return in_array($type, [E_ERROR, E_PARSE, E_CORE_ERROR, E_COMPILE_ERROR], true);
+    }
+
+    /**
+     * @param Throwable $throwable
+     */
+    public function handleException(Throwable $throwable)
+    {
+        $this->respondWithFatalError(
+            get_class($throwable) . ': ' . $throwable->getMessage(),
+            $throwable->getFile(),
+            $throwable->getLine()
+        );
+    }
+
+    /**
+     * Detect fatal errors that bypass set_error_handler.
+     */
+    public function handleShutdown()
+    {
+        if (self::$responded) {
+            return;
+        }
+
+        $error = error_get_last();
+        if (!is_array($error) || !self::isFatalErrorType($error['type'])) {
+            return;
+        }
+
+        $this->respondWithFatalError(
+            self::formatPhpError($error),
+            isset($error['file']) ? $error['file'] : null,
+            isset($error['line']) ? (int)$error['line'] : null
+        );
+    }
+
+    /**
+     * @param array $error
+     *
+     * @return string
+     */
+    public static function formatPhpError(array $error)
+    {
+        $message = isset($error['message']) ? $error['message'] : 'Unknown error';
+        $file = isset($error['file']) ? $error['file'] : '';
+        $line = isset($error['line']) ? $error['line'] : 0;
+
+        return 'Fatal error: ' . $message . ' in ' . $file . ' on line ' . $line;
+    }
+
+    /**
+     * @param string      $message
+     * @param string|null $file
+     * @param int|null    $line
+     */
+    public function respondWithFatalError($message, $file = null, $line = null)
+    {
+        if (self::$responded) {
+            return;
+        }
+        self::$responded = true;
+
+        if (headers_sent()) {
+            $this->modx->log(
+                modX::LOG_LEVEL_ERROR,
+                $message . ' (headers already sent; unable to set HTTP 500)',
+                '',
+                '',
+                $file !== null ? $file : '',
+                $line !== null ? $line : 0
+            );
+            exit(1);
+        }
+
+        $this->modx->log(
+            modX::LOG_LEVEL_FATAL,
+            $message,
+            '',
+            '',
+            $file !== null ? $file : '',
+            $line !== null ? $line : 0
+        );
+    }
+
+    /**
+     * Reset internal state. Intended for unit tests only.
+     */
+    public static function resetForTesting()
+    {
+        self::$responded = false;
+        self::$instance = null;
+    }
+}

--- a/core/src/Revolution/Error/modUncaughtErrorHandler.php
+++ b/core/src/Revolution/Error/modUncaughtErrorHandler.php
@@ -34,7 +34,7 @@ class modUncaughtErrorHandler
     /**
      * @param modX $modx
      */
-    private function __construct(modX $modx)
+    public function __construct(modX $modx)
     {
         $this->modx = $modx;
     }

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -17,6 +17,7 @@ use MODX\Revolution\Formatter\modManagerDateFormatter;
 use MODX\Revolution\Services\Container;
 use MODX\Revolution\Error\modError;
 use MODX\Revolution\Error\modErrorHandler;
+use MODX\Revolution\Error\modUncaughtErrorHandler;
 use MODX\Revolution\Mail\modMail;
 use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Processors\ProcessorResponse;
@@ -2740,6 +2741,8 @@ class modX extends xPDO {
         } catch (\Exception $exception) {
             $this->log(modX::LOG_LEVEL_ERROR, 'Error handler not found: ' . $exception->getMessage());
         }
+
+        modUncaughtErrorHandler::register($this);
     }
 
     protected function _initHttpClient()


### PR DESCRIPTION
### What changed and why

When a snippet, plugin, TV, or other element throws during web rendering, MODX often returned a blank page with HTTP 200. Proxies cached that response. Uptime checks saw 200 and missed the failure.

This PR adds `modUncaughtErrorHandler`, registered from `_initErrorHandler()`:

- `set_exception_handler()` for uncaught `\Throwable` (`TypeError`, `ParseError`, etc.)
- `register_shutdown_function()` with `error_get_last()` for `E_ERROR`, `E_PARSE`, `E_CORE_ERROR`, `E_COMPILE_ERROR`
- `E_USER_ERROR` in `modErrorHandler` routes to `LOG_LEVEL_FATAL` on web requests when `send_http_500_on_error` is enabled

Each path calls the existing `sendError('fatal')` flow. `fatal.include.php` now sends no-cache headers so reverse proxies do not store 500 responses.

Opt out with system setting `send_http_500_on_error` (default `true`).

### How to test

1. Create a snippet that throws a `TypeError` (pass a string to a typed `int` parameter).
2. Put `[[snippetName]]` on a published resource and open the page.
3. Expect HTTP 500 and the generic fatal error page, not a blank 200.
4. Check response headers for `Cache-Control: no-store`.
5. Set `send_http_500_on_error` to `false` and confirm the handler no longer forces 500.

Unit tests:

```bash
core/vendor/bin/phpunit -c _build/test/phpunit.xml --group modUncaughtErrorHandler
core/vendor/bin/phpunit -c _build/test/phpunit.xml --group modErrorHandler
```

CI (phpcs, PHPUnit on MySQL 8.1–8.5) is green on this branch.

### Related issue(s)/PR(s)

Resolves #16932

### Compatibility notes

- Web requests only. CLI skips handler registration; `sendError()` behavior in CLI is unchanged.
- Applies to frontend, manager, and connector contexts that initialize `modX`.
- PHP 7+ (`\Throwable` hierarchy). No new Composer dependencies.

### Breaking change assessment

**Behavior change:** `E_USER_ERROR` on web requests now terminates with HTTP 500 when `send_http_500_on_error` is enabled (default). Code that logged a user error and kept running should use `E_USER_WARNING` or disable the setting.

No public API signature changes. Patch-safe for sites that do not rely on `E_USER_ERROR` continuing after the handler runs.

### Test coverage

- Added `_build/test/Tests/Model/Error/modUncaughtErrorHandlerTest.php`: fatal type detection, error formatting, exception logging, shutdown behavior for non-fatal errors, registration (web only).
- Extended `_build/test/Tests/Model/Error/modErrorHandlerTest.php`: `E_USER_ERROR` → `LOG_LEVEL_FATAL` when enabled (web only; skipped under CLI PHPUnit).

### Contributors

Thanks to @pbowyer for #16932 and the documented workaround that shaped this approach.

### AI tool use

Claude (Cursor) helped draft the implementation, tests, and PR text from the issue analysis and codebase review.