### PR TITLE
Declare modx property on modPackageBuilder for PHP 8.2 compatibility

### DIFF
--- a/_build/test/Tests/Model/Transport/modPackageBuilderTest.php
+++ b/_build/test/Tests/Model/Transport/modPackageBuilderTest.php
@@ -12,7 +12,9 @@
 namespace MODX\Revolution\Tests\Model\Transport;
 
 
+use MODX\Revolution\modX;
 use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Transport\modPackageBuilder;
 
 /**
  * Tests related to the modPackageBuilder class.
@@ -24,7 +26,27 @@ use MODX\Revolution\MODxTestCase;
  * @group modPackageBuilder
  */
 class modPackageBuilderTest extends MODxTestCase {
-    public function testExample() {
-        $this->assertTrue(true);
+    /**
+     * modPackageBuilder must declare $modx to avoid PHP 8.2 dynamic property deprecations.
+     */
+    public function testConstructorDoesNotCreateDynamicModxProperty()
+    {
+        $deprecations = [];
+        set_error_handler(static function ($severity, $message) use (&$deprecations) {
+            if ($severity === E_DEPRECATED && str_contains($message, 'dynamic property')) {
+                $deprecations[] = $message;
+            }
+            return true;
+        }, E_DEPRECATED);
+
+        try {
+            $builder = new modPackageBuilder($this->modx);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame([], $deprecations, 'Expected no dynamic property deprecations on construction');
+        $this->assertInstanceOf(modX::class, $builder->modx);
+        $this->assertSame($this->modx, $builder->modx);
     }
 }

--- a/core/src/Revolution/Transport/modPackageBuilder.php
+++ b/core/src/Revolution/Transport/modPackageBuilder.php
@@ -25,6 +25,12 @@ class modPackageBuilder
 {
 
     /**
+     * @var modX A reference to the MODX instance.
+     * @access public
+     */
+    public $modx = null;
+
+    /**
      * @var string The directory in which the package file is located.
      * @access public
      */


### PR DESCRIPTION
### What changed and why

`modPackageBuilder` sets `$this->modx` in the constructor but never declared the property. PHP 8.2+ emits:

```
PHP deprecated: Creation of dynamic property MODX\Revolution\Transport\modPackageBuilder::$modx is deprecated
```

This PR adds `public $modx = null`, same as `modTransportManager`.

### How to test

```bash
php -l core/src/Revolution/Transport/modPackageBuilder.php
core/vendor/bin/phpunit -c ./_build/test/phpunit.xml Tests/Model/Transport/modPackageBuilderTest.php
```

Exit 0 on PHP 8.4 locally.

To see the original warning: create a `modPackageBuilder` during a package build (manager or `_build`). PHP 8.2+ logged the deprecation at line 70 before this change.

### Related issue(s)/PR(s)

Found in the manager error log.

### Compatibility notes

PHP 8.2+ only. No runtime behavior change.

### Breaking change assessment

No API changes. Safe for patch releases.

### Test coverage

Replaced the placeholder `testExample` with `testConstructorDoesNotCreateDynamicModxProperty`. It checks for no dynamic-property deprecation on construction and confirms the `$modx` reference is set.

### Contributors

N/A

### AI tool use

Cursor agent wrote the patch and test.