### PR TITLE
Publish exact-head compiled CSS and jsgrps from Compile Assets

### DIFF
--- a/.github/workflows/assets.yml
+++ b/.github/workflows/assets.yml
@@ -4,18 +4,60 @@ on:
     push:
         paths:
             - "_build/templates/**"
+            - "manager/assets/modext/**"
+            - "manager/assets/fileapi/FileAPI.js"
+            - ".github/workflows/assets.yml"
     pull_request:
         paths:
             - "_build/templates/**"
+            - "manager/assets/modext/**"
+            - "manager/assets/fileapi/FileAPI.js"
+            - ".github/workflows/assets.yml"
 
     workflow_dispatch:
+
+permissions:
+    contents: read
 
 jobs:
     compile-assets:
         runs-on: ubuntu-latest
         steps:
-            -   name: Checkout
+            -   name: Resolve revision metadata
+                id: meta
+                env:
+                    EVENT_NAME: ${{ github.event_name }}
+                    PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+                    PR_BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                    PUSH_SHA: ${{ github.sha }}
+                    PUSH_BEFORE: ${{ github.event.before }}
+                    PR_NUMBER: ${{ github.event.pull_request.number }}
+                shell: bash
+                run: |
+                    set -euo pipefail
+                    if [[ "${EVENT_NAME}" == "pull_request" ]]; then
+                      HEAD_SHA="${PR_HEAD_SHA}"
+                      BASE_SHA="${PR_BASE_SHA}"
+                    else
+                      HEAD_SHA="${PUSH_SHA}"
+                      BASE_SHA="${PUSH_BEFORE}"
+                    fi
+                    if [[ -z "${HEAD_SHA}" ]]; then
+                      echo "HEAD_SHA is empty" >&2
+                      exit 1
+                    fi
+                    {
+                      echo "head_sha=${HEAD_SHA}"
+                      echo "base_sha=${BASE_SHA}"
+                      echo "pr_number=${PR_NUMBER}"
+                      echo "artifact_name=compiled-assets-${HEAD_SHA:0:12}"
+                    } >> "$GITHUB_OUTPUT"
+
+            -   name: Checkout exact head
                 uses: actions/checkout@v4
+                with:
+                    ref: ${{ steps.meta.outputs.head_sha }}
+                    persist-credentials: false
 
             -   name: Install Node.js
                 uses: actions/setup-node@v4
@@ -29,3 +71,115 @@ jobs:
 
             -   name: Build assets
                 run: cd _build/templates/default && npm run build
+
+            -   name: Write compiled assets manifest
+                env:
+                    GITHUB_REPOSITORY: ${{ github.repository }}
+                    GITHUB_RUN_ID: ${{ github.run_id }}
+                    GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+                    HEAD_SHA: ${{ steps.meta.outputs.head_sha }}
+                    BASE_SHA: ${{ steps.meta.outputs.base_sha }}
+                    PULL_REQUEST_NUMBER: ${{ steps.meta.outputs.pr_number }}
+                shell: bash
+                run: |
+                    set -euo pipefail
+                    python3 <<'PY'
+                    import hashlib
+                    import json
+                    import os
+                    from pathlib import Path
+
+                    outputs = [
+                        "manager/templates/default/css/index.css",
+                        "manager/templates/default/css/index-min.css",
+                        "manager/templates/default/css/login.css",
+                        "manager/templates/default/css/login-min.css",
+                        "setup/assets/css/installer.css",
+                        "setup/assets/css/installer-min.css",
+                        "manager/assets/modext/modx.jsgrps-min.js",
+                    ]
+                    # Ordered inputs for modx.jsgrps-min.js (coreJSFiles in gruntfile.js).
+                    jsgrps_inputs = [
+                        "manager/assets/modext/core/modx.localization.js",
+                        "manager/assets/modext/util/utilities.js",
+                        "manager/assets/modext/util/datetime.js",
+                        "manager/assets/modext/util/uploaddialog.js",
+                        "manager/assets/modext/util/fileupload.js",
+                        "manager/assets/modext/util/superboxselect.js",
+                        "manager/assets/modext/core/modx.component.js",
+                        "manager/assets/modext/core/modx.view.js",
+                        "manager/assets/modext/widgets/core/modx.button.js",
+                        "manager/assets/modext/widgets/core/modx.searchbar.js",
+                        "manager/assets/modext/widgets/core/modx.panel.js",
+                        "manager/assets/modext/widgets/core/modx.tabs.js",
+                        "manager/assets/modext/widgets/core/modx.window.js",
+                        "manager/assets/modext/widgets/core/modx.combo.js",
+                        "manager/assets/modext/widgets/core/modx.grid.js",
+                        "manager/assets/modext/widgets/core/modx.console.js",
+                        "manager/assets/modext/widgets/core/modx.portal.js",
+                        "manager/assets/modext/widgets/windows.js",
+                        "manager/assets/fileapi/FileAPI.js",
+                        "manager/assets/modext/util/multiuploaddialog.js",
+                        "manager/assets/modext/widgets/core/tree/modx.tree.js",
+                        "manager/assets/modext/widgets/core/tree/modx.tree.treeloader.js",
+                        "manager/assets/modext/widgets/modx.treedrop.js",
+                        "manager/assets/modext/widgets/core/modx.tree.asynctreenode.js",
+                        "manager/assets/modext/widgets/resource/modx.tree.resource.js",
+                        "manager/assets/modext/widgets/resource/modx.window.resource.js",
+                        "manager/assets/modext/widgets/element/modx.tree.element.js",
+                        "manager/assets/modext/widgets/system/modx.tree.directory.js",
+                        "manager/assets/modext/widgets/system/modx.panel.filetree.js",
+                        "manager/assets/modext/widgets/media/modx.browser.js",
+                        "manager/assets/modext/core/modx.layout.js",
+                    ]
+
+                    def entry(rel: str) -> dict:
+                        path = Path(rel)
+                        if not path.is_file():
+                            raise SystemExit(f"Missing required file: {rel}")
+                        data = path.read_bytes()
+                        return {
+                            "path": rel,
+                            "bytes": len(data),
+                            "sha256": hashlib.sha256(data).hexdigest(),
+                        }
+
+                    for name in ("GITHUB_REPOSITORY", "GITHUB_RUN_ID", "HEAD_SHA"):
+                        if not os.environ.get(name, "").strip():
+                            raise SystemExit(f"Missing required environment variable: {name}")
+
+                    pr = os.environ.get("PULL_REQUEST_NUMBER", "").strip()
+                    attempt = os.environ.get("GITHUB_RUN_ATTEMPT", "").strip()
+                    manifest = {
+                        "schema_version": 1,
+                        "repository": os.environ["GITHUB_REPOSITORY"],
+                        "pull_request": int(pr) if pr else None,
+                        "head_sha": os.environ["HEAD_SHA"],
+                        "base_sha": os.environ.get("BASE_SHA") or None,
+                        "run_id": os.environ["GITHUB_RUN_ID"],
+                        "run_attempt": int(attempt) if attempt else None,
+                        "outputs": [entry(path) for path in outputs],
+                        "jsgrps_inputs": [entry(path) for path in jsgrps_inputs],
+                    }
+                    Path("compiled-assets-manifest.json").write_text(
+                        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+                        encoding="utf-8",
+                    )
+                    print("wrote compiled-assets-manifest.json")
+                    PY
+
+            -   name: Upload compiled assets artifact
+                uses: actions/upload-artifact@v4
+                with:
+                    name: ${{ steps.meta.outputs.artifact_name }}
+                    path: |
+                        manager/templates/default/css/index.css
+                        manager/templates/default/css/index-min.css
+                        manager/templates/default/css/login.css
+                        manager/templates/default/css/login-min.css
+                        setup/assets/css/installer.css
+                        setup/assets/css/installer-min.css
+                        manager/assets/modext/modx.jsgrps-min.js
+                        compiled-assets-manifest.json
+                    if-no-files-found: error
+                    retention-days: 30


