### PR TITLE
Fix undefined $_SESSION warning when rebuilding menu cache

### DIFF
--- a/_build/test/Tests/Model/modMenuTest.php
+++ b/_build/test/Tests/Model/modMenuTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+namespace MODX\Revolution\Tests\Model;
+
+use MODX\Revolution\modMenu;
+use MODX\Revolution\MODxTestCase;
+use xPDO\xPDO;
+
+/**
+ * Tests related to modMenu cache rebuild and invalidation.
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Model
+ * @group modMenu
+ */
+class modMenuTest extends MODxTestCase
+{
+    /**
+     * rebuildCache must not emit Undefined global variable $_SESSION.
+     */
+    public function testRebuildCacheWithoutSessionDoesNotWarn()
+    {
+        $hadSession = array_key_exists('_SESSION', $GLOBALS);
+        $previousSession = $hadSession ? $_SESSION : null;
+        unset($GLOBALS['_SESSION']);
+
+        $sessionWarnings = [];
+        set_error_handler(static function ($severity, $message) use (&$sessionWarnings) {
+            if (strpos($message, 'Undefined global variable $_SESSION') !== false) {
+                $sessionWarnings[] = $message;
+                return true;
+            }
+
+            return false;
+        });
+
+        try {
+            $this->modx->setOption('cultureKey', 'en');
+            $this->modx->getCacheManager();
+
+            /** @var modMenu $menu */
+            $menu = $this->modx->newObject(modMenu::class);
+            $menus = $menu->rebuildCache('topnav');
+            $this->assertIsArray($menus);
+            $this->assertSame([], $sessionWarnings);
+        } finally {
+            restore_error_handler();
+            if ($hadSession) {
+                $_SESSION = $previousSession;
+            } else {
+                unset($GLOBALS['_SESSION']);
+            }
+        }
+    }
+
+    /**
+     * clearCache (used by save/remove) must wipe language shards without $_SESSION.
+     */
+    public function testClearCacheWithoutSessionRemovesMenuKeys()
+    {
+        $hadSession = array_key_exists('_SESSION', $GLOBALS);
+        $previousSession = $hadSession ? $_SESSION : null;
+        unset($GLOBALS['_SESSION']);
+
+        $this->modx->setOption('cultureKey', 'en');
+        $cacheManager = $this->modx->getCacheManager();
+        $cacheOptions = [
+            xPDO::OPT_CACHE_KEY => $this->modx->getOption('cache_menu_key', null, 'menu'),
+            xPDO::OPT_CACHE_HANDLER => $this->modx->getOption(
+                'cache_menu_handler',
+                null,
+                $this->modx->getOption(xPDO::OPT_CACHE_HANDLER)
+            ),
+        ];
+
+        $cacheKey = 'menus/topnav/en';
+        $probe = ['probe' => true];
+        $cacheManager->set($cacheKey, $probe, 0, $cacheOptions);
+        $this->assertSame(['probe' => true], $cacheManager->get($cacheKey, $cacheOptions));
+
+        try {
+            /** @var modMenu $menu */
+            $menu = $this->modx->newObject(modMenu::class);
+            $clearCache = new \ReflectionMethod(modMenu::class, 'clearCache');
+            $clearCache->setAccessible(true);
+            $clearCache->invoke($menu);
+            $this->assertNull($cacheManager->get($cacheKey, $cacheOptions));
+        } finally {
+            if ($hadSession) {
+                $_SESSION = $previousSession;
+            } else {
+                unset($GLOBALS['_SESSION']);
+            }
+        }
+    }
+}

