### PR TITLE
fix(acl): resolve renamed Resource policy for parallel groups

### DIFF
--- a/_build/test/Tests/Model/Security/modAccessPolicyTest.php
+++ b/_build/test/Tests/Model/Security/modAccessPolicyTest.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+namespace MODX\Revolution\Tests\Model\Security;
+
+use MODX\Revolution\modAccessPolicy;
+use MODX\Revolution\modAccessPolicyTemplate;
+use MODX\Revolution\MODxTestCase;
+
+/**
+ * Tests related to modAccessPolicy core policy resolution.
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Model
+ * @group Access
+ * @group modAccessPolicy
+ */
+class modAccessPolicyTest extends MODxTestCase
+{
+    /**
+     * Renamed core Resource policy must still resolve for parallel resource groups (#13831).
+     */
+    public function testGetPolicyFindsRenamedResourcePolicy()
+    {
+        /** @var modAccessPolicy|null $policy */
+        $policy = $this->modx->getObject(modAccessPolicy::class, [
+            'name' => modAccessPolicy::POLICY_RESOURCE,
+        ]);
+        if (!$policy instanceof modAccessPolicy) {
+            $this->markTestSkipped('Core Resource access policy is not installed.');
+        }
+
+        $originalName = $policy->get('name');
+        $policyId = (int)$policy->get('id');
+        $renamed = $originalName . '_renamed_13831';
+
+        $policy->set('name', $renamed);
+        $this->assertTrue($policy->save(), 'Failed to rename Resource policy for the test.');
+
+        try {
+            $this->assertNull(
+                $this->modx->getObject(modAccessPolicy::class, ['name' => modAccessPolicy::POLICY_RESOURCE]),
+                'Direct name lookup must fail after rename.'
+            );
+
+            $resolved = modAccessPolicy::getPolicy($this->modx, modAccessPolicy::POLICY_RESOURCE);
+            $this->assertInstanceOf(modAccessPolicy::class, $resolved);
+            $this->assertSame($policyId, (int)$resolved->get('id'));
+            $this->assertSame($renamed, $resolved->get('name'));
+        } finally {
+            $policy->set('name', $originalName);
+            $policy->save();
+        }
+    }
+
+    /**
+     * Unchanged core policy name still resolves via getPolicy().
+     */
+    public function testGetPolicyFindsResourcePolicyByName()
+    {
+        $resolved = modAccessPolicy::getPolicy($this->modx, modAccessPolicy::POLICY_RESOURCE);
+        if (!$resolved instanceof modAccessPolicy) {
+            $this->markTestSkipped('Core Resource access policy is not installed.');
+        }
+
+        $this->assertSame(modAccessPolicy::POLICY_RESOURCE, $resolved->get('name'));
+    }
+
+    /**
+     * Ambiguous ResourceTemplate (renamed core + duplicate) must fail closed.
+     */
+    public function testGetPolicyFailsClosedWhenMultiplePoliciesShareTemplate()
+    {
+        /** @var modAccessPolicy|null $policy */
+        $policy = $this->modx->getObject(modAccessPolicy::class, [
+            'name' => modAccessPolicy::POLICY_RESOURCE,
+        ]);
+        if (!$policy instanceof modAccessPolicy) {
+            $this->markTestSkipped('Core Resource access policy is not installed.');
+        }
+
+        $originalName = $policy->get('name');
+        $templateId = (int)$policy->get('template');
+        $duplicate = null;
+
+        $policy->set('name', $originalName . '_renamed_13831_ambiguous');
+        $this->assertTrue($policy->save());
+
+        try {
+            $duplicate = $this->modx->newObject(modAccessPolicy::class);
+            $duplicate->fromArray([
+                'name' => 'Resource Duplicate 13831',
+                'description' => 'Temporary duplicate for #13831 ambiguity test',
+                'parent' => 0,
+                'template' => $templateId,
+                'class' => '',
+                'data' => $policy->get('data'),
+                'lexicon' => $policy->get('lexicon'),
+            ]);
+            $this->assertTrue($duplicate->save());
+
+            $this->assertNull(
+                modAccessPolicy::getPolicy($this->modx, modAccessPolicy::POLICY_RESOURCE),
+                'Multiple policies on ResourceTemplate must not silently pick one.'
+            );
+        } finally {
+            if ($duplicate instanceof modAccessPolicy && !$duplicate->isNew()) {
+                $duplicate->remove();
+            }
+            $policy->set('name', $originalName);
+            $policy->save();
+        }
+    }
+}