### PR DESCRIPTION
### What changed and why

Compile Assets already builds Manager CSS/JS on relevant PRs, but nothing was downloadable afterward. Reviewers had a green check and still needed a local Node/Grunt run to exercise `compress_js` Manager mode.

The workflow now:

- checks out the exact PR/push head SHA;
- builds as before;
- uploads an allowlisted set via standard `actions/upload-artifact@v4` (index/login/installer CSS + min counterparts, plus `manager/assets/modext/modx.jsgrps-min.js`);
- writes `compiled-assets-manifest.json` inline in the workflow step (schema version, repo, PR number, head/base SHAs, run id/attempt, output sizes/SHA-256, ordered jsgrps input map).

Triggers also cover mapped Manager JS under `manager/assets/modext/**` and `FileAPI.js`. `permissions: contents: read` and `persist-credentials: false` keep the untrusted build surface smaller.

**Not a custom maintained tool:** there is no `.github/scripts/*` helper to own long-term. That is intentional after [#16971](https://github.com/modxcms/revolution/pull/16971) (maintainers closed a custom PHPCS wrapper as something the project should not maintain). Here the only non-standard bit is a short inline Python block inside the workflow for the JSON manifest; upload stays on stock `actions/upload-artifact@v4` with an explicit path list.

### How to test

1. Open this PR (or any PR that touches `_build/templates/**` / mapped modext JS) and wait for **Compile Assets**.
2. On the run page, download artifact `compiled-assets-<head12>`.
3. Confirm it contains the six CSS files, `modx.jsgrps-min.js`, and `compiled-assets-manifest.json`.
4. Check the manifest `head_sha` matches the PR head and `outputs` / `jsgrps_inputs` hashes look sane.

### Related issue(s)/PR(s)

Resolves #16998.
Addresses the jsgrps ask in https://github.com/modxcms/revolution/issues/16998#issuecomment-5305193876.
Avoids the “custom script to maintain” rejection pattern from [#16971](https://github.com/modxcms/revolution/pull/16971#issuecomment-4990352034) / [#16971](https://github.com/modxcms/revolution/pull/16971#issuecomment-4994424403).

### Compatibility notes

CI workflow only. No runtime or platform changes.

### Breaking change assessment

No public API or product behavior changes. Safe for a patch release.

### Test coverage

No product unit tests. Verification is the workflow run + downloaded artifact contents.

### Contributors

Issue #16998; jsgrps follow-up from @opengeek.

### AI tool use

AI helped draft the workflow and PR text. Reviewers should treat the workflow YAML as the source of truth.