--- a/_build/test/Tests/Model/modXTest.php
+++ b/_build/test/Tests/Model/modXTest.php
@@ -119,6 +119,55 @@ class modXTest extends MODxTestCase
     }
 
     /**
+     * getManagerLanguage must not require $_SESSION and must honor session when present.
+     */
+    public function testGetManagerLanguageWithoutSession()
+    {
+        $this->withSessionFixture(null, function () {
+            $this->modx->setOption('cultureKey', 'de');
+            $this->modx->setOption('manager_language', null);
+            $this->assertSame('de', $this->modx->getManagerLanguage());
+        });
+    }
+
+    /**
+     * @depends testGetManagerLanguageWithoutSession
+     */
+    public function testGetManagerLanguagePrefersSessionValue()
+    {
+        $this->withSessionFixture(['manager_language' => 'fr'], function () {
+            $this->modx->setOption('cultureKey', 'de');
+            $this->assertSame('fr', $this->modx->getManagerLanguage());
+        });
+    }
+
+    /**
+     * @param array|null $session null unsets $_SESSION; array replaces it
+     * @param callable $callback
+     */
+    private function withSessionFixture($session, callable $callback)
+    {
+        $hadSession = array_key_exists('_SESSION', $GLOBALS);
+        $previousSession = $hadSession ? $_SESSION : null;
+
+        if ($session === null) {
+            unset($GLOBALS['_SESSION']);
+        } else {
+            $_SESSION = $session;
+        }
+
+        try {
+            $callback();
+        } finally {
+            if ($hadSession) {
+                $_SESSION = $previousSession;
+            } else {
+                unset($GLOBALS['_SESSION']);
+            }
+        }
+    }
+
+    /**
      * @param string $expected
      * @param string $string
      * @param array $chars

--- a/_build/test/phpunit.xml
+++ b/_build/test/phpunit.xml
@@ -20,6 +20,7 @@
             <file>Tests/Model/modXTest.php</file>
             <file>Tests/Model/modXLoggingTest.php</file>
             <file>Tests/Model/modParserTest.php</file>
+            <file>Tests/Model/modMenuTest.php</file>
             <directory>Tests/Model/Dashboard</directory>
             <directory>Tests/Model/Element</directory>
             <directory>Tests/Model/Error</directory>

--- a/core/src/Revolution/Processors/System/Country/GetList.php
+++ b/core/src/Revolution/Processors/System/Country/GetList.php
@@ -52,7 +52,7 @@ class GetList extends Processor
     {
         $_country_lang = [];
         include $this->modx->getOption('core_path') . 'lexicon/country/en.inc.php';
-        $ml = $this->modx->getOption('manager_language', $_SESSION, $this->modx->getOption('cultureKey', null, 'en'));
+        $ml = $this->modx->getManagerLanguage();
         if ($ml !== 'en' && file_exists($this->modx->getOption('core_path') . 'lexicon/country/' . $ml . '.inc.php')) {
             include $this->modx->getOption('core_path') . 'lexicon/country/' . $ml . '.inc.php';
         }

--- a/core/src/Revolution/Transport/modTransportProvider.php
+++ b/core/src/Revolution/Transport/modTransportProvider.php
@@ -474,8 +474,7 @@ class modTransportProvider extends xPDOSimpleObject
             'supports' => $this->xpdo->version['code_name'] . '-' . $this->xpdo->version['full_version'],
             'http_host' => $this->xpdo->getOption('http_host'),
             'php_version' => PHP_VERSION,
-            'language' => $this->xpdo->getOption('manager_language', $_SESSION,
-                $this->xpdo->getOption('cultureKey', null, 'en')),
+            'language' => $this->xpdo->getManagerLanguage(),
         ];
 
         return array_merge($baseArgs, $args);

--- a/core/src/Revolution/modConnectorRequest.php
+++ b/core/src/Revolution/modConnectorRequest.php
@@ -38,8 +38,7 @@ class modConnectorRequest extends modManagerRequest
         if ($this->modx && is_object($this->modx->context) && $this->modx->context instanceof modContext) {
             $ctx = $this->modx->context->get('key');
             if (!empty($ctx) && $ctx == 'mgr') {
-                $ml = $this->modx->getOption('manager_language', $_SESSION ?? [],
-                    $this->modx->getOption('cultureKey', null, 'en'));
+                $ml = $this->modx->getManagerLanguage();
                 if (!empty($ml)) {
                     $this->modx->setOption('cultureKey', $ml);
                 }

--- a/core/src/Revolution/modLexicon.php
+++ b/core/src/Revolution/modLexicon.php
@@ -194,7 +194,7 @@ class modLexicon
         $topics = func_get_args(); /* allow for dynamic number of lexicons to load */
 
         if ($this->modx->context && $this->modx->context->get('key') == 'mgr') {
-            $defaultLanguage = $this->modx->getOption('manager_language', $_SESSION ?? [], $this->modx->getOption('cultureKey', null, 'en'));
+            $defaultLanguage = $this->modx->getManagerLanguage();
         } else {
             $defaultLanguage = $this->modx->getOption('cultureKey', null, 'en');
         }

--- a/core/src/Revolution/modManagerRequest.php
+++ b/core/src/Revolution/modManagerRequest.php
@@ -104,7 +104,7 @@ class modManagerRequest extends modRequest
             $this->modx->getVersionData();
         }
 
-        $ml = $this->modx->getOption('manager_language', $_SESSION, $this->modx->getOption('cultureKey', null, 'en'));
+        $ml = $this->modx->getManagerLanguage();
         if (!empty($ml)) {
             $this->modx->setOption('cultureKey', $ml);
         }