--- a/core/src/Revolution/Processors/Security/Group/Create.php
+++ b/core/src/Revolution/Processors/Security/Group/Create.php
@@ -203,7 +203,7 @@ class Create extends CreateProcessor
     public function addContextAccessViaWizard(array $contexts)
     {
         /** @var modAccessPolicy $policy */
-        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Context']);
+        $policy = modAccessPolicy::getPolicy($this->modx, modAccessPolicy::POLICY_CONTEXT);
         if (!$policy) {
             return false;
         }
@@ -234,7 +234,7 @@ class Create extends CreateProcessor
         $resourceGroupNames = array_unique($resourceGroupNames);
 
         /** @var modAccessPolicy $policy */
-        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Resource']);
+        $policy = modAccessPolicy::getPolicy($this->modx, modAccessPolicy::POLICY_RESOURCE);
         if (!$policy) {
             return false;
         }
@@ -283,7 +283,7 @@ class Create extends CreateProcessor
         }
 
         /** @var modAccessPolicy $policy */
-        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Resource']);
+        $policy = modAccessPolicy::getPolicy($this->modx, modAccessPolicy::POLICY_RESOURCE);
         if (!$policy) {
             return false;
         }
@@ -315,7 +315,7 @@ class Create extends CreateProcessor
         $categoryNames = array_unique($categoryNames);
 
         /** @var modAccessPolicy $policy */
-        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Element']);
+        $policy = modAccessPolicy::getPolicy($this->modx, modAccessPolicy::POLICY_ELEMENT);
         if (!$policy) {
             return false;
         }

--- a/core/src/Revolution/Processors/Security/ResourceGroup/Create.php
+++ b/core/src/Revolution/Processors/Security/ResourceGroup/Create.php
@@ -120,7 +120,7 @@ class Create extends CreateProcessor
         }
 
         /** @var modAccessPolicy $policy */
-        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Resource']);
+        $policy = modAccessPolicy::getPolicy($this->modx, modAccessPolicy::POLICY_RESOURCE);
         if (!$policy) {
             return false;
         }
@@ -150,7 +150,7 @@ class Create extends CreateProcessor
     protected function addAnonymousAccess(array $contexts = [])
     {
         /** @var modAccessPolicy $policy */
-        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Load, List and View']);
+        $policy = modAccessPolicy::getPolicy($this->modx, modAccessPolicy::POLICY_LOAD_LIST_VIEW);
         if (!$policy) {
             return false;
         }
@@ -191,7 +191,7 @@ class Create extends CreateProcessor
         }
 
         /** @var modAccessPolicy $policy */
-        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Resource']);
+        $policy = modAccessPolicy::getPolicy($this->modx, modAccessPolicy::POLICY_RESOURCE);
         if (!$policy) {
             return false;
         }
@@ -224,7 +224,7 @@ class Create extends CreateProcessor
         $userGroupNames = array_unique($userGroupNames);
 
         /** @var modAccessPolicy $policy */
-        $policy = $this->modx->getObject(modAccessPolicy::class, ['name' => 'Resource']);
+        $policy = modAccessPolicy::getPolicy($this->modx, modAccessPolicy::POLICY_RESOURCE);
         if (!$policy) {
             return false;
         }

