### PR TITLE
Remove cache_format from the manager system settings UI

### DIFF
--- a/_build/data/transport.core.system_settings.php
+++ b/_build/data/transport.core.system_settings.php
@@ -227,15 +227,6 @@ $settings['cache_expires']->fromArray([
   'area' => 'caching',
   'editedon' => null,
 ], '', true, true);
-$settings['cache_format'] = $xpdo->newObject(modSystemSetting::class);
-$settings['cache_format']->fromArray([
-  'key' => 'cache_format',
-  'value' => 0,
-  'xtype' => 'numberfield',
-  'namespace' => 'core',
-  'area' => 'caching',
-  'editedon' => null,
-], '', true, true);
 $settings['cache_handler'] = $xpdo->newObject(modSystemSetting::class);
 $settings['cache_handler']->fromArray([
   'key' => 'cache_handler',

--- a/setup/includes/upgrades/common/3.3.0-remove-cache-format.php
+++ b/setup/includes/upgrades/common/3.3.0-remove-cache-format.php
@@ -1,0 +1,17 @@
+<?php
+
+/**
+ * Remove cache_format from system settings.
+ *
+ * Changing this setting in the manager crashes the site: system settings are
+ * loaded from cache, so a new format cannot read the old cache files. Override
+ * via $config_options['cache_format'] in core/config/config.inc.php instead
+ * (and clear the cache directory when changing it).
+ *
+ * @var modX $modx
+ * @package setup
+ */
+
+use MODX\Revolution\modSystemSetting;
+
+$modx->removeObject(modSystemSetting::class, ['key' => 'cache_format']);

--- a/setup/includes/upgrades/mysql/3.3.0-pl.php
+++ b/setup/includes/upgrades/mysql/3.3.0-pl.php
@@ -1,0 +1,12 @@
+<?php
+
+/**
+ * Specific upgrades for Revolution 3.3.0-pl
+ *
+ * @var modX $modx
+ * @package setup
+ * @subpackage upgrades
+ */
+
+/* run upgrades common to all db platforms */
+include dirname(__DIR__) . '/common/3.3.0-remove-cache-format.php';


### PR DESCRIPTION
### What changed and why

Changing `cache_format` in System Settings crashes the manager and the site. Settings are loaded from cache, so a new format cannot read files written in the old one. Maintainers agreed to remove the setting from the manager UI and document overrides via `$config_options` in `config.inc.php` instead (#15105).

This PR drops `cache_format` from the install transport (new sites) and removes the row on upgrade for existing installs, same pattern as `cache_disabled` (#14022). Runtime support through `xPDO::OPT_CACHE_FORMAT` / `$config_options` is unchanged.

### How to test

1. Fresh install from this branch: System Settings → Caching must not list `cache_format`.
2. Upgrade from 3.2.x: run setup upgrade, confirm the `cache_format` row is gone from `system_settings` and from the manager grid.
3. Optional override: set `$config_options['cache_format']` in `core/config/config.inc.php`, clear the cache directory, confirm the site still boots.

Gate E:
- `php -l setup/includes/upgrades/common/3.3.0-remove-cache-format.php` — exit 0
- `php -l setup/includes/upgrades/mysql/3.3.0-pl.php` — exit 0
- `php -l _build/data/transport.core.system_settings.php` — exit 0
- Local upgrade script run removed the DB row; `getOption(OPT_CACHE_FORMAT)` still resolved

### Related issue(s)/PR(s)

Resolves #15105

Refs #13832 (removed `cache_system_settings` from transport only)
Refs #14022 (`cache_disabled` transport + upgrade remove)

### Compatibility notes

Universal for 3.3.0. Sites that relied on editing `cache_format` in the manager must use `$config_options['cache_format']` in `config.inc.php` and clear the cache directory when changing the value.

### Breaking change assessment

No public method signature change. The setting disappears from the manager UI and from the `system_settings` table after upgrade. Config-file overrides keep working. Safe for 3.3.0; not a silent behavior change for sites that never touched the setting (default stayed 0 / PHP).

### Test coverage

No PHPUnit added. Setup upgrade scripts in this repo are not covered by the unit suite (same as `2.7-remove-cache-disabled.php`). Verification was manual Gate E above.

### Contributors

@sergant210 reported the crash and proposed removing the setting from the UI.
@opengeek confirmed config_options is the supported override path.
@Mark-H authored the earlier `cache_system_settings` removal (#13832).

### AI tool use

Cursor drafted the upgrade scripts and PR text. I ran the Gate E checks above before opening this.