--- a/core/src/Revolution/modMenu.php
+++ b/core/src/Revolution/modMenu.php
@@ -24,7 +24,7 @@ use xPDO\xPDO;
 class modMenu extends modAccessibleObject
 {
     /**
-     * Overrides xPDOObject::save to cache the menus.
+     * Overrides xPDOObject::save to invalidate the menu cache.
      *
      * {@inheritdoc}
      */
@@ -32,14 +32,14 @@ class modMenu extends modAccessibleObject
     {
         $saved = parent::save($cacheFlag);
         if ($saved && empty($this->xpdo->config[xPDO::OPT_SETUP])) {
-            $this->rebuildCache();
+            $this->clearCache();
         }
 
         return $saved;
     }
 
     /**
-     * Overrides xPDOObject::remove to cache the menus.
+     * Overrides xPDOObject::remove to invalidate the menu cache.
      *
      * {@inheritdoc}
      */
@@ -47,10 +47,27 @@ class modMenu extends modAccessibleObject
     {
         $removed = parent::remove($ancestors);
         if ($removed && empty($this->xpdo->config[xPDO::OPT_SETUP])) {
-            $this->rebuildCache();
+            $this->clearCache();
         }
 
         return $removed;
+    }
+
+    /**
+     * Clear all language shards of the menu cache partition without firing OnCacheUpdate.
+     *
+     * Menu processors still call refresh() once so plugins see a single cache event.
+     */
+    protected function clearCache()
+    {
+        $this->xpdo->getCacheManager()->clean([
+            xPDO::OPT_CACHE_KEY => $this->xpdo->getOption('cache_menu_key', null, 'menu'),
+            xPDO::OPT_CACHE_HANDLER => $this->xpdo->getOption(
+                'cache_menu_handler',
+                null,
+                $this->xpdo->getOption(xPDO::OPT_CACHE_HANDLER)
+            ),
+        ]);
     }
 
     /**
@@ -66,8 +83,7 @@ class modMenu extends modAccessibleObject
         if ($start !== '') {
             $cacheKey .= "{$start}/";
         }
-        $cacheKey .= $this->xpdo->getOption('manager_language', $_SESSION,
-            $this->xpdo->getOption('cultureKey', null, 'en'));
+        $cacheKey .= $this->xpdo->getManagerLanguage();
         $menus = $this->getSubMenus($start);
         $cached = $this->xpdo->cacheManager->set($cacheKey, $menus, 0, [
             xPDO::OPT_CACHE_KEY => $this->xpdo->cacheManager->getOption('cache_menu_key', null, 'menu'),
@@ -147,45 +163,29 @@ class modMenu extends modAccessibleObject
         $list = [];
         /** @var modMenu $menu */
         foreach ($menus as $menu) {
+            $textKey = $menu->get('text');
             $ma = $menu->toArray();
-            $ma['id'] = $menu->get('text');
-            $action = $menu->get('action');
+            $ma['id'] = $textKey;
             $namespace = $menu->get('namespace');
 
             if ($namespace !== 'core') {
                 $this->xpdo->lexicon->load($namespace . ':default');
             }
 
-            /* if 3rd party menu item, load proper text */
-            if (!empty($action)) {
-                if (!empty($namespace) && $namespace !== 'core') {
-                    $ma['text'] = $menu->get('text') === 'user'
-                        ? $this->xpdo->lexicon($menu->get('text'), ['username' => $this->xpdo->getLoginUserName()])
-                        : $this->xpdo->lexicon($menu->get('text'));
-                } else {
-                    $ma['text'] = $menu->get('text') === 'user'
-                        ? $this->xpdo->lexicon($menu->get('text'), ['username' => $this->xpdo->getLoginUserName()])
-                        : $this->xpdo->lexicon($menu->get('text'));
-                }
-            } else {
-                $ma['text'] = $menu->get('text') === 'user'
-                    ? $this->xpdo->lexicon($menu->get('text'), ['username' => $this->xpdo->getLoginUserName()])
-                    : $this->xpdo->lexicon($menu->get('text'));
-            }
+            $ma['text'] = $this->xpdo->lexicon(
+                $textKey,
+                $textKey === 'user' ? ['username' => $this->xpdo->getLoginUserName()] : []
+            );
 
             $desc = $menu->get('description');
             $ma['description'] = !empty($desc) ? $this->xpdo->lexicon($desc) : '';
-            $ma['children'] = $menu->get('text') != '' ? $this->getSubMenus($menu->get('text')) : [];
+            $ma['children'] = $textKey != '' ? $this->getSubMenus($textKey) : [];
 
-            if ($ma['id'] === 'language') {
+            if ($textKey === 'language') {
                 $ma['children'] = $this->getLanguageMenu();
             }
 
-            if ($menu->get('controller')) {
-                $ma['controller'] = $menu->get('controller');
-            } else {
-                $ma['controller'] = '';
-            }
+            $ma['controller'] = $menu->get('controller') ?: '';
             $list[] = $ma;
         }
         unset($menu, $desc, $namespace, $ma);

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -2286,6 +2286,23 @@ class modX extends xPDO {
     }
 
     /**
+     * Resolve the manager UI language without requiring $_SESSION.
+     *
+     * Looks up session `manager_language`, then config `manager_language`,
+     * then cultureKey, then en.
+     *
+     * @return string
+     */
+    public function getManagerLanguage()
+    {
+        return (string) $this->getOption(
+            'manager_language',
+            $_SESSION ?? [],
+            $this->getOption('cultureKey', null, 'en')
+        );
+    }
+
+    /**
      * Executed before parser processing of an element.
      */
     public function beforeProcessing() {}

--- a/manager/controllers/default/header.php
+++ b/manager/controllers/default/header.php
@@ -258,9 +258,7 @@ class TopMenu
      */
     protected function getCacheKey($name)
     {
-        $ml = $this->modx->getOption('manager_language', $_SESSION, $this->modx->getOption('cultureKey', null, 'en'));
-
-        return "menus/{$name}/" . $ml;
+        return "menus/{$name}/" . $this->modx->getManagerLanguage();
     }
 
     /**

--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -205,7 +205,7 @@ class SecurityLoginManagerController extends modManagerController
 
         $ml = $this->modx->sanitizeString($this->modx->getOption('manager_language', $_REQUEST));
         if (!$ml || !in_array($ml, $languages)) {
-            $ml = $this->modx->getOption('manager_language', $_SESSION);
+            $ml = $this->modx->getOption('manager_language', $_SESSION ?? []);
             if (!$ml) {
                 // Try to detect default browser language
                 $accept_languages = strtolower($_SERVER['HTTP_ACCEPT_LANGUAGE']);


### PR DESCRIPTION
### What changed and why

`modMenu::rebuildCache()` and other manager-language lookups passed bare `$_SESSION` into `getOption()`. Without an active session (CLI, early bootstrap, save/remove cache work) PHP 8+ logs `Undefined global variable $_SESSION`.

Changes:

- `modX::getManagerLanguage()` resolves language as `$_SESSION ?? []` → config `manager_language` → `cultureKey` → `en`.
- `modMenu::save` / `remove` call `clearCache()` (`clean` on the menu partition) and skip session-keyed rebuild. Menu processors still call `refresh(['menu' => []])` once, so `OnCacheUpdate` fires once.
- Rebuild/read paths use `getManagerLanguage()`: `rebuildCache`, manager header, lexicon, connector/manager request, country list, transport provider.
- `getSubMenus` drops identical dead lexicon branches.
- Login keeps Accept-Language. Session read uses `$_SESSION ?? []`.

### How to test

1. Run `php -l` on the touched PHP files.
2. Run `composer phpunit -- --filter 'modMenuTest|testGetManagerLanguage'` (expect exit 0: 4 tests, 8 assertions).
3. Save or remove a manager menu item without an HTTP session. Confirm the log has no `Undefined global variable $_SESSION` from `modMenu.php`.
4. Set session `manager_language`, clear the menu cache, open the manager. Confirm the top menu renders in that language.

### Related issue(s)/PR(s)

No GitHub issue. Production log:

`PHPwarning: Undefined global variable $_SESSION` at `core/src/Revolution/modMenu.php:69`.

### Compatibility notes

Applies to PHP 8+ installs. No config changes. With an active manager session, language resolution matches the old `getOption('manager_language', $_SESSION, …)` chain.

### Breaking change assessment

No public API removals. Adds `modX::getManagerLanguage()`. Menu mutate hooks clear the full menu partition instead of rewriting one language-keyed entry. Processors still fire `OnCacheUpdate` once. Safe for patch-level consumers.

### Test coverage

- `_build/test/Tests/Model/modXTest.php`: `getManagerLanguage` without session and with session preference
- `_build/test/Tests/Model/modMenuTest.php`: `rebuildCache` without `$_SESSION` warning; `clearCache` removes menu partition keys
- Registered in `_build/test/phpunit.xml`

### Contributors

### AI tool use

Cursor (Composer) handled implementation and reviews: code-simplifier, code-reviewer, thermo-nuclear code-quality review, security-review.