### PR TITLE
Stop using getService for lexicon, registry, error, smarty, mail, and hashing

### DIFF
--- a/_build/test/MODxControllerTestCase.php
+++ b/_build/test/MODxControllerTestCase.php
@@ -11,7 +11,6 @@
 */
 namespace MODX\Revolution;
 
-use MODX\Revolution\Smarty\modSmarty;
 
 /**
  * Abstract class extending MODxTestCase for controller-specific testing
@@ -43,9 +42,7 @@ abstract class MODxControllerTestCase extends MODxTestCase {
 
         /* load smarty template engine */
         $templatePath = $this->modx->getOption('manager_path') . 'templates/default/';
-        $this->modx->getService('smarty', modSmarty::class, '', [
-            'template_dir' => $templatePath,
-        ]);
+        $this->modx->getSmarty($templatePath);
         $this->modx->smarty->setCachePath('mgr/smarty/default/');
         $this->modx->smarty->assign('_config',$this->modx->config);
         $this->modx->smarty->assignByRef('modx',$this->modx);

--- a/_build/test/Tests/Controllers/LoadControllerTest.php
+++ b/_build/test/Tests/Controllers/LoadControllerTest.php
@@ -7,7 +7,6 @@ use MODX\Revolution\modManagerResponse;
 use MODX\Revolution\modX;
 use MODX\Revolution\MODxTestCase;
 use MODX\Revolution\Processors\Resource\Create;
-use MODX\Revolution\Smarty\modSmarty;
 
 /**
  * Tests related to the modManagerResponse and modManagerController classes for loading controllers
@@ -27,9 +26,7 @@ class LoadControllerTest extends MODxTestCase
 
         /* load smarty template engine */
         $templatePath = $this->modx->getOption('manager_path') . 'templates/default/';
-        $this->modx->getService('smarty', modSmarty::class, '', [
-            'template_dir' => $templatePath,
-        ]);
+        $this->modx->getSmarty($templatePath);
         $this->modx->smarty->setCachePath('mgr/smarty/default/');
         $this->modx->smarty->assign('_config', $this->modx->config);
         $this->modx->smarty->assignByRef('modx', $this->modx);

--- a/core/src/Revolution/Filters/modOutputFilter.php
+++ b/core/src/Revolution/Filters/modOutputFilter.php
@@ -469,9 +469,6 @@ class modOutputFilter
                             break;
                         case 'fuzzydate':
                             /* displays a "fuzzy" date reference */
-                            if (empty($this->modx->lexicon)) {
-                                $this->modx->getService('lexicon', 'modLexicon');
-                            }
                             $this->modx->lexicon->load('filters');
                             if (empty($m_val)) {
                                 $m_val = '%b %e';
@@ -494,9 +491,6 @@ class modOutputFilter
                             /* calculates relative time ago from a timestamp */
                             if (empty($output)) {
                                 break;
-                            }
-                            if (empty($this->modx->lexicon)) {
-                                $this->modx->getService('lexicon', 'modLexicon');
                             }
                             $this->modx->lexicon->load('filters');
 

--- a/core/src/Revolution/Mail/modPHPMailer.php
+++ b/core/src/Revolution/Mail/modPHPMailer.php
@@ -241,7 +241,7 @@ class modPHPMailer extends modMail
             }
             $sent = $this->mailer->send();
         } catch (Exception $e) {
-            $this->error = $this->modx->getService('error.modError');
+            $this->error = $this->modx->services->get('error');
             $this->error->addError($e->getMessage());
         }
 
@@ -302,7 +302,7 @@ class modPHPMailer extends modMail
         try {
             $this->mailer->addAttachment($file, $name, $encoding, $type);
         } catch (Exception $e) {
-            $this->error = $this->modx->getService('error.modError');
+            $this->error = $this->modx->services->get('error');
             $this->error->addError($e->getMessage());
         }
     }

