### PR TITLE
Fix Windows media source paths for Flysystem

### DIFF
--- a/_build/test/Tests/Model/Sources/modMediaSourceTest.php
+++ b/_build/test/Tests/Model/Sources/modMediaSourceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of the MODX Revolution package.
  *
@@ -11,10 +12,10 @@
 */
 namespace MODX\Revolution\Tests\Model\Sources;
 
-
 use MODX\Revolution\MODxTestCase;
 use MODX\Revolution\Sources\modFileMediaSource;
 use MODX\Revolution\Sources\modMediaSource;
+use ReflectionMethod;
 
 /**
  * Tests related to the modMediaSource class.
@@ -25,7 +26,8 @@ use MODX\Revolution\Sources\modMediaSource;
  * @group Sources
  * @group modMediaSource
  */
-class modMediaSourceTest extends MODxTestCase {
+class modMediaSourceTest extends MODxTestCase
+{
     /** @var modMediaSource $source */
     public $source;
 
@@ -34,28 +36,75 @@ class modMediaSourceTest extends MODxTestCase {
      *
      * @before
      */
-    public function setUpFixtures() {
+    public function setUpFixtures()
+    {
         parent::setUpFixtures();
 
-        $this->source = $this->modx->newObject(modMediaSource::class);
+        $this->source = $this->modx->newObject(modFileMediaSource::class);
         $this->source->fromArray([
             'name' => 'UnitTestSource',
             'description' => '',
             'class_key' => modFileMediaSource::class,
             'properties' => [],
-        ],'',true);
+        ], '', true);
     }
     /**
      * Tear down fixtures after each test.
      *
      * @after
      */
-    public function tearDownFixtures() {
+    public function tearDownFixtures()
+    {
         parent::tearDownFixtures();
         $this->source = null;
     }
 
-    public function testExample() {
-        $this->assertTrue(true);
+    /**
+     * Flysystem object paths must stay on forward slashes, even when the OS uses "\".
+     */
+    public function testSanitizePathUsesForwardSlash()
+    {
+        $this->assertSame('folder/sub', $this->source->sanitizePath('folder\\sub'));
+        $this->assertSame('folder/sub', $this->source->sanitizePath('folder//sub'));
+        $this->assertSame('folder/sub/', $this->source->postfixSlash('folder\\sub'));
+        $this->assertSame('/', $this->source->postfixSlash(''));
+    }
+
+    /**
+     * Renaming a nested path must keep the parent directory (#15438 Windows regression).
+     */
+    public function testGetRenamedPathKeepsParentWithMixedSeparators()
+    {
+        $method = new ReflectionMethod(modMediaSource::class, 'getRenamedPath');
+
+        $this->assertSame('parent/new-name', $method->invoke($this->source, 'parent/old-name', 'new-name'));
+        $this->assertSame('parent/new-name', $method->invoke($this->source, 'parent\\old-name', 'new-name'));
+        $this->assertSame('a/b/renamed', $method->invoke($this->source, 'a/b/c', 'renamed'));
+        $this->assertSame('renamed', $method->invoke($this->source, 'old-name', 'renamed'));
+    }
+
+    /**
+     * Root detection must treat "/" as root after postfixSlash (Windows DIRECTORY_SEPARATOR is "\").
+     */
+    public function testIsFilesystemRootPathAfterPostfix()
+    {
+        $method = new ReflectionMethod(modMediaSource::class, 'isFilesystemRootPath');
+
+        $this->assertTrue($method->invoke($this->source, '/'));
+        $this->assertTrue($method->invoke($this->source, '\\'));
+        $this->assertTrue($method->invoke($this->source, ''));
+        $this->assertFalse($method->invoke($this->source, 'assets/'));
+    }
+
+    /**
+     * Move/create path joins must use "/" so Windows hosts match Flysystem keys.
+     */
+    public function testJoinFilesystemPathsUsesForwardSlash()
+    {
+        $method = new ReflectionMethod(modMediaSource::class, 'joinFilesystemPaths');
+
+        $this->assertSame('folder/sub/file.txt', $method->invoke($this->source, 'folder/sub/', 'file.txt'));
+        $this->assertSame('folder/sub/file.txt', $method->invoke($this->source, 'folder\\sub\\', 'file.txt'));
+        $this->assertSame('file.txt', $method->invoke($this->source, '/', 'file.txt'));
     }
 }

--- a/core/src/Revolution/Sources/modMediaSource.php
+++ b/core/src/Revolution/Sources/modMediaSource.php
@@ -73,6 +73,58 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
     public const SOURCE_FILESYSTEM = 'Filesystem';
 
     /**
+     * Path separator for Flysystem virtual object paths.
+     * Flysystem normalizes paths to "/", including on Windows.
+     */
+    public const FILESYSTEM_SEPARATOR = '/';
+
+    /**
+     * Whether a Flysystem object path is the media source root.
+     *
+     * @param string $path
+     *
+     * @return bool
+     */
+    protected function isFilesystemRootPath($path)
+    {
+        $path = $this->sanitizePath((string)$path);
+
+        return $path === '' || $path === self::FILESYSTEM_SEPARATOR;
+    }
+
+    /**
+     * Trim Flysystem separators from both ends of an object path.
+     *
+     * @param string $path
+     *
+     * @return string
+     */
+    protected function trimFilesystemPath($path)
+    {
+        return trim($this->sanitizePath((string)$path), self::FILESYSTEM_SEPARATOR);
+    }
+
+    /**
+     * Join Flysystem object path segments with "/".
+     *
+     * @param string ...$segments
+     *
+     * @return string
+     */
+    protected function joinFilesystemPaths(...$segments)
+    {
+        $parts = [];
+        foreach ($segments as $segment) {
+            $segment = $this->trimFilesystemPath($segment);
+            if ($segment !== '') {
+                $parts[] = $segment;
+            }
+        }
+
+        return implode(self::FILESYSTEM_SEPARATOR, $parts);
+    }
+
+    /**
      * Get the default MODX filesystem source
      *
      * @static
@@ -289,11 +341,11 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             $bases['pathAbsolute'] = $bases['path'];
         }
 
-        $bases['pathAbsoluteWithPath'] = $bases['pathAbsolute'] . ltrim($path, DIRECTORY_SEPARATOR);
+        $bases['pathAbsoluteWithPath'] = $bases['pathAbsolute'] . ltrim($path, self::FILESYSTEM_SEPARATOR);
         if (is_dir($bases['pathAbsoluteWithPath'])) {
             $bases['pathAbsoluteWithPath'] = $this->postfixSlash($bases['pathAbsoluteWithPath']);
         }
-        $bases['pathRelative'] = ltrim($path, DIRECTORY_SEPARATOR);
+        $bases['pathRelative'] = ltrim($path, self::FILESYSTEM_SEPARATOR);
 
         // get relative url
         $bases['urlIsRelative'] = false;
@@ -305,8 +357,8 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             $bases['urlAbsolute'] = $bases['url'];
         }
 
-        $bases['urlAbsoluteWithPath'] = $bases['urlAbsolute'] . ltrim($path, DIRECTORY_SEPARATOR);
-        $bases['urlRelative'] = ltrim($path, DIRECTORY_SEPARATOR);
+        $bases['urlAbsoluteWithPath'] = $bases['urlAbsolute'] . ltrim($path, self::FILESYSTEM_SEPARATOR);
+        $bases['urlRelative'] = ltrim($path, self::FILESYSTEM_SEPARATOR);
 
         return $bases;
     }
@@ -351,7 +403,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
     {
         $properties = $this->getPropertyListWithDefaults();
         $path = $this->postfixSlash($path);
-        if ($path == DIRECTORY_SEPARATOR || $path == '\\') {
+        if ($this->isFilesystemRootPath($path)) {
             $path = '';
         }
 
@@ -402,7 +454,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                     $dirNames[] = strtoupper($file_name);
                     $visibility = $this->visibility_dirs ? $this->getVisibility($object['path']) : false;
                     $directories[$file_name] = [
-                        'id' => rawurlencode(rtrim($object['path'], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR),
+                        'id' => rawurlencode(rtrim($object['path'], self::FILESYSTEM_SEPARATOR) . self::FILESYSTEM_SEPARATOR),
                         'sid' => $this->get('id'),
                         'text' => $file_name,
                         'cls' => implode(' ', $cls),
@@ -470,7 +522,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
 
         $fullPath = $path;
         if (!empty($bases['pathAbsolute'])) {
-            $fullPath = $bases['pathAbsolute'] . ltrim($path, DIRECTORY_SEPARATOR);
+            $fullPath = $bases['pathAbsolute'] . ltrim($path, self::FILESYSTEM_SEPARATOR);
         }
 
         $imageExtensions = explode(',', $properties['imageExtensions']);
@@ -480,7 +532,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         $skipExtensions = $this->getSkipExtensionsArray($properties);
         $files = $fileNames = [];
 
-        if (!empty($path) && $path != DIRECTORY_SEPARATOR) {
+        if (!empty($path) && !$this->isFilesystemRootPath($path)) {
             try {
                 $mimeType = $this->filesystem->mimeType($path);
             } catch (FilesystemException | UnableToRetrieveMetadata $e) {
@@ -506,7 +558,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         foreach ($contents as $object) {
             if (
                 in_array($object['path'], $skipFiles) ||
-                in_array(trim($object['path'], DIRECTORY_SEPARATOR), $skipFiles) ||
+                in_array($this->trimFilesystemPath($object['path']), $skipFiles) ||
                 in_array($fullPath . $object['path'], $skipFiles)
             ) {
                 continue;
@@ -594,7 +646,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         );
         try {
             $fa = [
-                'name' => rtrim($path, DIRECTORY_SEPARATOR),
+                'name' => rtrim($path, self::FILESYSTEM_SEPARATOR),
                 'basename' => basename($path),
                 'path' => $path,
                 'size' => $this->filesystem->fileSize($path),
@@ -628,10 +680,10 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      */
     public function createContainer($name, $parentContainer)
     {
-        if ($parentContainer == DIRECTORY_SEPARATOR) {
+        if ($this->isFilesystemRootPath($parentContainer)) {
             $parentContainer = '';
         }
-        $path = $this->sanitizePath($parentContainer . DIRECTORY_SEPARATOR . ltrim($name, DIRECTORY_SEPARATOR));
+        $path = $this->joinFilesystemPaths($parentContainer, $name);
 
         // Ensure directory doesn't already exist.
         try {
@@ -691,12 +743,12 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      */
     public function createObject($path, $name, $content)
     {
-        if ($path == DIRECTORY_SEPARATOR) {
+        if ($this->isFilesystemRootPath($path)) {
             $path = '';
         }
         $path = !empty($path)
-            ? $this->sanitizePath($path . DIRECTORY_SEPARATOR . ltrim($name, DIRECTORY_SEPARATOR))
-            : $name;
+            ? $this->joinFilesystemPaths($path, $name)
+            : $this->trimFilesystemPath($name);
 
         if (!$this->checkFileType($path)) {
             return false;
@@ -756,7 +808,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
     {
         $path = $this->postfixSlash($from);
         $to = $this->postfixSlash($to);
-        $newPath = rtrim($to, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . basename($from);
+        $newPath = $this->joinFilesystemPaths($to, basename($this->sanitizePath($from)));
 
         // Ensure object can be read.
         try {
@@ -800,8 +852,8 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
                     'destination' => $destination,
                 ]);
                 $mountManager->move(
-                    'org://' . ltrim($path, DIRECTORY_SEPARATOR),
-                    'destination://' . ltrim($newPath, DIRECTORY_SEPARATOR)
+                    'org://' . ltrim($path, self::FILESYSTEM_SEPARATOR),
+                    'destination://' . ltrim($newPath, self::FILESYSTEM_SEPARATOR)
                 );
             } catch (FilesystemException | UnableToMoveFile $e) {
                 $this->addError('source', $e->getMessage());
@@ -922,6 +974,28 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
 
 
     /**
+     * Build a renamed object path while keeping the parent directory.
+     * Always uses "/" so Windows hosts match Flysystem path keys.
+     *
+     * @param string $oldPath Current object path from Flysystem
+     * @param string $newName New basename (file or folder name)
+     *
+     * @return string
+     */
+    protected function getRenamedPath($oldPath, $newName)
+    {
+        $oldPath = $this->trimFilesystemPath($oldPath);
+        $newName = $this->trimFilesystemPath($newName);
+        $parent = dirname($oldPath);
+        if ($parent === '.' || $parent === self::FILESYSTEM_SEPARATOR) {
+            return $newName;
+        }
+
+        return $this->joinFilesystemPaths($parent, $newName);
+    }
+
+
+    /**
      * @param string $oldPath
      * @param string $newName
      *
@@ -929,16 +1003,9 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      */
     public function renameContainer($oldPath, $newName)
     {
-        $oldPath = trim($oldPath, DIRECTORY_SEPARATOR);
-        if (strpos($oldPath, DIRECTORY_SEPARATOR)) {
-            $path = explode(DIRECTORY_SEPARATOR, $oldPath);
-            array_pop($path);
-            $newPath = implode(DIRECTORY_SEPARATOR, $path) . DIRECTORY_SEPARATOR . $newName;
-        } else {
-            $newPath = $newName;
-        }
-        $oldPath = $this->sanitizePath($oldPath) . DIRECTORY_SEPARATOR;
-        $newPath = $this->sanitizePath($newPath) . DIRECTORY_SEPARATOR;
+        $newPath = $this->getRenamedPath($oldPath, $newName);
+        $oldPath = $this->sanitizePath($oldPath) . self::FILESYSTEM_SEPARATOR;
+        $newPath = $this->sanitizePath($newPath) . self::FILESYSTEM_SEPARATOR;
 
         // Ensure current directory can be read.
         try {
@@ -994,14 +1061,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      */
     public function renameObject($oldPath, $newName)
     {
-        $oldPath = trim($oldPath, DIRECTORY_SEPARATOR);
-        if (strpos($oldPath, DIRECTORY_SEPARATOR)) {
-            $path = explode(DIRECTORY_SEPARATOR, $oldPath);
-            array_pop($path);
-            $newPath = implode(DIRECTORY_SEPARATOR, $path) . DIRECTORY_SEPARATOR . $newName;
-        } else {
-            $newPath = $newName;
-        }
+        $newPath = $this->getRenamedPath($oldPath, $newName);
         $oldPath = $this->sanitizePath($oldPath);
         $newPath = $this->sanitizePath($newPath);
 
@@ -1113,7 +1173,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         $properties = $this->getPropertyList();
         $visibility = $this->xpdo->getOption('visibility', $properties, Visibility::PUBLIC);
 
-        if ($container != DIRECTORY_SEPARATOR) {
+        if (!$this->isFilesystemRootPath($container)) {
             try {
                 $this->filesystem->fileExists($container);
             } catch (FilesystemException | UnableToRetrieveMetadata $e) {
@@ -1343,7 +1403,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
         $properties = $this->getPropertyList();
 
         return !empty($properties['baseUrl'])
-            ? rtrim($properties['baseUrl'], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR . $object
+            ? rtrim($properties['baseUrl'], self::FILESYSTEM_SEPARATOR) . self::FILESYSTEM_SEPARATOR . ltrim($object, self::FILESYSTEM_SEPARATOR)
             : false;
     }
 
@@ -1593,7 +1653,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
 
         $properties = $this->getPropertyList();
         if (isset($properties['url'])) {
-            $src = $properties['url'] . DIRECTORY_SEPARATOR . ltrim($src, DIRECTORY_SEPARATOR);
+            $src = $properties['url'] . self::FILESYSTEM_SEPARATOR . ltrim($src, self::FILESYSTEM_SEPARATOR);
         }
 
         // don't strip stuff for absolute URLs
@@ -1788,7 +1848,11 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      */
     public function sanitizePath($path)
     {
-        return preg_replace(["/\.*[\/|\\\]/i", "/[\/|\\\]+/i"], [DIRECTORY_SEPARATOR, DIRECTORY_SEPARATOR], $path);
+        return preg_replace(
+            ['#\.*[/\\\\]#i', '#[/\\\\]+#'],
+            [self::FILESYSTEM_SEPARATOR, self::FILESYSTEM_SEPARATOR],
+            (string)$path
+        );
     }
 
 
@@ -1801,9 +1865,9 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
      */
     public function postfixSlash($path)
     {
-        $len = strlen($path);
-        if (substr($path, $len - 1, $len) != DIRECTORY_SEPARATOR) {
-            $path .= DIRECTORY_SEPARATOR;
+        $path = str_replace('\\', self::FILESYSTEM_SEPARATOR, (string)$path);
+        if (!str_ends_with($path, self::FILESYSTEM_SEPARATOR)) {
+            $path .= self::FILESYSTEM_SEPARATOR;
         }
 
         return $path;
@@ -1875,7 +1939,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
 
         $fullPath = $path;
         if (!empty($bases['pathAbsolute'])) {
-            $fullPath = $bases['pathAbsolute'] . ltrim($path, DIRECTORY_SEPARATOR);
+            $fullPath = $bases['pathAbsolute'] . ltrim($path, self::FILESYSTEM_SEPARATOR);
         }
 
         if (!empty($properties['currentFile']) && rawurldecode($properties['currentFile']) == $fullPath . $path && $properties['currentAction'] == $editAction) {
@@ -1913,7 +1977,7 @@ abstract class modMediaSource extends modAccessibleSimpleObject implements modMe
             'directory' => $bases['path'],
             'url' => $bases['url'] . $path,
             'urlExternal' => $this->getObjectUrl($path),
-            'urlAbsolute' => $bases['urlAbsoluteWithPath'] . ltrim($file_name, DIRECTORY_SEPARATOR),
+            'urlAbsolute' => $bases['urlAbsoluteWithPath'] . ltrim($file_name, self::FILESYSTEM_SEPARATOR),
             'file' => rawurlencode($fullPath . $path),
         ];
         if ($this->visibility_files && $visibility) {
@@ -2015,8 +2079,8 @@ QTIP;
             'thumb_height' => $thumb_image_info['height'],
 
             'url' => $path,
-            'relativeUrl' => ltrim($path, DIRECTORY_SEPARATOR),
-            'fullRelativeUrl' => rtrim($bases['url']) . ltrim($path, DIRECTORY_SEPARATOR),
+            'relativeUrl' => ltrim($path, self::FILESYSTEM_SEPARATOR),
+            'fullRelativeUrl' => rtrim($bases['url']) . ltrim($path, self::FILESYSTEM_SEPARATOR),
             'ext' => $ext,
             'pathname' => $path,
             'pathRelative' => rawurlencode($path),
@@ -2284,7 +2348,7 @@ QTIP;
         $size = $this->getImageDimensions($path, $ext);
         if (is_array($size) && $size['width'] > 0 && $size['height'] > 0) {
             if ($ext == 'svg') {
-                $size['src'] = $bases['urlAbsolute'] . ltrim($path, DIRECTORY_SEPARATOR);
+                $size['src'] = $bases['urlAbsolute'] . ltrim($path, self::FILESYSTEM_SEPARATOR);
 
                 return $size;
             }

--- a/core/src/Revolution/Sources/modS3MediaSource.php
+++ b/core/src/Revolution/Sources/modS3MediaSource.php
@@ -336,7 +336,7 @@ class modS3MediaSource extends modMediaSource
     {
         $properties = $this->getPropertyListWithDefaults();
         $path = $this->postfixSlash($path);
-        if ($path === DIRECTORY_SEPARATOR || $path === '\\') {
+        if ($this->isFilesystemRootPath($path)) {
             $path = '';
         }
 
@@ -371,9 +371,9 @@ class modS3MediaSource extends modMediaSource
         }
 
         $re = '#^(.*?/|)(' . implode('|', array_map('preg_quote', $skipFiles)) . ')/?$#';
-        $pathid = rawurlencode(rtrim($path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);
+        $pathid = rawurlencode(rtrim($path, self::FILESYSTEM_SEPARATOR) . self::FILESYSTEM_SEPARATOR);
         foreach ($contents as $object) {
-            $id = rawurlencode(rtrim($object['path'], DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR);
+            $id = rawurlencode(rtrim($object['path'], self::FILESYSTEM_SEPARATOR) . self::FILESYSTEM_SEPARATOR);
             if ($id === $pathid || preg_match($re, $object['path'])) {
                 continue;
             }
@@ -457,7 +457,7 @@ class modS3MediaSource extends modMediaSource
 
         $fullPath = $path;
         if (!empty($bases['pathAbsolute'])) {
-            $fullPath = $bases['pathAbsolute'] . ltrim($path, DIRECTORY_SEPARATOR);
+            $fullPath = $bases['pathAbsolute'] . ltrim($path, self::FILESYSTEM_SEPARATOR);
         }
 
         $imageExtensions = explode(',', $properties['imageExtensions']);
@@ -467,7 +467,7 @@ class modS3MediaSource extends modMediaSource
 
         $files = $fileNames = [];
 
-        if (!empty($path) && $path !== DIRECTORY_SEPARATOR) {
+        if (!empty($path) && !$this->isFilesystemRootPath($path)) {
             try {
                 $mimeType = $this->filesystem->mimeType($path);
             } catch (FilesystemException | UnableToRetrieveMetadata $e) {
@@ -493,7 +493,7 @@ class modS3MediaSource extends modMediaSource
             if (
                 (in_array($fullPath . $object['path'], $skipFiles, true)) ||
                 in_array($object['path'], $skipFiles, true) ||
-                in_array(trim($object['path'], DIRECTORY_SEPARATOR), $skipFiles, true)
+                in_array($this->trimFilesystemPath($object['path']), $skipFiles, true)
             ) {
                 continue;
             }
@@ -582,16 +582,9 @@ class modS3MediaSource extends modMediaSource
      */
     public function renameContainer($oldPath, $newName)
     {
-        $oldPath = trim($oldPath, DIRECTORY_SEPARATOR);
-        if (strpos($oldPath, DIRECTORY_SEPARATOR)) {
-            $path = explode(DIRECTORY_SEPARATOR, $oldPath);
-            array_pop($path);
-            $newPath = implode(DIRECTORY_SEPARATOR, $path) . DIRECTORY_SEPARATOR . $newName;
-        } else {
-            $newPath = $newName;
-        }
-        $oldPath = $this->sanitizePath($oldPath) . DIRECTORY_SEPARATOR;
-        $newPath = $this->sanitizePath($newPath) . DIRECTORY_SEPARATOR;
+        $newPath = $this->getRenamedPath($oldPath, $newName);
+        $oldPath = $this->sanitizePath($oldPath) . self::FILESYSTEM_SEPARATOR;
+        $newPath = $this->sanitizePath($newPath) . self::FILESYSTEM_SEPARATOR;
 
         // Ensure current directory can be read.
         try {
@@ -771,8 +764,8 @@ class modS3MediaSource extends modMediaSource
             'thumb_height' => $thumb_height,
 
             'url' => $path,
-            'relativeUrl' => ltrim($path, DIRECTORY_SEPARATOR),
-            'fullRelativeUrl' => rtrim($bases['url']) . ltrim($path, DIRECTORY_SEPARATOR),
+            'relativeUrl' => ltrim($path, self::FILESYSTEM_SEPARATOR),
+            'fullRelativeUrl' => rtrim($bases['url']) . ltrim($path, self::FILESYSTEM_SEPARATOR),
             'ext' => $ext,
             'pathname' => $path,
             'pathRelative' => rawurlencode($path),


### PR DESCRIPTION
### What changed and why

On Windows, Flysystem object keys use `/`, while media source code joined and split paths with `DIRECTORY_SEPARATOR` (`\`). Nested rename dropped the parent directory and moved the object to the wrong place (often under the site core path). `#15440` only cleared PHP “passed by reference” notices; path creation stayed broken (confirmed in issue comments).

This change treats Flysystem object paths as always `/`: `sanitizePath` / `postfixSlash`, helpers for root / join / rename, and the same join logic for create, move, list ids, and S3.

### How to test

1. On Windows (or with backslash-style inputs): create a nested folder under a media source, rename it, confirm it stays under the same parent.
2. Rename a nested file the same way.
3. Create a folder/file under a nested path and move an object between folders.
4. Gate E:
   - `php -l core/src/Revolution/Sources/modMediaSource.php` → exit 0
   - `php -l core/src/Revolution/Sources/modS3MediaSource.php` → exit 0
   - `composer run-script phpunit -- --filter modMediaSourceTest` → OK (4 tests, 15 assertions)

### Related issue(s)/PR(s)

Resolves #15438

### Compatibility notes

Affects local and S3 media sources on all platforms. Behavior on Unix stays the same (`/` already matched `DIRECTORY_SEPARATOR`). Windows file manager path joins should now match Flysystem keys. Local OS path handling in `prepareSrcForThumb` still uses `DIRECTORY_SEPARATOR` for phpThumb/file_exists checks.

### Breaking change assessment

No public method signatures changed. Path strings returned from media source APIs may normalize separators to `/` more consistently (Flysystem-compatible). Safe for patch consumers that already treated Flysystem paths as `/`.

### Test coverage

`_build/test/Tests/Model/Sources/modMediaSourceTest.php`: sanitize/postfix with `\`, `getRenamedPath` parent retention, root detection after `postfixSlash('')` → `/`, `joinFilesystemPaths` for move/create-style joins.

### Contributors

Thanks @sergant210 for the report, @wax100 for the Windows/OpenServer reproduction, and @Mark-H for confirming `#15440` did not fix path creation.

### AI tool use

Cursor agent assisted implementation, tests, and review loops. Human review still required before merge.