### PR TITLE
Add optional Monolog PSR-3 logger (MAB-05)

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -767,6 +767,15 @@ $settings['log_deprecated']->fromArray([
   'area' => 'system',
   'editedon' => null,
 ], '', true, true);
+$settings['log_monolog'] = $xpdo->newObject(modSystemSetting::class);
+$settings['log_monolog']->fromArray([
+  'key' => 'log_monolog',
+  'value' => false,
+  'xtype' => 'combo-boolean',
+  'namespace' => 'core',
+  'area' => 'system',
+  'editedon' => null,
+], '', true, true);
 $settings['link_tag_scheme'] = $xpdo->newObject(modSystemSetting::class);
 $settings['link_tag_scheme']->fromArray([
   'key' => 'link_tag_scheme',

--- a/_build/test/Tests/Model/MonologLoggerFactoryTest.php
+++ b/_build/test/Tests/Model/MonologLoggerFactoryTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * @package modx-test
+ */
+
+namespace MODX\Revolution\Tests\Model;
+
+use Monolog\Logger;
+use MODX\Revolution\Logging\MonologLoggerFactory;
+use MODX\Revolution\MODxTestCase;
+use Psr\Log\LoggerInterface;
+use xPDO\xPDO;
+use xPDO\Cache\xPDOCacheManager;
+
+/**
+ * Tests for the default Monolog factory and log_monolog opt-in.
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Model
+ * @group modX
+ * @group Logging
+ */
+class MonologLoggerFactoryTest extends MODxTestCase
+{
+    /**
+     * @var mixed Original log_monolog option value.
+     */
+    private $originalLogMonolog;
+
+    /**
+     * @var int Original log level.
+     */
+    private $originalLogLevel;
+
+    /**
+     * @var mixed Original log target.
+     */
+    private $originalLogTarget;
+
+    /**
+     * @before
+     * @throws \xPDO\xPDOException
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+        $this->originalLogMonolog = $this->modx->getOption('log_monolog');
+        $this->originalLogLevel = $this->modx->getLogLevel();
+        $this->originalLogTarget = $this->modx->getLogTarget();
+        $this->modx->logger = null;
+        $this->unsetContainerLogger();
+    }
+
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
+    {
+        $this->modx->setOption('log_monolog', $this->originalLogMonolog);
+        $this->modx->setLogLevel($this->originalLogLevel);
+        $this->modx->setLogTarget($this->originalLogTarget);
+        $this->modx->logger = null;
+        $this->unsetContainerLogger();
+        parent::tearDownFixtures();
+    }
+
+    public function testCreateReturnsMonologLogger()
+    {
+        $logger = MonologLoggerFactory::create($this->modx);
+
+        $this->assertInstanceOf(LoggerInterface::class, $logger);
+        $this->assertInstanceOf(Logger::class, $logger);
+    }
+
+    public function testApplyDoesNothingWhenDisabled()
+    {
+        $this->modx->setOption('log_monolog', false);
+        $this->modx->logger = null;
+        $this->unsetContainerLogger();
+
+        MonologLoggerFactory::apply($this->modx);
+
+        $this->assertFalse($this->modx->services->has(LoggerInterface::class));
+        $this->assertNull($this->modx->logger);
+    }
+
+    public function testApplySetsLoggerAndContainerWhenEnabled()
+    {
+        $this->modx->setOption('log_monolog', true);
+
+        MonologLoggerFactory::apply($this->modx);
+
+        $this->assertTrue($this->modx->services->has(LoggerInterface::class));
+        $this->assertInstanceOf(LoggerInterface::class, $this->modx->logger);
+        $this->assertSame(
+            $this->modx->services->get(LoggerInterface::class),
+            $this->modx->logger
+        );
+    }
+
+    public function testOptInWritesToResolvedErrorLog()
+    {
+        $cachePath = $this->modx->getCachePath();
+        $filepath = $cachePath . xPDOCacheManager::LOG_DIR;
+        $filename = 'monolog_factory_test.log';
+        $fullpath = $filepath . $filename;
+        if (file_exists($fullpath)) {
+            unlink($fullpath);
+        }
+
+        $this->modx->setLogTarget([
+            'target' => 'FILE',
+            'options' => [
+                'filename' => $filename,
+                'filepath' => $filepath,
+            ],
+        ]);
+        $this->modx->setOption('log_monolog', true);
+        $this->modx->setLogLevel(xPDO::LOG_LEVEL_DEBUG);
+
+        $this->unsetContainerLogger();
+        MonologLoggerFactory::apply($this->modx);
+
+        $this->modx->log(xPDO::LOG_LEVEL_ERROR, 'Monolog opt-in test', '', 'UnitTest', __FILE__, 42);
+
+        $this->assertFileExists($fullpath);
+        $contents = file_get_contents($fullpath);
+        $this->assertStringContainsString('Monolog opt-in test', $contents);
+        unlink($fullpath);
+    }
+
+    public function testCreateHonorsCustomLogTargetPath()
+    {
+        $this->modx->setLogTarget([
+            'target' => 'FILE',
+            'options' => [
+                'filename' => 'custom.log',
+                'filepath' => '/tmp/modx-logs/',
+            ],
+        ]);
+
+        $logger = MonologLoggerFactory::create($this->modx);
+        $this->assertInstanceOf(Logger::class, $logger);
+
+        $handlers = $logger->getHandlers();
+        $this->assertNotEmpty($handlers);
+        $this->assertStringContainsString('custom.log', (string) $handlers[0]->getUrl());
+    }
+
+    private function unsetContainerLogger(): void
+    {
+        if ($this->modx->services->has(LoggerInterface::class)) {
+            $this->modx->services->offsetUnset(LoggerInterface::class);
+        }
+    }
+}

--- a/_build/test/phpunit.xml
+++ b/_build/test/phpunit.xml
@@ -19,6 +19,7 @@
         <testsuite name="Model">
             <file>Tests/Model/modXTest.php</file>
             <file>Tests/Model/modXLoggingTest.php</file>
+            <file>Tests/Model/MonologLoggerFactoryTest.php</file>
             <file>Tests/Model/modParserTest.php</file>
             <directory>Tests/Model/Dashboard</directory>
             <directory>Tests/Model/Element</directory>

--- a/composer.json
+++ b/composer.json
@@ -61,6 +61,7 @@
         "inlinestyle/inlinestyle": "^1.2",
         "simplepie/simplepie": "^1.5",
         "pimple/pimple": "^3.0",
+        "monolog/monolog": "^3.0",
         "psr/http-client": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-factory": "^1.0",

--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,6 +2,10 @@
 This file shows the changes in recent releases of MODX. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
+MODX Revolution 3.3.0-dev
+====================================
+- Add optional Monolog PSR-3 logger via log_monolog system setting (MAB-05)
+
 MODX Revolution 3.2.2-pl (July 7, 2026)
 ====================================
 - Add checkbox style to Add Property Set window (#16883)

--- a/core/docs/changelog.txt
+++ b/core/docs/changelog.txt
@@ -2,10 +2,6 @@
 This file shows the changes in recent releases of MODX. The most current release is usually the
 development release, and is only shown to give an idea of what's currently in the pipeline.
 
-MODX Revolution 3.3.0-dev
-====================================
-- Add optional Monolog PSR-3 logger via log_monolog system setting (MAB-05)
-
 MODX Revolution 3.2.2-pl (July 7, 2026)
 ====================================
 - Add checkbox style to Add Property Set window (#16883)

--- a/core/lexicon/en/setting.inc.php
+++ b/core/lexicon/en/setting.inc.php
@@ -363,6 +363,9 @@ $_lang['setting_log_target_desc'] = 'The default logging target where log messag
 $_lang['setting_log_deprecated'] = 'Log Deprecated Functions';
 $_lang['setting_log_deprecated_desc'] = 'Enable to receive notices in your error log when deprecated functions are used.';
 
+$_lang['setting_log_monolog'] = 'Use Monolog Logger';
+$_lang['setting_log_monolog_desc'] = 'When enabled, MODX uses a PSR-3 Monolog logger writing to the error log file instead of the legacy FILE/ECHO/HTML log targets. Leave disabled to preserve the previous logging behaviour.';
+
 $_lang['setting_mail_charset'] = 'Mail Charset';
 $_lang['setting_mail_charset_desc'] = 'The default charset for emails, e.g., \'iso-8859-1\' or \'utf-8\'';
 

--- a/core/src/Revolution/Logging/MonologLoggerFactory.php
+++ b/core/src/Revolution/Logging/MonologLoggerFactory.php
@@ -1,0 +1,103 @@
+<?php
+
+/*
+ * This file is part of MODX Revolution.
+ *
+ * Copyright (c) MODX, LLC. All Rights Reserved.
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ */
+
+namespace MODX\Revolution\Logging;
+
+use Monolog\Handler\StreamHandler;
+use Monolog\Level;
+use Monolog\Logger;
+use MODX\Revolution\modX;
+use Psr\Log\LoggerInterface;
+use xPDO\Cache\xPDOCacheManager;
+
+/**
+ * Builds and installs the default Monolog logger when log_monolog is enabled.
+ *
+ * Disabled (default): no container binding and no setLogger() call — legacy
+ * FILE/ECHO/HTML behaviour is unchanged.
+ *
+ * Enabled: creates Monolog → binds LoggerInterface in the DI container →
+ * setLogger(), so PSR-3 replaces legacy FILE/ECHO/HTML output.
+ */
+final class MonologLoggerFactory
+{
+    /**
+     * Opt in to Monolog: create, bind LoggerInterface, and setLogger().
+     */
+    public static function apply(modX $modx): void
+    {
+        if (!(bool) $modx->getOption('log_monolog', null, false)) {
+            return;
+        }
+
+        $logger = self::create($modx);
+
+        if ($modx->services->has(LoggerInterface::class)) {
+            $modx->services->offsetUnset(LoggerInterface::class);
+        }
+        $modx->services->add(LoggerInterface::class, $logger);
+        $modx->setLogger($logger);
+    }
+
+    /**
+     * Create a Monolog logger writing to the resolved error.log path.
+     */
+    public static function create(modX $modx): LoggerInterface
+    {
+        [$filepath, $filename] = self::resolveLogPath($modx);
+
+        if (!is_dir($filepath)) {
+            $cacheManager = $modx->getCacheManager();
+            if ($cacheManager) {
+                $cacheManager->writeTree($filepath);
+            } else {
+                @mkdir($filepath, 0755, true);
+            }
+        }
+
+        $logger = new Logger('modx');
+        // Debug: modX already filters by logLevel before dispatch.
+        $logger->pushHandler(new StreamHandler($filepath . $filename, Level::Debug));
+
+        return $logger;
+    }
+
+    /**
+     * Resolve the same path used by the legacy FILE log target / Error Log UI.
+     *
+     * @return array{0: string, 1: string} filepath (with trailing slash), filename
+     */
+    private static function resolveLogPath(modX $modx): array
+    {
+        $target = $modx->getLogTarget();
+        $options = is_array($target) && isset($target['options']) && is_array($target['options'])
+            ? $target['options']
+            : [];
+
+        $filename = !empty($options['filename'])
+            ? (string) $options['filename']
+            : (string) $modx->getOption('error_log_filename', null, 'error.log');
+        if ($filename === '') {
+            $filename = 'error.log';
+        }
+
+        if (!empty($options['filepath'])) {
+            $filepath = rtrim((string) $options['filepath'], '/') . '/';
+        } else {
+            $customPath = (string) $modx->getOption('error_log_filepath', null, '');
+            $filepath = $customPath !== ''
+                ? rtrim($customPath, '/') . '/'
+                : $modx->getCachePath() . xPDOCacheManager::LOG_DIR;
+        }
+
+        return [$filepath, $filename];
+    }
+}

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -14,6 +14,7 @@ use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\HttpFactory;
 use MODX\Revolution\Formatter\modManagerDateFormatter;
+use MODX\Revolution\Logging\MonologLoggerFactory;
 use MODX\Revolution\Services\Container;
 use MODX\Revolution\Error\modError;
 use MODX\Revolution\Error\modErrorHandler;
@@ -582,6 +583,7 @@ class modX extends xPDO {
                 $this->_initNamespaces();
                 $this->_initContext($contextKey, false, $options);
                 $this->_loadExtensionPackages($options);
+                MonologLoggerFactory::apply($this);
             }
             $this->_initSession($options);
             $this->_initErrorHandler($options);

--- a/setup/includes/upgrades/common/3.3.0-log-monolog-setting.php
+++ b/setup/includes/upgrades/common/3.3.0-log-monolog-setting.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * Add the log_monolog system setting (default off) for Monolog opt-in.
+ *
+ * @var modX $modx
+ * @var modInstallVersion $this
+ * @package setup
+ * @subpackage upgrades
+ */
+
+use MODX\Revolution\modSystemSetting;
+
+$key = 'log_monolog';
+$existing = $modx->getObject(modSystemSetting::class, ['key' => $key]);
+if ($existing instanceof modSystemSetting) {
+    return;
+}
+
+$setting = $modx->newObject(modSystemSetting::class);
+$setting->fromArray([
+    'key' => $key,
+    'value' => false,
+    'xtype' => 'combo-boolean',
+    'namespace' => 'core',
+    'area' => 'system',
+], '', true, true);
+
+if ($setting->save()) {
+    $this->runner->addResult(
+        modInstallRunner::RESULT_SUCCESS,
+        '<p class="ok">Added system setting: ' . $key . '</p>'
+    );
+} else {
+    $this->runner->addResult(
+        modInstallRunner::RESULT_FAILURE,
+        '<p class="notok">Could not add system setting: ' . $key . '</p>'
+    );
+}

--- a/setup/includes/upgrades/mysql/3.3.0-dev.php
+++ b/setup/includes/upgrades/mysql/3.3.0-dev.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Specific upgrades for Revolution 3.3.0-dev
+ *
+ * @var modX $modx
+ * @var modInstallVersion $this
+ * @package setup
+ * @subpackage upgrades
+ */
+
+include dirname(__DIR__) . '/common/3.3.0-log-monolog-setting.php';


### PR DESCRIPTION
### What changed and why

#16931 added `setLogger(LoggerInterface)`, but MODX still ships with no default PSR-3 logger. This PR finishes that path for [MAB-05](https://github.com/modxcms/mab-recommendations):

- depend on `monolog/monolog`
- add `MODX\Revolution\Logging\MonologLoggerFactory`
- add system setting `log_monolog` (default off)

When you turn the setting on, `initialize()` builds a Monolog logger for the same `error.log` path the Error Log UI already uses, binds `LoggerInterface` in the container, and calls `setLogger()`. With the setting off, FILE/ECHO/HTML logging stays exactly as today.

`modX` only gets one `MonologLoggerFactory::apply($this)` call after `_initContext`. Registry-as-feedback is still out of scope.

### How to test

```bash
composer update monolog/monolog
core/vendor/bin/phpunit -c _build/test/phpunit.xml --filter 'MonologLoggerFactoryTest|modXLoggingTest'
```

Manual:

1. Fresh install or run the `3.3.0-dev` upgrade — confirm `log_monolog` exists and is No.
2. Leave it off, log an error — legacy FILE format in `core/cache/logs/error.log`.
3. Set `log_monolog` to Yes, clear system settings cache, log again — Monolog line in the same file, no legacy double-write.
4. Confirm front/manager still load.

### Related issue(s)/PR(s)

- Follows #16931 (`setLogger` / PSR-3 dispatch)
- Implements the remaining MAB-05 default-logger piece (registry feedback path separate)

### Compatibility notes

Universal. Needs Composer install so `monolog/monolog` is present. Existing sites stay on legacy logging until someone enables `log_monolog`.

### Breaking change assessment

No public API break. Default behaviour unchanged (`log_monolog` off). Enabling the setting replaces FILE/ECHO/HTML output with Monolog for messages that pass `log_level`, which is intentional and documented on the setting.

### Test coverage

- New: `_build/test/Tests/Model/MonologLoggerFactoryTest.php`
- Existing `modXLoggingTest` still passes under the same filter (25 tests total)

### Contributors

Thanks @opengeek and @pbowyer / the #16931 work that made `setLogger()` available.

### AI tool use

Cursor assisted with scaffolding, tests, and local smoke against `revolution.test`. I reviewed the design (opt-in only, factory outside `modX`), ran PHPUnit, and verified on the local stand.