### PR TITLE
Make Resource content regions independently hideable via Form Customization

### DIFF
--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -714,8 +714,7 @@ Ext.extend(MODx.panel.Resource, MODx.FormPanel, {
                     value: config.record.introtext || ''
                 }]
             }]
-
-        }, this.getContentField(config)];
+        }, ...this.getContentField(config)];
     },
 
     getMainRightFields: function(config = {}) {
@@ -1082,32 +1081,25 @@ Ext.extend(MODx.panel.Resource, MODx.FormPanel, {
     },
 
     getContentField: function(config) {
-        return {
-            id: 'modx-resource-content',
-            layout: 'form',
-            autoHeight: true,
-            hideMode: 'offsets',
-            items: [{
+        return [
+            {
                 id: 'modx-resource-content-above'
             }, {
-                /** @deprecated To be removed in 3.3, reference new region id 'modx-resource-content-above' */
-                id: 'modx-content-above'
-            }, {
-                xtype: 'textarea',
-                name: 'ta',
-                id: 'ta',
-                fieldLabel: _('resource_content'),
-                anchor: '100%',
-                height: 488,
-                grow: false,
-                value: (config.record.content || config.record.ta) || ''
-            }, {
-                /** @deprecated To be removed in 3.3, reference new region id 'modx-resource-content-below' */
-                id: 'modx-content-below'
+                id: 'modx-resource-content',
+                items: [{
+                    xtype: 'textarea',
+                    name: 'ta',
+                    id: 'ta',
+                    fieldLabel: _('resource_content'),
+                    anchor: '100%',
+                    height: 488,
+                    grow: false,
+                    value: (config.record.content || config.record.ta) || ''
+                }]
             }, {
                 id: 'modx-resource-content-below'
-            }]
-        };
+            }
+        ];
     },
 
     getAccessPermissionsTab: function(config) {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.js
@@ -714,7 +714,27 @@ Ext.extend(MODx.panel.Resource, MODx.FormPanel, {
                     value: config.record.introtext || ''
                 }]
             }]
-        }, ...this.getContentField(config)];
+        }, {
+            id: 'modx-resource-content-above'
+        }, this.getContentField(config), {
+            id: 'modx-resource-content-below'
+        }];
+    },
+
+    getContentField: function(config) {
+        return {
+            id: 'modx-resource-content',
+            items: [{
+                xtype: 'textarea',
+                name: 'ta',
+                id: 'ta',
+                fieldLabel: _('resource_content'),
+                height: 488,
+                anchor: '100%',
+                grow: false,
+                value: (config.record.content || config.record.ta) || ''
+            }]
+        };
     },
 
     getMainRightFields: function(config = {}) {
@@ -1078,28 +1098,6 @@ Ext.extend(MODx.panel.Resource, MODx.FormPanel, {
             inputValue: 1,
             checked: config.record.syncsite !== undefined && config.record.syncsite !== null ? parseInt(config.record.syncsite, 10) : true
         }];
-    },
-
-    getContentField: function(config) {
-        return [
-            {
-                id: 'modx-resource-content-above'
-            }, {
-                id: 'modx-resource-content',
-                items: [{
-                    xtype: 'textarea',
-                    name: 'ta',
-                    id: 'ta',
-                    fieldLabel: _('resource_content'),
-                    anchor: '100%',
-                    height: 488,
-                    grow: false,
-                    value: (config.record.content || config.record.ta) || ''
-                }]
-            }, {
-                id: 'modx-resource-content-below'
-            }
-        ];
     },
 
     getAccessPermissionsTab: function(config) {

--- a/manager/assets/modext/widgets/resource/modx.panel.resource.static.js
+++ b/manager/assets/modext/widgets/resource/modx.panel.resource.static.js
@@ -18,7 +18,7 @@ Ext.extend(MODx.panel.Static, MODx.panel.Resource, {
     defaultClassKey: 'MODX\\Revolution\\modStaticResource',
     classLexiconKey: 'static_resource',
     rteElements: false,
-    contentField: 'modx-resource-content',
+    contentField: 'modx-static-content',
 
     getContentField: function(config) {
         return {
@@ -29,7 +29,7 @@ Ext.extend(MODx.panel.Static, MODx.panel.Resource, {
             fieldLabel: _('static_resource'),
             description: '<b>[[*content]]</b>',
             name: 'content',
-            id: 'modx-resource-content',
+            id: 'modx-static-content',
             maxLength: 255,
             anchor: '100%',
             value: (config.record.content || config.record.ta) || '',
@@ -43,7 +43,7 @@ Ext.extend(MODx.panel.Static, MODx.panel.Resource, {
                             str = str.replace(regex, '/$1');
                         }
                         if (str.substring(0, 1) === '/') { str = str.substring(1); }
-                        Ext.getCmp('modx-resource-content').setValue(str);
+                        Ext.getCmp('modx-static-content').setValue(str);
                         this.markDirty();
                     },
                     scope: this


### PR DESCRIPTION
### What changed and why

Re-factored the component structure for the content-related regions/field to allow them to be individually shown/hidden. Note that the change in how these are defined also makes the above and below regions renderable for _all_ Resource types instead of just the Document type.

### How to test

Create two TVs and a Form Customization set to move those TVs into the `modx-resource-content-above` and `modx-resource-content-below` Regions. Toggle the visibility of those and the main `modx-resource-content` field to verify all work as expected.

### Related issue(s)/PR(s)

Resolves #15711

### Compatibility notes

n/a

### Breaking change assessment

n/a

### Test coverage

n/a

### Contributors

Issue authored by @Jako

### AI tool use

None