### PR TITLE
Add CI check against re-bundled phpmailer/Smarty/AWS (MAB-01)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,16 @@ on:
   workflow_dispatch:
 
 jobs:
+  bundled-libs-check:
+    name: No bundled phpmailer/Smarty/AWS
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Reject copies outside core/vendor
+        run: bash _build/check_no_bundled_libs.sh
+
   mysql-check:
     name: MySQL Check
     runs-on: ubuntu-latest

--- a/_build/check_no_bundled_libs.sh
+++ b/_build/check_no_bundled_libs.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+#
+# MAB-01 hygiene: fail if phpmailer, Smarty, or AWS SDK are re-bundled under
+# core/ outside Composer-managed core/vendor/.
+#
+# Checks tree fingerprints (historical 3.0.0 cleanup paths + library signature
+# files). Does not search for the words "phpmailer"/"smarty"/"aws" — those hit
+# MODX wrappers, lexicons, and docs.
+#
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT"
+
+failed=0
+
+# Paths removed by setup/includes/upgrades/common/3.0.0-cleanup-files.php
+forbidden_paths=(
+    'core/model/aws'
+    'core/model/smarty'
+    'core/model/modx/mail'
+    'core/model/modx/smarty'
+    'core/model/phpmailer'
+    'core/model/PHPMailer'
+)
+
+for path in "${forbidden_paths[@]}"; do
+    if [[ -e "$path" ]]; then
+        echo "FAIL: bundled library path exists outside core/vendor: ${path}"
+        failed=1
+    fi
+done
+
+# Signature files that only belong to the Composer packages
+while IFS= read -r -d '' file; do
+    echo "FAIL: library signature file outside core/vendor: ${file}"
+    failed=1
+done < <(
+    find core \
+        \( -path 'core/vendor' -o -path 'core/cache' -o -path 'core/packages' \) -prune -o \
+        -type f \( \
+            -name 'PHPMailer.php' \
+            -o -name 'class.phpmailer.php' \
+            -o -name 'Smarty.class.php' \
+            -o -path '*/sysplugins/smarty_internal_templatebase.php' \
+            -o -path '*/Aws/Sdk.php' \
+            -o -path '*/Aws/S3/S3Client.php' \
+        \) -print0 2>/dev/null || true
+)
+
+if [[ "$failed" -ne 0 ]]; then
+    echo
+    echo 'MAB-01: keep phpmailer, Smarty, and AWS SDK only via Composer in core/vendor.'
+    echo 'Remove the paths above or move the dependency to composer.json.'
+    exit 1
+fi
+
+echo 'OK: no bundled phpmailer/Smarty/AWS SDK outside core/vendor'

--- a/composer.json
+++ b/composer.json
@@ -114,10 +114,12 @@
         ],
         "phpcs": "core/vendor/bin/phpcs --standard=phpcs.xml",
         "phpcbf": "core/vendor/bin/phpcbf --standard=phpcs.xml",
+        "check-bundled-libs": "bash _build/check_no_bundled_libs.sh",
         "pre-autoload-dump": "Aws\\Script\\Composer\\Composer::removeUnusedServices"
     },
     "scripts-descriptions": {
-        "phpunit": "Run PHPUnit test"
+        "phpunit": "Run PHPUnit test",
+        "check-bundled-libs": "Fail if phpmailer/Smarty/AWS SDK are copied under core/ outside vendor (MAB-01)"
     },
     "extra": {
         "aws/aws-sdk-php": [


### PR DESCRIPTION
### What changed and why

MAB-01 already put PHPMailer, Smarty, and the AWS SDK behind Composer in `core/vendor/`. The old trees under `core/model/` were cleaned up in 3.0. Nothing stops someone from copying them back in a later PR.

This adds a small hygiene gate:

- `_build/check_no_bundled_libs.sh` — fails on the historical paths and on library signature files (`PHPMailer.php`, `Smarty.class.php`, `Aws/Sdk.php`, …) under `core/` outside `vendor` / `cache` / `packages`
- a dedicated job in `.github/workflows/ci.yml` (no PHP matrix, no Composer)
- `composer check-bundled-libs` for the same check locally

It looks at paths and file fingerprints, not the words “phpmailer” / “smarty” / “aws”, so wrappers like `modPHPMailer` and `MODX\Revolution\Smarty` do not trip it.

### How to test

```bash
bash _build/check_no_bundled_libs.sh
# or
composer check-bundled-libs
```

Expect `OK`. To see it fail: `mkdir -p core/model/aws` then run again; remove the dir after.

### Related issue(s)/PR(s)

- Residual risk close-out for MAB-01 (Composer dependency management)
- Sibling status paperwork: modxcms/mab-recommendations#26

### Compatibility notes

CI-only. No runtime behaviour change. Needs bash + `find` (already true on GitHub-hosted runners and typical Mac/Linux dev machines).

### Breaking change assessment

No public API or default behaviour change. A PR that re-introduces a forbidden tree will fail CI until that copy is removed.

### Test coverage

No PHPUnit case — the gate is the test. Manual negative checks: forbidden path and planted `Aws/Sdk.php` both exit 1; clean tree exits 0.

### Contributors

Builds on the MAB-01 Composer work already in 3.x.

### AI tool use

Cursor helped draft the script and CI job. I chose path fingerprints over keyword search, ran pass/fail smoke locally, and kept the change to one script + one workflow job.