--- a/core/src/Revolution/Processors/Element/TemplateVar/Configs/GetInputPropertyConfigs.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Configs/GetInputPropertyConfigs.php
@@ -138,7 +138,7 @@ class GetInputPropertyConfigs extends Processor
     public function initialize()
     {
         /* simulate controller to allow controller methods in TV Input Properties controllers */
-        $this->modx->getService('smarty', 'MODX\Revolution\Smarty\modSmarty', '');
+        $this->modx->smarty = $this->modx->services->get('smarty');
 
         $context = $this->getProperty('context');
         if (empty($context)) {

--- a/core/src/Revolution/Processors/Element/TemplateVar/Configs/GetInputPropertyConfigs.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Configs/GetInputPropertyConfigs.php
@@ -138,7 +138,7 @@ class GetInputPropertyConfigs extends Processor
     public function initialize()
     {
         /* simulate controller to allow controller methods in TV Input Properties controllers */
-        $this->modx->smarty = $this->modx->services->get('smarty');
+        $this->modx->getSmarty($this->modx->getManagerTemplatePath());
 
         $context = $this->getProperty('context');
         if (empty($context)) {

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputProperties.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputProperties.php
@@ -45,7 +45,7 @@ class GetInputProperties extends Processor
     public function initialize()
     {
         /* simulate controller to allow controller methods in TV Input Properties controllers */
-        $this->modx->smarty = $this->modx->services->get('smarty');
+        $this->modx->getSmarty($this->modx->getManagerTemplatePath());
 
         $context = $this->getProperty('context');
         if (empty($context)) {

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputProperties.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputProperties.php
@@ -45,7 +45,7 @@ class GetInputProperties extends Processor
     public function initialize()
     {
         /* simulate controller to allow controller methods in TV Input Properties controllers */
-        $this->modx->getService('smarty', 'MODX\Revolution\Smarty\modSmarty', '');
+        $this->modx->smarty = $this->modx->services->get('smarty');
 
         $context = $this->getProperty('context');
         if (empty($context)) {

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputs.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputs.php
@@ -39,7 +39,7 @@ class GetInputs extends Processor
     public function initialize()
     {
         /* simulate controller to allow controller methods in TV Input Properties controllers */
-        $this->modx->getService('smarty', 'MODX\Revolution\Smarty\modSmarty', '');
+        $this->modx->smarty = $this->modx->services->get('smarty');
         return true;
     }
 

--- a/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputs.php
+++ b/core/src/Revolution/Processors/Element/TemplateVar/Renders/GetInputs.php
@@ -39,7 +39,7 @@ class GetInputs extends Processor
     public function initialize()
     {
         /* simulate controller to allow controller methods in TV Input Properties controllers */
-        $this->modx->smarty = $this->modx->services->get('smarty');
+        $this->modx->getSmarty($this->modx->getManagerTemplatePath());
         return true;
     }
 

--- a/core/src/Revolution/Processors/Resource/Reload.php
+++ b/core/src/Revolution/Processors/Resource/Reload.php
@@ -37,10 +37,8 @@ class Reload extends Processor
     {
         $return = true;
         $modx =& $this->modx;
-        if (!isset($modx->registry)) {
-            if (!$modx->getService('registry', 'registry.modRegistry')) {
-                $return = 'Could not instantiate registry service.';
-            }
+        if (!$modx->services->has('registry') || !$modx->registry) {
+            $return = 'Could not instantiate registry service.';
         }
         $modx->registry->addRegister('resource_reload', 'registry.modDbRegister', ['directory' => 'resource_reload']);
         $this->reg = $modx->registry->resource_reload;

--- a/core/src/Revolution/Processors/Resource/Reload.php
+++ b/core/src/Revolution/Processors/Resource/Reload.php
@@ -37,9 +37,6 @@ class Reload extends Processor
     {
         $return = true;
         $modx =& $this->modx;
-        if (!$modx->services->has('registry') || !$modx->registry) {
-            $return = 'Could not instantiate registry service.';
-        }
         $modx->registry->addRegister('resource_reload', 'registry.modDbRegister', ['directory' => 'resource_reload']);
         $this->reg = $modx->registry->resource_reload;
         if (!$this->reg->connect()) {

--- a/core/src/Revolution/Processors/Security/User/Create.php
+++ b/core/src/Revolution/Processors/Security/User/Create.php
@@ -12,7 +12,6 @@ namespace MODX\Revolution\Processors\Security\User;
 
 
 use Exception;
-use MODX\Revolution\Hashing\modHashing;
 use MODX\Revolution\Processors\Model\CreateProcessor;
 use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\modUser;
@@ -22,7 +21,6 @@ use MODX\Revolution\modUserProfile;
 use MODX\Revolution\modX;
 use MODX\Revolution\Registry\modRegister;
 use MODX\Revolution\Registry\modRegistry;
-use MODX\Revolution\Smarty\modSmarty;
 
 /**
  * Create a user
@@ -224,9 +222,12 @@ class Create extends CreateProcessor {
             // Then restore previous placeholders to prevent any breakage
             $this->modx->placeholders = $ph;
 
-            $this->modx->getService('smarty', modSmarty::class, '', [
-                'template_dir' => $this->modx->getOption('manager_path') . 'templates/' . $this->modx->getOption('manager_theme', null, 'default') . '/',
-            ]);
+            if (!$this->modx->smarty) {
+                $this->modx->smarty = $this->modx->services->get('smarty');
+                $this->modx->smarty->setTemplatePath(
+                    $this->modx->getOption('manager_path') . 'templates/' . $this->modx->getOption('manager_theme', null, 'default') . '/'
+                );
+            }
             $this->modx->smarty->assign('_config', $this->modx->config);
             $this->modx->smarty->assign('content', $message);
             $message = $this->modx->smarty->fetch('email/default.tpl');
@@ -263,7 +264,10 @@ class Create extends CreateProcessor {
             // Then restore previous placeholders to prevent any breakage
             $this->modx->placeholders = $ph;
 
-            $this->modx->getService('smarty', 'smarty.modSmarty', '', ['template_dir' => $this->modx->getOption('manager_path') . 'templates/default/']);
+            if (!$this->modx->smarty) {
+                $this->modx->smarty = $this->modx->services->get('smarty');
+                $this->modx->smarty->setTemplatePath($this->modx->getOption('manager_path') . 'templates/default/');
+            }
 
             $this->modx->smarty->assign('_config', $this->modx->config);
             $this->modx->smarty->assign('content', $message, true);

--- a/core/src/Revolution/Processors/Security/User/Create.php
+++ b/core/src/Revolution/Processors/Security/User/Create.php
@@ -242,7 +242,7 @@ class Create extends CreateProcessor {
             $activationHash = bin2hex(random_bytes(32));
 
             /** @var modRegistry $registry */
-            $registry = $this->modx->getService('registry', 'registry.modRegistry');
+            $registry = $this->modx->services->get('registry');
             /** @var modRegister $register */
             $register = $registry->getRegister('user', 'registry.modDbRegister');
             $register->connect();

--- a/core/src/Revolution/Processors/Security/User/Create.php
+++ b/core/src/Revolution/Processors/Security/User/Create.php
@@ -222,12 +222,7 @@ class Create extends CreateProcessor {
             // Then restore previous placeholders to prevent any breakage
             $this->modx->placeholders = $ph;
 
-            if (!$this->modx->smarty) {
-                $this->modx->smarty = $this->modx->services->get('smarty');
-                $this->modx->smarty->setTemplatePath(
-                    $this->modx->getOption('manager_path') . 'templates/' . $this->modx->getOption('manager_theme', null, 'default') . '/'
-                );
-            }
+            $this->modx->getSmarty($this->modx->getManagerTemplatePath());
             $this->modx->smarty->assign('_config', $this->modx->config);
             $this->modx->smarty->assign('content', $message);
             $message = $this->modx->smarty->fetch('email/default.tpl');
@@ -243,7 +238,7 @@ class Create extends CreateProcessor {
             $activationHash = bin2hex(random_bytes(32));
 
             /** @var modRegistry $registry */
-            $registry = $this->modx->services->get('registry');
+            $registry = $this->modx->registry;
             /** @var modRegister $register */
             $register = $registry->getRegister('user', 'registry.modDbRegister');
             $register->connect();
@@ -264,10 +259,7 @@ class Create extends CreateProcessor {
             // Then restore previous placeholders to prevent any breakage
             $this->modx->placeholders = $ph;
 
-            if (!$this->modx->smarty) {
-                $this->modx->smarty = $this->modx->services->get('smarty');
-                $this->modx->smarty->setTemplatePath($this->modx->getOption('manager_path') . 'templates/default/');
-            }
+            $this->modx->getSmarty($this->modx->getManagerTemplatePath());
 
             $this->modx->smarty->assign('_config', $this->modx->config);
             $this->modx->smarty->assign('content', $message, true);

--- a/core/src/Revolution/Processors/Security/User/Update.php
+++ b/core/src/Revolution/Processors/Security/User/Update.php
@@ -319,7 +319,7 @@ class Update extends UpdateProcessor {
             $activationHash = bin2hex(random_bytes(32));
 
             /** @var modRegistry $registry */
-            $registry = $this->modx->getService('registry', 'registry.modRegistry');
+            $registry = $this->modx->services->get('registry');
             /** @var modRegister $register */
             $register = $registry->getRegister('user', 'registry.modDbRegister');
             $register->connect();

--- a/core/src/Revolution/Processors/Security/User/Update.php
+++ b/core/src/Revolution/Processors/Security/User/Update.php
@@ -319,7 +319,7 @@ class Update extends UpdateProcessor {
             $activationHash = bin2hex(random_bytes(32));
 
             /** @var modRegistry $registry */
-            $registry = $this->modx->services->get('registry');
+            $registry = $this->modx->registry;
             /** @var modRegister $register */
             $register = $registry->getRegister('user', 'registry.modDbRegister');
             $register->connect();
@@ -342,10 +342,7 @@ class Update extends UpdateProcessor {
             // Then restore previous placeholders to prevent any breakage
             $this->modx->placeholders = $ph;
 
-            if (!$this->modx->smarty) {
-                $this->modx->smarty = $this->modx->services->get('smarty');
-                $this->modx->smarty->setTemplatePath($this->modx->getOption('manager_path') . 'templates/default/');
-            }
+            $this->modx->getSmarty($this->modx->getManagerTemplatePath());
 
             $this->modx->smarty->assign('_config', $this->modx->config);
             $this->modx->smarty->assign('content', $message, true);

--- a/core/src/Revolution/Processors/Security/User/Update.php
+++ b/core/src/Revolution/Processors/Security/User/Update.php
@@ -342,7 +342,10 @@ class Update extends UpdateProcessor {
             // Then restore previous placeholders to prevent any breakage
             $this->modx->placeholders = $ph;
 
-            $this->modx->getService('smarty', 'smarty.modSmarty', '', ['template_dir' => $this->modx->getOption('manager_path') . 'templates/default/']);
+            if (!$this->modx->smarty) {
+                $this->modx->smarty = $this->modx->services->get('smarty');
+                $this->modx->smarty->setTemplatePath($this->modx->getOption('manager_path') . 'templates/default/');
+            }
 
             $this->modx->smarty->assign('_config', $this->modx->config);
             $this->modx->smarty->assign('content', $message, true);

--- a/core/src/Revolution/Processors/System/Console.php
+++ b/core/src/Revolution/Processors/System/Console.php
@@ -66,7 +66,6 @@ class Console extends Processor
             'remove_read' => true,
         ];
 
-        $this->modx->getService('registry', modRegistry::class);
         $this->modx->registry->addRegister($register, $registerClass, ['directory' => $register]);
         if (!$this->modx->registry->$register->connect()) {
             return $this->failure($this->modx->lexicon('error'));

--- a/core/src/Revolution/Processors/System/Registry/Register/Read.php
+++ b/core/src/Revolution/Processors/System/Registry/Register/Read.php
@@ -71,7 +71,6 @@ class Read extends Processor
     public function connectRegister($register)
     {
         $register_class = trim($this->getProperty('register_class', modFileRegister::class));
-        $this->modx->getService('registry', modRegistry::class);
         $this->modx->registry->addRegister($register, $register_class, ['directory' => $register]);
 
         $this->register = $this->modx->registry->$register;

--- a/core/src/Revolution/Processors/System/Registry/Register/Send.php
+++ b/core/src/Revolution/Processors/System/Registry/Register/Send.php
@@ -63,7 +63,6 @@ class Send extends Processor
     public function connectRegister($register)
     {
         $register_class = trim($this->getProperty('register_class', modFileRegister::class));
-        $this->modx->getService('registry', modRegistry::class);
         $this->modx->registry->addRegister($register, $register_class, ['directory' => $register]);
 
         $this->register = $this->modx->registry->$register;

--- a/core/src/Revolution/Processors/System/RemoveLocks.php
+++ b/core/src/Revolution/Processors/System/RemoveLocks.php
@@ -34,7 +34,7 @@ class RemoveLocks extends Processor
     public function process()
     {
         /** @var modRegistry $registry */
-        $registry = $this->modx->services->get('registry');
+        $registry = $this->modx->registry;
         if ($registry) {
             $registry->addRegister('locks', modDbRegister::class, ['directory' => 'locks']);
             $registry->locks->connect();

--- a/core/src/Revolution/Processors/System/RemoveLocks.php
+++ b/core/src/Revolution/Processors/System/RemoveLocks.php
@@ -34,7 +34,7 @@ class RemoveLocks extends Processor
     public function process()
     {
         /** @var modRegistry $registry */
-        $registry = $this->modx->getService('registry', modRegistry::class);
+        $registry = $this->modx->services->get('registry');
         if ($registry) {
             $registry->addRegister('locks', modDbRegister::class, ['directory' => 'locks']);
             $registry->locks->connect();

--- a/core/src/Revolution/Rest/modRest.php
+++ b/core/src/Revolution/Rest/modRest.php
@@ -60,7 +60,6 @@ class modRest
             'userAgent' => 'MODX RestClient/1.0.0',
             'username' => null,
         ], $config);
-        $this->modx->getService('lexicon', 'modLexicon');
         if ($this->modx->lexicon) {
             $this->modx->lexicon->load('rest');
         }

--- a/core/src/Revolution/Rest/modRestService.php
+++ b/core/src/Revolution/Rest/modRestService.php
@@ -69,7 +69,6 @@ class modRestService
             'xmlRootNode' => 'response',
             'sanitize' => false,
         ], $config);
-        $this->modx->getService('lexicon', 'modLexicon');
         if ($this->modx->lexicon) {
             $this->modx->lexicon->load('rest');
         }

--- a/core/src/Revolution/modLexiconTag.php
+++ b/core/src/Revolution/modLexiconTag.php
@@ -75,9 +75,6 @@ class modLexiconTag extends modTag
             if (isset($options['content'])) {
                 $this->_content = $options['content'];
             } else {
-                if (!is_object($this->modx->lexicon)) {
-                    $this->modx->getService('lexicon', 'modLexicon');
-                }
                 $topic = !empty($this->_properties['topic']) ? $this->_properties['topic'] : 'default';
                 $namespace = !empty($this->_properties['namespace']) ? $this->_properties['namespace'] : 'core';
                 $language = !empty($this->_properties['language']) ? $this->_properties['language'] : $this->modx->getOption('cultureKey',

--- a/core/src/Revolution/modManagerRequest.php
+++ b/core/src/Revolution/modManagerRequest.php
@@ -12,7 +12,6 @@ namespace MODX\Revolution;
 
 use MODX\Revolution\Error\modError;
 use MODX\Revolution\Registry\modFileRegister;
-use MODX\Revolution\Smarty\modSmarty;
 use xPDO\Cache\xPDOCacheManager;
 use xPDO\xPDO;
 
@@ -77,9 +76,8 @@ class modManagerRequest extends modRequest
         if (!file_exists($templatePath)) { /* fallback to default */
             $templatePath = $this->modx->getOption('manager_path') . 'templates/default/';
         }
-        $this->modx->getService('smarty', modSmarty::class, '', [
-            'template_dir' => $templatePath,
-        ]);
+        $this->modx->smarty = $this->modx->services->get('smarty');
+        $this->modx->smarty->setTemplatePath($templatePath);
         /* load context-specific cache dir */
         $this->modx->smarty->setCachePath($this->modx->context->get('key') . '/smarty/' . $theme . '/');
 

--- a/core/src/Revolution/modManagerRequest.php
+++ b/core/src/Revolution/modManagerRequest.php
@@ -72,12 +72,7 @@ class modManagerRequest extends modRequest
 
         /* load smarty template engine */
         $theme = $this->modx->getOption('manager_theme', null, 'default');
-        $templatePath = $this->modx->getOption('manager_path') . 'templates/' . $theme . '/';
-        if (!file_exists($templatePath)) { /* fallback to default */
-            $templatePath = $this->modx->getOption('manager_path') . 'templates/default/';
-        }
-        $this->modx->smarty = $this->modx->services->get('smarty');
-        $this->modx->smarty->setTemplatePath($templatePath);
+        $this->modx->getSmarty($this->modx->getManagerTemplatePath(), true);
         /* load context-specific cache dir */
         $this->modx->smarty->setCachePath($this->modx->context->get('key') . '/smarty/' . $theme . '/');
 

--- a/core/src/Revolution/modMenu.php
+++ b/core/src/Revolution/modMenu.php
@@ -120,10 +120,6 @@ class modMenu extends modAccessibleObject
      */
     public function getSubMenus($start = '')
     {
-        if (!$this->xpdo->lexicon) {
-            $this->xpdo->getService('lexicon', modLexicon::class);
-        }
-
         $this->xpdo->lexicon->load('menu', 'en:menu', 'topmenu', 'en:topmenu');
 
         $c = $this->xpdo->newQuery(modMenu::class);

--- a/core/src/Revolution/modRequest.php
+++ b/core/src/Revolution/modRequest.php
@@ -471,7 +471,7 @@ class modRequest
     public function registerLogging(array $options = [])
     {
         if (isset($options['register']) && isset($options['topic'])) {
-            if ($this->modx->getService('registry', modRegistry::class)) {
+            if ($this->modx->registry) {
                 $register_class = isset($options['register_class']) ? $options['register_class'] : modFileRegister::class;
                 $register = $this->modx->registry->getRegister($options['register'], $register_class);
                 if ($register) {

--- a/core/src/Revolution/modResource.php
+++ b/core/src/Revolution/modResource.php
@@ -3,7 +3,6 @@
 namespace MODX\Revolution;
 
 use MODX\Revolution\Registry\modDbRegister;
-use MODX\Revolution\Registry\modRegistry;
 use MODX\Revolution\modX;
 use PDO;
 use ReflectionClass;
@@ -208,7 +207,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
         $segment = html_entity_decode($segment, ENT_QUOTES, $charset);
 
         /* prepare '&' replacement */
-        if ($xpdo instanceof modX && $xpdo->getService('lexicon', modLexicon::class) && $xpdo->lexicon('and')) {
+        if ($xpdo instanceof modX && $xpdo->lexicon && $xpdo->lexicon('and')) {
             $ampersand = ' ' . $xpdo->lexicon('and') . ' ';
         } else {
             $ampersand = ' and ';
@@ -797,7 +796,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
     {
         $lock = 0;
         if ($this->xpdo instanceof modX) {
-            if ($this->xpdo->getService('registry', modRegistry::class)) {
+            if ($this->xpdo->registry) {
                 $this->xpdo->registry->addRegister('locks', modDbRegister::class, ['directory' => 'locks']);
                 $this->xpdo->registry->locks->connect();
                 $this->xpdo->registry->locks->subscribe('/resource/' . md5($this->get('id')));
@@ -829,7 +828,7 @@ class modResource extends modAccessibleSimpleObject implements modResourceInterf
             }
             $lockedBy = $this->getLock();
             if (empty($lockedBy) || $lockedBy == $user) {
-                if ($this->xpdo->getService('registry', modRegistry::class)) {
+                if ($this->xpdo->registry) {
                     $this->xpdo->registry->addRegister('locks', modDbRegister::class, ['directory' => 'locks']);
                     $this->xpdo->registry->locks->connect();
                     $this->xpdo->registry->locks->subscribe('/resource/' . md5($this->get('id')));

--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -3,7 +3,6 @@
 namespace MODX\Revolution;
 
 use DirectoryIterator;
-use MODX\Revolution\Smarty\modSmarty;
 use MODX\Revolution\Sources\modFileMediaSource;
 use MODX\Revolution\Sources\modFTPMediaSource;
 use MODX\Revolution\Sources\modMediaSource;
@@ -384,10 +383,11 @@ class modTemplateVar extends modElement
             $style = is_array($options) && isset($options['style']) ? strval($options['style']) : '';
             $value = is_array($options) && isset($options['value']) ? strval($options['value']) : '';
         }
-        if (!isset($this->xpdo->smarty)) {
-            $this->xpdo->getService('smarty', modSmarty::class, '', [
-                'template_dir' => $this->xpdo->getOption('manager_path') . 'templates/' . $this->xpdo->getOption('manager_theme', null, 'default') . '/'
-            ]);
+        if (!$this->xpdo->smarty) {
+            $this->xpdo->smarty = $this->xpdo->services->get('smarty');
+            $this->xpdo->smarty->setTemplatePath(
+                $this->xpdo->getOption('manager_path') . 'templates/' . $this->xpdo->getOption('manager_theme', null, 'default') . '/'
+            );
         }
         $this->xpdo->smarty->assign('style', $style);
         if (!isset($value) || empty($value)) {

--- a/core/src/Revolution/modTemplateVar.php
+++ b/core/src/Revolution/modTemplateVar.php
@@ -383,11 +383,8 @@ class modTemplateVar extends modElement
             $style = is_array($options) && isset($options['style']) ? strval($options['style']) : '';
             $value = is_array($options) && isset($options['value']) ? strval($options['value']) : '';
         }
-        if (!$this->xpdo->smarty) {
-            $this->xpdo->smarty = $this->xpdo->services->get('smarty');
-            $this->xpdo->smarty->setTemplatePath(
-                $this->xpdo->getOption('manager_path') . 'templates/' . $this->xpdo->getOption('manager_theme', null, 'default') . '/'
-            );
+        if ($this->xpdo instanceof modX) {
+            $this->xpdo->getSmarty($this->xpdo->getManagerTemplatePath());
         }
         $this->xpdo->smarty->assign('style', $style);
         if (!isset($value) || empty($value)) {

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -283,7 +283,7 @@ class modUser extends modPrincipal
     {
         $activated = -1;
         if ($this->get('cachepwd')) {
-            if ($this->xpdo->getService('registry', modRegistry::class)
+            if ($this->xpdo->registry
                 && $this->xpdo->registry->getRegister('user', modDbRegister::class)) {
                 if ($this->xpdo->registry->user->connect()) {
                     $activated = false;
@@ -866,7 +866,7 @@ class modUser extends modPrincipal
     {
         $removed = false;
         if ($this->xpdo instanceof modX) {
-            if ($this->xpdo->getService('registry', modRegistry::class)) {
+            if ($this->xpdo->registry) {
                 $this->xpdo->registry->addRegister('locks', modDbRegister::class, ['directory' => 'locks']);
                 $this->xpdo->registry->locks->connect();
 

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -282,8 +282,10 @@ class modUser extends modPrincipal
     {
         $activated = -1;
         if ($this->get('cachepwd')) {
-            if ($this->xpdo->registry
-                && $this->xpdo->registry->getRegister('user', modDbRegister::class)) {
+            if (
+                $this->xpdo->registry
+                && $this->xpdo->registry->getRegister('user', modDbRegister::class)
+            ) {
                 if ($this->xpdo->registry->user->connect()) {
                     $activated = false;
                     $this->xpdo->registry->user->subscribe('/pwd/reset/' . md5($this->get('username')));

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -3,6 +3,7 @@
 namespace MODX\Revolution;
 
 use MODX\Revolution\Hashing\modHash;
+use MODX\Revolution\Hashing\modHashing;
 use MODX\Revolution\Mail\modMail;
 use MODX\Revolution\Mail\modPHPMailer;
 use MODX\Revolution\Registry\modDbRegister;
@@ -58,12 +59,15 @@ class modUser extends modPrincipal
                 return false;
             }
         }
-        if (in_array($k, ['password', 'cachepwd']) && $this->xpdo->hashing) {
-            if (!$this->get('salt')) {
-                $this->set('salt', md5(uniqid(rand(), true)));
+        if (in_array($k, ['password', 'cachepwd'])) {
+            $hashing = $this->getHashingService();
+            if ($hashing) {
+                if (!$this->get('salt')) {
+                    $this->set('salt', md5(uniqid(rand(), true)));
+                }
+                $vOptions = ['salt' => $this->get('salt')];
+                $v = $hashing->getHash('', $this->get('hash_class'))->hash($v, $vOptions);
             }
-            $vOptions = ['salt' => $this->get('salt')];
-            $v = $this->xpdo->hashing->getHash('', $this->get('hash_class'))->hash($v, $vOptions);
         }
 
         return parent::set($k, $v, $vType);
@@ -256,15 +260,39 @@ class modUser extends modPrincipal
     public function passwordMatches($password, array $options = [])
     {
         $match = false;
-        if ($this->xpdo->hashing) {
+        $hashing = $this->getHashingService();
+        if ($hashing) {
             $options = array_merge(['salt' => $this->get('salt')], $options);
 
             /** @var modHash $hasher */
-            $hasher = $this->xpdo->hashing->getHash('', $this->get('hash_class'));
+            $hasher = $hashing->getHash('', $this->get('hash_class'));
             $match = $hasher->verify($password, $this->get('password'), $options);
         }
 
         return $match;
+    }
+
+    /**
+     * Resolve the hashing service from modX property or the DI container (plain xPDO / setup).
+     */
+    private function getHashingService(): ?modHashing
+    {
+        if ($this->xpdo instanceof modX && $this->xpdo->hashing instanceof modHashing) {
+            return $this->xpdo->hashing;
+        }
+        if (!$this->xpdo->services->has('hashing')) {
+            $this->xpdo->services->add('hashing', new modHashing($this->xpdo));
+        }
+        $hashing = $this->xpdo->services->get('hashing');
+        if ($hashing instanceof modHashing) {
+            if ($this->xpdo instanceof modX && empty($this->xpdo->hashing)) {
+                $this->xpdo->hashing = $hashing;
+            }
+
+            return $hashing;
+        }
+
+        return null;
     }
 
     /**

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -3,7 +3,6 @@
 namespace MODX\Revolution;
 
 use MODX\Revolution\Hashing\modHash;
-use MODX\Revolution\Hashing\modHashing;
 use MODX\Revolution\Mail\modMail;
 use MODX\Revolution\Mail\modPHPMailer;
 use MODX\Revolution\Registry\modDbRegister;
@@ -59,7 +58,7 @@ class modUser extends modPrincipal
                 return false;
             }
         }
-        if (in_array($k, ['password', 'cachepwd']) && $this->xpdo->getService('hashing', modHashing::class)) {
+        if (in_array($k, ['password', 'cachepwd']) && $this->xpdo->hashing) {
             if (!$this->get('salt')) {
                 $this->set('salt', md5(uniqid(rand(), true)));
             }
@@ -257,7 +256,7 @@ class modUser extends modPrincipal
     public function passwordMatches($password, array $options = [])
     {
         $match = false;
-        if ($this->xpdo->getService('hashing', modHashing::class)) {
+        if ($this->xpdo->hashing) {
             $options = array_merge(['salt' => $this->get('salt')], $options);
 
             /** @var modHash $hasher */
@@ -938,7 +937,8 @@ class modUser extends modPrincipal
         /** @var modUserProfile $profile */
         $profile = $this->getOne('Profile');
         /** @var modPHPMailer $mail */
-        $mail = $this->xpdo->getService('mail', modPHPMailer::class);
+        $mail = $this->xpdo->services->get('mail');
+        $this->xpdo->mail = $mail;
 
         if (!$profile || !$mail) {
             return false;

--- a/core/src/Revolution/modUser.php
+++ b/core/src/Revolution/modUser.php
@@ -939,8 +939,7 @@ class modUser extends modPrincipal
         /** @var modUserProfile $profile */
         $profile = $this->getOne('Profile');
         /** @var modPHPMailer $mail */
-        $mail = $this->xpdo->services->get('mail');
-        $this->xpdo->mail = $mail;
+        $mail = $this->xpdo->getMail();
 
         if (!$profile || !$mail) {
             return false;

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -14,10 +14,12 @@ use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\HttpFactory;
 use MODX\Revolution\Formatter\modManagerDateFormatter;
+use MODX\Revolution\Hashing\modHashing;
 use MODX\Revolution\Services\Container;
 use MODX\Revolution\Error\modError;
 use MODX\Revolution\Error\modErrorHandler;
 use MODX\Revolution\Mail\modMail;
+use MODX\Revolution\Mail\modPHPMailer;
 use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\Registry\modRegister;
@@ -219,6 +221,10 @@ class modX extends xPDO {
      * @var modRegistry $registry
      */
     public $registry;
+    /**
+     * @var modHashing $hashing
+     */
+    public $hashing;
     /**
      * @var modMail $mail
      */
@@ -588,7 +594,7 @@ class modX extends xPDO {
             $this->_initHttpClient();
             $this->_initCulture($options);
 
-            // Core DI services (tier 1 of #15986): prefer $modx->services->get() over getService().
+            // Core DI services (#15986 tiers 1–2): prefer $modx->services->get() over getService().
             $this->services->add('registry', new modRegistry($this));
             $this->registry = $this->services->get('registry');
 
@@ -596,6 +602,23 @@ class modX extends xPDO {
                 $this->services->add('error', new modError($this));
             }
             $this->error = $this->services->get('error');
+
+            if (!$this->services->has('hashing')) {
+                $this->services->add('hashing', new modHashing($this));
+            }
+            $this->hashing = $this->services->get('hashing');
+
+            // Lazy shared: mail/smarty are heavier and unused on many front-end requests.
+            if (!$this->services->has('mail')) {
+                $this->services->add('mail', function () {
+                    return new modPHPMailer($this);
+                });
+            }
+            if (!$this->services->has('smarty')) {
+                $this->services->add('smarty', function () {
+                    return new modSmarty($this);
+                });
+            }
 
             $this->services->add(modManagerDateFormatter::class, fn() => new modManagerDateFormatter($this));
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -593,7 +593,7 @@ class modX extends xPDO {
             $this->_initErrorHandler($options);
             $this->_initHttpClient();
             $this->_initCulture($options);
-            $this->_registerCoreServices();
+            $this->registerCoreServices();
             $this->services->add(modManagerDateFormatter::class, fn() => new modManagerDateFormatter($this));
 
             if (!$this->getOption(xPDO::OPT_SETUP)) {
@@ -799,7 +799,7 @@ class modX extends xPDO {
      * Prefer $modx->services->get() or the accessors below over getService().
      * hashing/registry/error are eager; mail/smarty are lazy shared factories.
      */
-    protected function _registerCoreServices(): void
+    protected function registerCoreServices(): void
     {
         if (!$this->services->has('registry')) {
             $this->services->add('registry', new modRegistry($this));

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -797,7 +797,7 @@ class modX extends xPDO {
      * Register built-in DI services that replace deprecated getService() usage for core keys.
      *
      * Prefer $modx->services->get() or the accessors below over getService().
-     * hashing/registry/error are eager; mail/smarty are lazy shared factories.
+     * hashing/registry/error are eager; mail/smarty register on first accessor/getService use.
      */
     protected function registerCoreServices(): void
     {
@@ -816,16 +816,8 @@ class modX extends xPDO {
         }
         $this->hashing = $this->services->get('hashing');
 
-        if (!$this->services->has('mail')) {
-            $this->services->add('mail', function () {
-                return new modPHPMailer($this);
-            });
-        }
-        if (!$this->services->has('smarty')) {
-            $this->services->add('smarty', function () {
-                return new modSmarty($this);
-            });
-        }
+        // mail/smarty stay on-demand via getMail()/getSmarty() so getService() can still
+        // construct them with params and sync $modx->mail / $modx->smarty (tests, extras).
     }
 
     /**
@@ -853,6 +845,11 @@ class modX extends xPDO {
      */
     public function getSmarty(?string $templatePath = null, bool $forceTemplatePath = false): modSmarty
     {
+        if (!$this->services->has('smarty')) {
+            $this->services->add('smarty', function () {
+                return new modSmarty($this);
+            });
+        }
         if (!$this->smarty) {
             $this->smarty = $this->services->get('smarty');
             if ($templatePath) {
@@ -870,11 +867,32 @@ class modX extends xPDO {
      */
     public function getMail(): modMail
     {
+        if (!$this->services->has('mail')) {
+            $this->services->add('mail', function () {
+                return new modPHPMailer($this);
+            });
+        }
         if (!$this->mail) {
             $this->mail = $this->services->get('mail');
         }
 
         return $this->mail;
+    }
+
+    /**
+     * Ensure $modx->$name is synced when a service was already registered in the container
+     * (parent getService only assigns the property on first construction).
+     *
+     * @deprecated Use $modx->services or accessors (getSmarty/getMail/…)
+     */
+    public function getService($name, $class = '', $path = '', $params = [])
+    {
+        $service = parent::getService($name, $class, $path, $params);
+        if (is_object($service) && empty($this->$name)) {
+            $this->$name = $service;
+        }
+
+        return $service;
     }
 
     /**

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -588,8 +588,14 @@ class modX extends xPDO {
             $this->_initHttpClient();
             $this->_initCulture($options);
 
+            // Core DI services (tier 1 of #15986): prefer $modx->services->get() over getService().
             $this->services->add('registry', new modRegistry($this));
             $this->registry = $this->services->get('registry');
+
+            if (!$this->services->has('error')) {
+                $this->services->add('error', new modError($this));
+            }
+            $this->error = $this->services->get('error');
 
             $this->services->add(modManagerDateFormatter::class, fn() => new modManagerDateFormatter($this));
 
@@ -1764,17 +1770,11 @@ class modX extends xPDO {
     public function runProcessor($action = '', $scriptProperties = [], $options = []) {
         $result = null;
 
-        // Make sure the required services are loaded before initialising a processor
-        if (!$this->lexicon) {
-            if (!$this->services->has('lexicon')) {
-                $this->services->add('lexicon', new modLexicon($this));
-            }
+        // lexicon/error are registered during initialize(); sync properties if a custom bootstrap cleared them
+        if (!$this->lexicon && $this->services->has('lexicon')) {
             $this->lexicon = $this->services->get('lexicon');
         }
-        if (!$this->error) {
-            if (!$this->services->has('error')) {
-                $this->services->add('error', new modError($this));
-            }
+        if (!$this->error && $this->services->has('error')) {
             $this->error = $this->services->get('error');
         }
 

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -593,33 +593,7 @@ class modX extends xPDO {
             $this->_initErrorHandler($options);
             $this->_initHttpClient();
             $this->_initCulture($options);
-
-            // Core DI services (#15986 tiers 1–2): prefer $modx->services->get() over getService().
-            $this->services->add('registry', new modRegistry($this));
-            $this->registry = $this->services->get('registry');
-
-            if (!$this->services->has('error')) {
-                $this->services->add('error', new modError($this));
-            }
-            $this->error = $this->services->get('error');
-
-            if (!$this->services->has('hashing')) {
-                $this->services->add('hashing', new modHashing($this));
-            }
-            $this->hashing = $this->services->get('hashing');
-
-            // Lazy shared: mail/smarty are heavier and unused on many front-end requests.
-            if (!$this->services->has('mail')) {
-                $this->services->add('mail', function () {
-                    return new modPHPMailer($this);
-                });
-            }
-            if (!$this->services->has('smarty')) {
-                $this->services->add('smarty', function () {
-                    return new modSmarty($this);
-                });
-            }
-
+            $this->_registerCoreServices();
             $this->services->add(modManagerDateFormatter::class, fn() => new modManagerDateFormatter($this));
 
             if (!$this->getOption(xPDO::OPT_SETUP)) {
@@ -817,6 +791,90 @@ class modX extends xPDO {
         }
 
         return $this->parser;
+    }
+
+    /**
+     * Register built-in DI services that replace deprecated getService() usage for core keys.
+     *
+     * Prefer $modx->services->get() or the accessors below over getService().
+     * hashing/registry/error are eager; mail/smarty are lazy shared factories.
+     */
+    protected function _registerCoreServices(): void
+    {
+        if (!$this->services->has('registry')) {
+            $this->services->add('registry', new modRegistry($this));
+        }
+        $this->registry = $this->services->get('registry');
+
+        if (!$this->services->has('error')) {
+            $this->services->add('error', new modError($this));
+        }
+        $this->error = $this->services->get('error');
+
+        if (!$this->services->has('hashing')) {
+            $this->services->add('hashing', new modHashing($this));
+        }
+        $this->hashing = $this->services->get('hashing');
+
+        if (!$this->services->has('mail')) {
+            $this->services->add('mail', function () {
+                return new modPHPMailer($this);
+            });
+        }
+        if (!$this->services->has('smarty')) {
+            $this->services->add('smarty', function () {
+                return new modSmarty($this);
+            });
+        }
+    }
+
+    /**
+     * Resolve the manager Smarty template directory for the active theme.
+     */
+    public function getManagerTemplatePath(): string
+    {
+        $theme = $this->getOption('manager_theme', null, 'default');
+        $templatePath = $this->getOption('manager_path') . 'templates/' . $theme . '/';
+        if (!file_exists($templatePath)) {
+            $templatePath = $this->getOption('manager_path') . 'templates/default/';
+        }
+
+        return $templatePath;
+    }
+
+    /**
+     * Get the shared Smarty service, syncing $modx->smarty.
+     *
+     * Path policy matches former getService() first-wins: setTemplatePath runs only on the
+     * first bind unless $forceTemplatePath is true (manager request always forces the theme path).
+     *
+     * @param string|null $templatePath Optional template directory to apply on first bind (or when forced)
+     * @param bool $forceTemplatePath When true, always apply $templatePath even if smarty was already bound
+     */
+    public function getSmarty(?string $templatePath = null, bool $forceTemplatePath = false): modSmarty
+    {
+        if (!$this->smarty) {
+            $this->smarty = $this->services->get('smarty');
+            if ($templatePath) {
+                $this->smarty->setTemplatePath($templatePath);
+            }
+        } elseif ($forceTemplatePath && $templatePath) {
+            $this->smarty->setTemplatePath($templatePath);
+        }
+
+        return $this->smarty;
+    }
+
+    /**
+     * Get the shared mail service, syncing $modx->mail.
+     */
+    public function getMail(): modMail
+    {
+        if (!$this->mail) {
+            $this->mail = $this->services->get('mail');
+        }
+
+        return $this->mail;
     }
 
     /**

--- a/manager/controllers/default/dashboard/widget.buttons.php
+++ b/manager/controllers/default/dashboard/widget.buttons.php
@@ -15,6 +15,7 @@ class modDashboardWidgetButtons extends modDashboardWidgetInterface
      */
     public function render()
     {
+        $this->modx->getSmarty();
         foreach ($this->widget->toArray() as $key => $value) {
             $this->modx->smarty->assign($key, $value);
         }

--- a/manager/controllers/default/dashboard/widget.buttons.php
+++ b/manager/controllers/default/dashboard/widget.buttons.php
@@ -2,7 +2,6 @@
 
 use MODX\Revolution\modChunk;
 use MODX\Revolution\modDashboardWidgetInterface;
-use MODX\Revolution\Smarty\modSmarty;
 
 /**
  * @package modx
@@ -16,7 +15,7 @@ class modDashboardWidgetButtons extends modDashboardWidgetInterface
      */
     public function render()
     {
-        $this->modx->getService('smarty', modSmarty::class);
+        $this->modx->smarty = $this->modx->services->get('smarty');
         foreach ($this->widget->toArray() as $key => $value) {
             $this->modx->smarty->assign($key, $value);
         }

--- a/manager/controllers/default/dashboard/widget.buttons.php
+++ b/manager/controllers/default/dashboard/widget.buttons.php
@@ -15,7 +15,6 @@ class modDashboardWidgetButtons extends modDashboardWidgetInterface
      */
     public function render()
     {
-        $this->modx->smarty = $this->modx->services->get('smarty');
         foreach ($this->widget->toArray() as $key => $value) {
             $this->modx->smarty->assign($key, $value);
         }

--- a/manager/controllers/default/dashboard/widget.configcheck.php
+++ b/manager/controllers/default/dashboard/widget.configcheck.php
@@ -31,7 +31,6 @@ class modDashboardWidgetConfigCheck extends modDashboardWidgetInterface
         /** @var ProcessorResponse $response */
         $response = $this->modx->runProcessor(ConfigCheck::class);
 
-        $this->modx->smarty = $this->modx->services->get('smarty');
         $this->modx->smarty->assign('warnings', $response->getObject());
 
         return $this->controller->fetchTemplate('dashboard/configcheck.tpl');

--- a/manager/controllers/default/dashboard/widget.configcheck.php
+++ b/manager/controllers/default/dashboard/widget.configcheck.php
@@ -11,7 +11,6 @@
 use MODX\Revolution\modDashboardWidgetInterface;
 use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\Processors\System\ConfigCheck;
-use MODX\Revolution\Smarty\modSmarty;
 
 /**
  * Renders the config check box
@@ -32,7 +31,7 @@ class modDashboardWidgetConfigCheck extends modDashboardWidgetInterface
         /** @var ProcessorResponse $response */
         $response = $this->modx->runProcessor(ConfigCheck::class);
 
-        $this->modx->getService('smarty', modSmarty::class);
+        $this->modx->smarty = $this->modx->services->get('smarty');
         $this->modx->smarty->assign('warnings', $response->getObject());
 
         return $this->controller->fetchTemplate('dashboard/configcheck.tpl');

--- a/manager/controllers/default/dashboard/widget.configcheck.php
+++ b/manager/controllers/default/dashboard/widget.configcheck.php
@@ -31,6 +31,7 @@ class modDashboardWidgetConfigCheck extends modDashboardWidgetInterface
         /** @var ProcessorResponse $response */
         $response = $this->modx->runProcessor(ConfigCheck::class);
 
+        $this->modx->getSmarty();
         $this->modx->smarty->assign('warnings', $response->getObject());
 
         return $this->controller->fetchTemplate('dashboard/configcheck.tpl');

--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -11,7 +11,6 @@
 use MODX\Revolution\modDashboardWidgetInterface;
 use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\Processors\Security\User\GetOnline;
-use MODX\Revolution\Smarty\modSmarty;
 
 /**
  * @package modx
@@ -36,7 +35,7 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface
                 $data = json_decode($data, true);
             }
         }
-        $this->modx->getService('smarty', modSmarty::class);
+        $this->modx->smarty = $this->modx->services->get('smarty');
         $this->modx->smarty->assign('data', $data);
         $this->modx->smarty->assign('can_view_logs', $this->modx->hasPermission('logs'));
 

--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -35,6 +35,7 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface
                 $data = json_decode($data, true);
             }
         }
+        $this->modx->getSmarty();
         $this->modx->smarty->assign('data', $data);
         $this->modx->smarty->assign('can_view_logs', $this->modx->hasPermission('logs'));
 

--- a/manager/controllers/default/dashboard/widget.grid-online.php
+++ b/manager/controllers/default/dashboard/widget.grid-online.php
@@ -35,7 +35,6 @@ class modDashboardWidgetWhoIsOnline extends modDashboardWidgetInterface
                 $data = json_decode($data, true);
             }
         }
-        $this->modx->smarty = $this->modx->services->get('smarty');
         $this->modx->smarty->assign('data', $data);
         $this->modx->smarty->assign('can_view_logs', $this->modx->hasPermission('logs'));
 

--- a/manager/controllers/default/dashboard/widget.grid-rer.php
+++ b/manager/controllers/default/dashboard/widget.grid-rer.php
@@ -11,7 +11,6 @@
 use MODX\Revolution\modDashboardWidgetInterface;
 use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\Processors\Security\User\GetRecentlyEditedResources;
-use MODX\Revolution\Smarty\modSmarty;
 
 /**
  * Renders a grid of recently edited resources by the active user
@@ -39,7 +38,7 @@ class modDashboardWidgetRecentlyEditedResources extends modDashboardWidgetInterf
                 $data = json_decode($data, true);
             }
         }
-        $this->modx->getService('smarty', modSmarty::class);
+        $this->modx->smarty = $this->modx->services->get('smarty');
         $this->modx->smarty->assign('data', $data);
         $this->modx->smarty->assign('can_view_logs', $this->modx->hasPermission('logs'));
 

--- a/manager/controllers/default/dashboard/widget.grid-rer.php
+++ b/manager/controllers/default/dashboard/widget.grid-rer.php
@@ -38,7 +38,6 @@ class modDashboardWidgetRecentlyEditedResources extends modDashboardWidgetInterf
                 $data = json_decode($data, true);
             }
         }
-        $this->modx->smarty = $this->modx->services->get('smarty');
         $this->modx->smarty->assign('data', $data);
         $this->modx->smarty->assign('can_view_logs', $this->modx->hasPermission('logs'));
 

--- a/manager/controllers/default/dashboard/widget.grid-rer.php
+++ b/manager/controllers/default/dashboard/widget.grid-rer.php
@@ -38,6 +38,7 @@ class modDashboardWidgetRecentlyEditedResources extends modDashboardWidgetInterf
                 $data = json_decode($data, true);
             }
         }
+        $this->modx->getSmarty();
         $this->modx->smarty->assign('data', $data);
         $this->modx->smarty->assign('can_view_logs', $this->modx->hasPermission('logs'));
 

--- a/manager/controllers/default/dashboard/widget.updates.php
+++ b/manager/controllers/default/dashboard/widget.updates.php
@@ -54,6 +54,7 @@ class modDashboardWidgetUpdates extends modDashboardWidgetInterface
             $this->modx->cacheManager->set($updateCacheKey, $data, $this->updatesCacheExpire, $updateCacheOptions);
         }
 
+        $this->modx->getSmarty();
         foreach ($data as $key => $value) {
             $this->modx->smarty->assign($key, $value);
         }

--- a/manager/controllers/default/dashboard/widget.updates.php
+++ b/manager/controllers/default/dashboard/widget.updates.php
@@ -54,7 +54,6 @@ class modDashboardWidgetUpdates extends modDashboardWidgetInterface
             $this->modx->cacheManager->set($updateCacheKey, $data, $this->updatesCacheExpire, $updateCacheOptions);
         }
 
-        $this->modx->smarty = $this->modx->services->get('smarty');
         foreach ($data as $key => $value) {
             $this->modx->smarty->assign($key, $value);
         }

--- a/manager/controllers/default/dashboard/widget.updates.php
+++ b/manager/controllers/default/dashboard/widget.updates.php
@@ -3,7 +3,6 @@
 use MODX\Revolution\modX;
 use MODX\Revolution\modDashboardWidgetInterface;
 use MODX\Revolution\Processors\SoftwareUpdate\GetList as SoftwareUpdateGetList;
-use MODX\Revolution\Smarty\modSmarty;
 use xPDO\xPDO;
 
 /**
@@ -55,7 +54,7 @@ class modDashboardWidgetUpdates extends modDashboardWidgetInterface
             $this->modx->cacheManager->set($updateCacheKey, $data, $this->updatesCacheExpire, $updateCacheOptions);
         }
 
-        $this->modx->getService('smarty', modSmarty::class);
+        $this->modx->smarty = $this->modx->services->get('smarty');
         foreach ($data as $key => $value) {
             $this->modx->smarty->assign($key, $value);
         }

--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -502,9 +502,6 @@ abstract class ResourceManagerController extends modManagerController
 
         // get reload data if reload token found in registry
         if (array_key_exists('reload', $scriptProperties) && !empty($scriptProperties['reload'])) {
-            if (!isset($modx->registry)) {
-                $modx->getService('registry', modRegistry::class);
-            }
             /** @var modRegistry $modx->registry */
             if (isset($modx->registry)) {
                 $modx->registry->addRegister('resource_reload', 'registry.modDbRegister', ['directory' => 'resource_reload']);

--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -263,7 +263,7 @@ class SecurityLoginManagerController extends modManagerController
         if (!empty($_GET['modhash'])) {
             $hash = $this->modx->sanitizeString($_GET['modhash']);
             /** @var modDbRegister $registry */
-            $registry = $this->modx->getService('registry', modRegistry::class)
+            $registry = $this->modx->services->get('registry')
                 ->getRegister('user', modDbRegister::class);
             $registry->connect();
             $registry->subscribe('/pwd/change/' . $hash);
@@ -291,7 +291,7 @@ class SecurityLoginManagerController extends modManagerController
         if (!empty($_GET['magiclink'])) {
             $hash = $this->modx->sanitizeString($_GET['magiclink']);
             /** @var modDbRegister $registry */
-            $registry = $this->modx->getService('registry', 'registry.modRegistry')
+            $registry = $this->modx->services->get('registry')
                 ->getRegister('user', 'registry.modDbRegister');
             $registry->connect();
             $registry->subscribe('/pwd/magiclink/' . $hash);
@@ -411,7 +411,7 @@ class SecurityLoginManagerController extends modManagerController
         $hash = $this->modx->sanitizeString($this->scriptProperties['modhash']);
         if (!empty($hash)) {
             /** @var modDbRegister $registry */
-            $registry = $this->modx->getService('registry', modRegistry::class)
+            $registry = $this->modx->services->get('registry')
                 ->getRegister('user', modDbRegister::class);
             $registry->connect();
             $registry->subscribe('/pwd/change/' . $hash);
@@ -533,7 +533,7 @@ class SecurityLoginManagerController extends modManagerController
         $hash = md5(uniqid(md5($user->get('email') . '/' . $user->get('id')), true));
 
         /** @var modRegistry $registry */
-        $registry = $this->modx->getService('registry', modRegistry::class);
+        $registry = $this->modx->services->get('registry');
         /** @var modDbRegister $register */
         $register = $registry->getRegister('user', modDbRegister::class);
         $register->connect();

--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -263,7 +263,7 @@ class SecurityLoginManagerController extends modManagerController
         if (!empty($_GET['modhash'])) {
             $hash = $this->modx->sanitizeString($_GET['modhash']);
             /** @var modDbRegister $registry */
-            $registry = $this->modx->services->get('registry')
+            $registry = $this->modx->registry
                 ->getRegister('user', modDbRegister::class);
             $registry->connect();
             $registry->subscribe('/pwd/change/' . $hash);
@@ -291,7 +291,7 @@ class SecurityLoginManagerController extends modManagerController
         if (!empty($_GET['magiclink'])) {
             $hash = $this->modx->sanitizeString($_GET['magiclink']);
             /** @var modDbRegister $registry */
-            $registry = $this->modx->services->get('registry')
+            $registry = $this->modx->registry
                 ->getRegister('user', 'registry.modDbRegister');
             $registry->connect();
             $registry->subscribe('/pwd/magiclink/' . $hash);
@@ -411,7 +411,7 @@ class SecurityLoginManagerController extends modManagerController
         $hash = $this->modx->sanitizeString($this->scriptProperties['modhash']);
         if (!empty($hash)) {
             /** @var modDbRegister $registry */
-            $registry = $this->modx->services->get('registry')
+            $registry = $this->modx->registry
                 ->getRegister('user', modDbRegister::class);
             $registry->connect();
             $registry->subscribe('/pwd/change/' . $hash);
@@ -533,7 +533,7 @@ class SecurityLoginManagerController extends modManagerController
         $hash = md5(uniqid(md5($user->get('email') . '/' . $user->get('id')), true));
 
         /** @var modRegistry $registry */
-        $registry = $this->modx->services->get('registry');
+        $registry = $this->modx->registry;
         /** @var modDbRegister $register */
         $register = $registry->getRegister('user', modDbRegister::class);
         $register->connect();


### PR DESCRIPTION
### What changed and why

`getService()` is deprecated, but core and manager still used it as a lazy factory for built-in services. This PR finishes **tiers 1–2** from the plan on #15986: stop calling it for six names in `core/src` and `manager`.

That work sits on the [MAB-03](https://github.com/modxcms/mab-recommendations/blob/master/03-xpdo-3-model-refactor.md) stack (xPDO 3 via Composer, autoloading, fewer map-era habits). Here we push the same direction for runtime services: register them on the DI container / accessors instead of the old xPDO service locator.

**Tier 1 — `lexicon`, `registry`, `error`**

- `registerCoreServices()` registers `registry`, `error`, and `hashing` during `initialize()` (`lexicon` already comes from `_initCulture`)
- Call sites use `$modx->services->get(…)` or the synced `$modx->registry` / `$modx->lexicon` / `$modx->error` properties

**Tier 2 — `smarty`, `mail`, `hashing`**

- `hashing` is eager (password paths need it)
- `getSmarty()` / `getMail()` / `getManagerTemplatePath()` are the canonical accessors; smarty/mail register on first use
- Manager request forces the theme template path; other call sites keep first-wins via `getSmarty($path)`
- `modX::getService()` still works for extras/tests and syncs `$modx->$name` when the service was already in the container

Grep gate for those six names under `core/src` and `manager` is empty.

### How to test

1. `rg "getService\s*\(\s*['\"](lexicon|registry|error|smarty|mail|hashing)" core/src manager` → empty
2. Manager login, including forgot-password / activation hash (registry)
3. Edit/save a resource (locks use registry)
4. Open the dashboard (widgets use smarty)
5. Create/update a user with email notification (smarty tpl + mail)
6. Change a user password (hashing)
7. CI PHPUnit / MySQL checks on this branch

### Related issue(s)/PR(s)

- Refs #15986 (tiers 1–2). Does not close the issue.
- Context: [MAB-03 — Refactor Data Model using xPDO 3.x](https://github.com/modxcms/mab-recommendations/blob/master/03-xpdo-3-model-refactor.md) (xPDO 3 / Composer foundation this service move builds on)
- Later tiers on #15986: `fileHandler` / `phpthumb` / `archive` / `translit`, extension packages, then stronger pressure on `getService` itself
- Plan: https://github.com/modxcms/revolution/issues/15986#issuecomment-5235166951

### Compatibility notes

Extras that still call `getService()` for these names keep working. Core prefers accessors and container/`$modx->*` properties after a normal `initialize()`.

### Breaking change assessment

No public signature removals. New helpers: `getSmarty()`, `getMail()`, `getManagerTemplatePath()`, `registerCoreServices()`.

Calling `getService('lexicon')` before `initialize()` / `_initCulture()` was already unsupported.

### Test coverage

Controller test harnesses now use `getSmarty()`. No new dedicated unit tests. Grep gate + PHPUnit + the manual smoke list above.

### Contributors

Thanks @BobRay for filing #15986 and pointing out the container did not already hold these services.

### AI tool use

Cursor helped inventory call sites, apply the changes, and draft this PR. Human review still required.