### PR TITLE
Fix nested chunk tags when the chunk name contains a tag

### DIFF
--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -11,6 +12,7 @@
  */
 namespace MODX\Revolution\Tests\Model;
 
+use MODX\Revolution\modChunk;
 use MODX\Revolution\modElementPropertySet;
 use MODX\Revolution\modPropertySet;
 use MODX\Revolution\modSnippet;
@@ -427,43 +429,10 @@ return implode("|", array_map(function ($k) use ($scriptProperties) { return $k 
                 ]
             ],
             [
-                // This test makes sure that spacing around the `:` doesn't matter and spacing in
-                // the output is kept
+                // Spacing around `:` is ignored; nested else tags finish in one pass once
+                // merge prefers the longer collected tag over `[[+is2]]`.
                 [
                     'processed' => 1,
-                    'content' => "
-                        [[+is2
-                            :is=`2`
-                            :then=`2`
-                            :else=`more`
-                        ]]
-                    "
-                ],
-                "[[+is2
-                    :is=`1`
-                    :then=`[[+is2]]`
-                    :else=`
-                        [[+is2
-                            :is=`2`
-                            :then=`[[+is2]]`
-                            :else=`more`
-                        ]]
-                    `
-                ]]",
-                [
-                    'parentTag' => '',
-                    'processUncacheable' => true,
-                    'removeUnprocessed' => false,
-                    'prefix' => '[[',
-                    'suffix' => ']]',
-                    'tokens' => [],
-                    'depth' => 0
-                ]
-            ],
-            [
-                // Same as previous, but now parsing 2-depth to get the final result
-                [
-                    'processed' => 2,
                     'content' => "
                         2
                     "
@@ -486,13 +455,13 @@ return implode("|", array_map(function ($k) use ($scriptProperties) { return $k 
                     'prefix' => '[[',
                     'suffix' => ']]',
                     'tokens' => [],
-                    'depth' => 2
+                    'depth' => 0
                 ]
             ],
             [
                 [
                     'processed' => 1,
-                    'content' => "[[+is2:is=`2`:then=`2`:else=`more`]]"
+                    'content' => "2"
                 ],
                 "[[+is2:is=`1`:then=`[[+is2]]`:else=`[[+is2:is=`2`:then=`[[+is2]]`:else=`more`]]`]]",
                 [
@@ -507,23 +476,7 @@ return implode("|", array_map(function ($k) use ($scriptProperties) { return $k 
             ],
             [
                 [
-                    'processed' => 2,
-                    'content' => "2"
-                ],
-                "[[+is2:is=`1`:then=`[[+is2]]`:else=`[[+is2:is=`2`:then=`[[+is2]]`:else=`more`]]`]]",
-                [
-                    'parentTag' => '',
-                    'processUncacheable' => true,
-                    'removeUnprocessed' => false,
-                    'prefix' => '[[',
-                    'suffix' => ']]',
-                    'tokens' => [],
-                    'depth' => 2
-                ]
-            ],
-            [
-                [
-                    'processed' => 2,
+                    'processed' => 1,
                     'content' => "more"
                 ],
                 "[[+is3:is=`1`:then=`[[+is3]]`:else=`[[+is3:is=`2`:then=`[[+is3]]`:else=`more`]]`]]",
@@ -1261,6 +1214,73 @@ ddd
             ["name", "name:filter"],
             ["name", "name@propset:filter"],
             ["name", "name@propset:filter=`name@propset:filter`"],
+        ];
+    }
+
+    /**
+     * Shorter tags that appear inside longer collected tags must not clobber them on merge.
+     * This is the #13043 failure mode: `[[*id]]` replaced inside `[[$chunk-[[*id]]?…]]`.
+     */
+    public function testMergeTagOutputOverlappingNestedTags()
+    {
+        $longTag = '[[$chunk-[[*id]]? &x=`1`]]';
+        $content = '$chunk-[[*id]]? &nestedcontent=`' . $longTag . '`';
+        $tagMap = [
+            '[[*id]]' => '1',
+            $longTag => '<div>inner</div>',
+        ];
+
+        $this->modx->parser->mergeTagOutput($tagMap, $content);
+
+        $this->assertSame(
+            '$chunk-1? &nestedcontent=`<div>inner</div>`',
+            $content
+        );
+    }
+
+    /**
+     * Nested chunk calls whose names contain another tag, e.g. `[[$chunk-[[+id]]]]`.
+     *
+     * @dataProvider providerNestedChunkNameContainsTag
+     * @param int $levels
+     */
+    public function testNestedChunkNameContainsTag($levels)
+    {
+        $suffix = bin2hex(random_bytes(3));
+        $chunkName = 'n13043-' . $suffix;
+        $chunk = $this->modx->newObject(modChunk::class);
+        $chunk->set('name', $chunkName);
+        $chunk->set('snippet', '<div class="wrapper"><span>Level: [[+level:default=`not set`]]</span>[[+nestedcontent]]</div>');
+        $chunk->setCacheable(false);
+        $this->assertTrue($chunk->save());
+
+        $this->modx->setPlaceholder('n13043id', $suffix);
+
+        $inner = 'inner-13043';
+        for ($level = $levels; $level >= 1; $level--) {
+            $inner = '[[$n13043-[[+n13043id]]? &level=`' . $level . '` &nestedcontent=`' . $inner . '`]]';
+        }
+        $content = $inner;
+
+        try {
+            $this->modx->parser->processElementTags('', $content, true, false, '[[', ']]', [], 10);
+            $this->assertSame($levels, substr_count($content, '<div class="wrapper">'));
+            for ($level = 1; $level <= $levels; $level++) {
+                $this->assertStringContainsString('Level: ' . $level, $content);
+            }
+            $this->assertStringContainsString('inner-13043', $content);
+            $this->assertStringNotContainsString('[[$', $content);
+        } finally {
+            $chunk->remove();
+            $this->modx->unsetPlaceholder('n13043id');
+        }
+    }
+
+    public function providerNestedChunkNameContainsTag()
+    {
+        return [
+            'two levels' => [2],
+            'three levels' => [3],
         ];
     }
 

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -1281,6 +1281,69 @@ ddd
         }
     }
 
+    /**
+     * A cacheable element's output may contain uncacheable tags, deferred to a later
+     * iteration when parser_recurse_uncacheable is enabled (the default). Merge order
+     * must not rewrite those emitted tags with values captured before the element executed.
+     */
+    public function testMergedOutputKeepsDeferredUncacheableTags()
+    {
+        $name = 'sg16991xx' . bin2hex(random_bytes(4));
+        $snippet = $this->modx->newObject(modSnippet::class);
+        $snippet->set('name', $name);
+        $snippet->set(
+            'snippet',
+            '$modx->setPlaceholder(\'greeting16991\', \'AFTER\'); return \'tpl says [[!+greeting16991]]\';'
+        );
+        $this->assertTrue($snippet->save());
+        $this->modx->setPlaceholder('greeting16991', 'BEFORE');
+        /* cacheable snippet call; same signature as the uncached pass in modResource::process() */
+        $content = "Header shows [[!+greeting16991]] ... [[{$name}]]";
+        try {
+            $this->modx->parser->processElementTags('', $content, true, false, '[[', ']]', [], 10);
+            $this->assertStringContainsString('Header shows BEFORE', $content);
+            $this->assertStringContainsString('tpl says AFTER', $content);
+        } finally {
+            $snippet->remove();
+            $this->modx->unsetPlaceholder('greeting16991');
+        }
+    }
+
+    /**
+     * An uncacheable snippet called standalone and also emitted by a cacheable chunk
+     * must execute once per occurrence, not have the standalone output duplicated.
+     */
+    public function testMergedOutputKeepsDeferredUncacheableSnippetExecutions()
+    {
+        $suffix = bin2hex(random_bytes(4));
+        $snipName = 'uid16991' . $suffix;
+        $chunkName = 'wrap16991xx' . $suffix;
+        $snippet = $this->modx->newObject(modSnippet::class);
+        $snippet->set('name', $snipName);
+        $snippet->set(
+            'snippet',
+            '$n = (int) $modx->getPlaceholder(\'uidcount16991\') + 1;'
+            . '$modx->setPlaceholder(\'uidcount16991\', $n);'
+            . 'return \'UID\' . $n;'
+        );
+        $this->assertTrue($snippet->save());
+        $chunk = $this->modx->newObject(modChunk::class);
+        $chunk->set('name', $chunkName);
+        $chunk->set('snippet', "<div>[[!{$snipName}]]</div>");
+        $this->assertTrue($chunk->save());
+        $content = "[[!{$snipName}]] ... [[\${$chunkName}]]";
+        try {
+            $this->modx->parser->processElementTags('', $content, true, false, '[[', ']]', [], 10);
+            $this->assertStringContainsString('UID1', $content);
+            $this->assertStringContainsString('UID2', $content);
+            $this->assertSame(2, (int) $this->modx->getPlaceholder('uidcount16991'));
+        } finally {
+            $snippet->remove();
+            $chunk->remove();
+            $this->modx->unsetPlaceholder('uidcount16991');
+        }
+    }
+
     public function providerNestedChunkNameContainsTag()
     {
         return [

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -461,6 +461,34 @@ return implode("|", array_map(function ($k) use ($scriptProperties) { return $k 
             [
                 [
                     'processed' => 1,
+                    'content' => "
+                        2
+                    "
+                ],
+                "[[+is2
+                    :is=`1`
+                    :then=`[[+is2]]`
+                    :else=`
+                        [[+is2
+                            :is=`2`
+                            :then=`[[+is2]]`
+                            :else=`more`
+                        ]]
+                    `
+                ]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 2
+                ]
+            ],
+            [
+                [
+                    'processed' => 1,
                     'content' => "2"
                 ],
                 "[[+is2:is=`1`:then=`[[+is2]]`:else=`[[+is2:is=`2`:then=`[[+is2]]`:else=`more`]]`]]",
@@ -472,6 +500,22 @@ return implode("|", array_map(function ($k) use ($scriptProperties) { return $k 
                     'suffix' => ']]',
                     'tokens' => [],
                     'depth' => 0
+                ]
+            ],
+            [
+                [
+                    'processed' => 1,
+                    'content' => "2"
+                ],
+                "[[+is2:is=`1`:then=`[[+is2]]`:else=`[[+is2:is=`2`:then=`[[+is2]]`:else=`more`]]`]]",
+                [
+                    'parentTag' => '',
+                    'processUncacheable' => true,
+                    'removeUnprocessed' => false,
+                    'prefix' => '[[',
+                    'suffix' => ']]',
+                    'tokens' => [],
+                    'depth' => 2
                 ]
             ],
             [

--- a/_build/test/Tests/Model/modParserTest.php
+++ b/_build/test/Tests/Model/modParserTest.php
@@ -1250,7 +1250,12 @@ ddd
         $chunkName = 'n13043-' . $suffix;
         $chunk = $this->modx->newObject(modChunk::class);
         $chunk->set('name', $chunkName);
-        $chunk->set('snippet', '<div class="wrapper"><span>Level: [[+level:default=`not set`]]</span>[[+nestedcontent]]</div>');
+        $chunk->set(
+            'snippet',
+            '<div class="wrapper">'
+            . '<span>Level: [[+level:default=`not set`]]</span>'
+            . '[[+nestedcontent]]</div>'
+        );
         $chunk->setCacheable(false);
         $this->assertTrue($chunk->save());
 

--- a/core/src/Revolution/modParser.php
+++ b/core/src/Revolution/modParser.php
@@ -250,10 +250,7 @@ class modParser
      */
     public function mergeTagOutput(array $tagMap, & $content) {
         if (!empty ($content) && is_array($tagMap) && !empty ($tagMap)) {
-            uksort($tagMap, static function ($a, $b) {
-                return strlen($b) <=> strlen($a);
-            });
-            $content= str_replace(array_keys($tagMap), array_values($tagMap), $content);
+            $content= strtr($content, $tagMap);
         }
     }
 

--- a/core/src/Revolution/modParser.php
+++ b/core/src/Revolution/modParser.php
@@ -248,9 +248,10 @@ class modParser
      * @param string $content The content to merge the tag output with (passed by
      * reference).
      */
-    public function mergeTagOutput(array $tagMap, & $content) {
-        if (!empty ($content) && is_array($tagMap) && !empty ($tagMap)) {
-            $content= strtr($content, $tagMap);
+    public function mergeTagOutput(array $tagMap, &$content)
+    {
+        if (!empty($content) && is_array($tagMap) && !empty($tagMap)) {
+            $content = strtr($content, $tagMap);
         }
     }
 

--- a/core/src/Revolution/modParser.php
+++ b/core/src/Revolution/modParser.php
@@ -250,6 +250,9 @@ class modParser
      */
     public function mergeTagOutput(array $tagMap, & $content) {
         if (!empty ($content) && is_array($tagMap) && !empty ($tagMap)) {
+            uksort($tagMap, static function ($a, $b) {
+                return strlen($b) <=> strlen($a);
+            });
             $content= str_replace(array_keys($tagMap), array_values($tagMap), $content);
         }
     }


### PR DESCRIPTION
### What changed and why

The three-level repro from #13043 fails because parser merge used sequential `str_replace`: a shorter tag key (like `[[*id]]`) could rewrite text that still contained a longer collected key from the same pass.

`mergeTagOutput()` now uses `strtr($content, $tagMap)`.

This fixes the overlap bug because `strtr`:
- matches the longest key at each position
- does one-pass substitution and does not re-scan already inserted output

That behavior is exactly what the nested-chunk case needs.

### How to test

1. Create chunk `chunk-1` with the markup from #13043 (level placeholder + `[[+nestedcontent]]`).
2. On resource 1, paste the three-level `[[$chunk-[[*id]]]]` snippet from the issue.
3. View the resource. You should see three nested wrappers and the inner sentence.

Commands:

- `php -l core/src/Revolution/modParser.php` → exit 0
- `core/vendor/bin/phpunit --enforce-time-limit -c _build/test/phpunit.xml --filter modParserTest` → OK (91 tests, 138 assertions)

### Related issue(s)/PR(s)

Resolves #13043

Refs #13044 (merged then reverted; that approach changed depth behavior by passing `parser_max_iterations` through `processTag`).

### Compatibility notes

Core parser merge only. No DB/setup migration.

### Breaking change assessment

No public API signature changes.

Behavioral change: with `strtr`, replacement keys no longer re-apply inside output inserted earlier in the same merge pass. For unresolved nested tags at `depth=0`, this can defer some substitutions to the next parser iteration instead of resolving them inside one merge pass. Resource rendering remains aligned with default iterative parser flow.

### Test coverage

`_build/test/Tests/Model/modParserTest.php`

- `testMergeTagOutputOverlappingNestedTags` pins the overlap bug
- `testNestedChunkNameContainsTag` verifies two and three levels
- `testMergedOutputKeepsDeferredUncacheableTags`
- `testMergedOutputKeepsDeferredUncacheableSnippetExecutions`
- `providerProcessElementTags` keeps both `is2` `depth=2` rows (`processed=1`) plus existing `is3` depth coverage

### Contributors

@christianseel reported the repro and opened #13044. @opengeek validated edge cases and review scenarios.

### AI tool use

Cursor assisted with implementation and test drafting; validation/testing was run in the local repository.