--- a/core/src/Revolution/modAccessPolicy.php
+++ b/core/src/Revolution/modAccessPolicy.php
@@ -72,6 +72,58 @@ class modAccessPolicy extends xPDOSimpleObject
     }
 
     /**
+     * Core policies that map 1:1 to a core template (rename fallback only when unique).
+     *
+     * @return array<string, string> policy name => template name
+     */
+    private static function getUniqueCorePolicyTemplates(): array
+    {
+        return [
+            self::POLICY_RESOURCE => modAccessPolicyTemplate::TEMPLATE_RESOURCE,
+            self::POLICY_ELEMENT => modAccessPolicyTemplate::TEMPLATE_ELEMENT,
+            self::POLICY_CONTEXT => modAccessPolicyTemplate::TEMPLATE_CONTEXT,
+            self::POLICY_HIDDEN_NAMESPACE => modAccessPolicyTemplate::TEMPLATE_NAMESPACE,
+        ];
+    }
+
+    /**
+     * Resolve a uniquely-templated core Access Policy by its shipped name.
+     * If renamed and exactly one policy remains on that core template, return it.
+     * Ambiguous templates (multiple policies) fail closed with null.
+     *
+     * @param xPDO $xpdo
+     * @param string $name Core policy name (e.g. modAccessPolicy::POLICY_RESOURCE)
+     *
+     * @return static|null
+     */
+    public static function getPolicy(xPDO $xpdo, string $name): ?self
+    {
+        $policy = $xpdo->getObject(static::class, ['name' => $name]);
+        if ($policy) {
+            return $policy;
+        }
+
+        $templateName = static::getUniqueCorePolicyTemplates()[$name] ?? null;
+        if ($templateName === null) {
+            return null;
+        }
+
+        $template = $xpdo->getObject(modAccessPolicyTemplate::class, ['name' => $templateName]);
+        if (!$template) {
+            return null;
+        }
+
+        $policies = $xpdo->getCollection(static::class, [
+            'template' => $template->get('id'),
+        ]);
+        if (count($policies) !== 1) {
+            return null;
+        }
+
+        return reset($policies) ?: null;
+    }
+
+    /**
      * Get the permissions for this access policy, in array format.
      *
      * @return array An array of access permissions for this Policy.


### PR DESCRIPTION
### What changed and why

Renaming the core Access Policy `Resource` broke “create parallel resource group” on user group create: the wizard looked up the policy by the literal name `Resource`, returned null, and never wrote `modAccessResourceGroup` rows (#13831).

`modAccessPolicy::getPolicy()` resolves the shipped name first. If missing, and the policy maps 1:1 to a core template (`Resource` / `Element` / `Context` / `Hidden Namespace`) with exactly one policy on that template, it returns that policy. Multiple policies on the template fail closed (`null`).

User/resource group create wizards now call `getPolicy()` with `POLICY_*` constants.

Out of scope (per issue comments): making core policies read-only. Duplicate-and-customize remains the recommended workflow; this fix only unbreaks rename.

### How to test

1. Rename Access Policy `Resource` to another name.
2. Create a user group with “create parallel resource group” enabled for a context.
3. Confirm a resource group ACL appears under Permissions / User group access.
4. Gate E:
   - `php -l core/src/Revolution/modAccessPolicy.php` → exit 0
   - `composer run-script phpunit -- --filter modAccessPolicyTest` → OK (3 tests, 9 assertions)

### Related issue(s)/PR(s)

Resolves #13831

### Compatibility notes

Affects ACL wizards that previously hardcoded core policy names. Sites that never rename core policies behave as before. If the Resource policy was deleted and replaced with multiple custom policies on `ResourceTemplate`, parallel-group ACL creation still fails closed (same as a missing policy).

### Breaking change assessment

No public method signatures removed. Adds `modAccessPolicy::getPolicy()`. Safe for patch consumers.

### Test coverage

`_build/test/Tests/Model/Security/modAccessPolicyTest.php`: resolve by name, resolve after rename, fail closed when two policies share `ResourceTemplate`.

### Contributors

Thanks @intersel for the report and pinpointing `addParallelResourceGroup`, @wshawn for the duplicate-vs-rename guidance, and @alroniks for confirming 3.x.

### AI tool use

Cursor agent assisted implementation, tests, review loops, and PR prose. Human review still required before merge.