### PR TITLE
fix(packages): show Package Up to Date instead of Error modal

### DIFF
--- a/_build/test/Tests/Processors/Workspace/Packages/CheckForUpdatesTest.php
+++ b/_build/test/Tests/Processors/Workspace/Packages/CheckForUpdatesTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+namespace MODX\Revolution\Tests\Processors\Workspace\Packages;
+
+use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Processors\Workspace\Packages\CheckForUpdates;
+use MODX\Revolution\Transport\modTransportPackage;
+
+/**
+ * Tests related to Workspace/Packages/CheckForUpdates.
+ *
+ * @package modx-test
+ * @subpackage modx
+ * @group Processors
+ * @group Workspace
+ * @group Packages
+ * @group CheckForUpdates
+ */
+class CheckForUpdatesTest extends MODxTestCase
+{
+    private const SIGNATURE = 'unittestpackage-1.0.0-pl';
+
+    /**
+     * @before
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+        $this->modx->lexicon->load('workspace');
+        $this->removeTestPackage();
+
+        /** @var modTransportPackage $package */
+        $package = $this->modx->newObject(modTransportPackage::class);
+        $package->fromArray([
+            'signature' => self::SIGNATURE,
+            'package_name' => 'unittestpackage',
+            'provider' => 0,
+            'workspace' => 1,
+            'state' => 1,
+        ], '', true, true);
+        $package->save();
+    }
+
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
+    {
+        $this->removeTestPackage();
+        $this->modx->error->reset();
+        parent::tearDownFixtures();
+    }
+
+    private function removeTestPackage(): void
+    {
+        $package = $this->modx->getObject(modTransportPackage::class, self::SIGNATURE);
+        if ($package) {
+            $package->remove();
+        }
+    }
+
+    public function testMissingPackageFails(): void
+    {
+        $result = $this->modx->runProcessor(CheckForUpdates::class, [
+            'signature' => 'missing-package-1.0.0-pl',
+        ]);
+        $this->assertFalse($this->checkForSuccess($result));
+        $this->assertSame(
+            $this->modx->lexicon('package_err_nf'),
+            $result->getMessage()
+        );
+    }
+
+    public function testPackageWithoutProviderIsUpToDateSuccess(): void
+    {
+        $result = $this->modx->runProcessor(CheckForUpdates::class, [
+            'signature' => self::SIGNATURE,
+        ]);
+        $this->assertTrue($this->checkForSuccess($result));
+        $this->assertSame(
+            $this->modx->lexicon('package_err_uptodate', ['signature' => self::SIGNATURE]),
+            $result->getMessage()
+        );
+        $this->assertSame([], $result->getObject());
+    }
+
+    public function testProviderWithNoUpdatesIsUpToDateSuccess(): void
+    {
+        $processor = new CheckForUpdates($this->modx, [
+            'signature' => self::SIGNATURE,
+        ]);
+        $this->assertTrue($processor->initialize());
+
+        $processor->provider = new class {
+            public function latest(string $identifier, string $constraint = '*', array $args = []): array
+            {
+                return [];
+            }
+
+            public function get($key)
+            {
+                return $key === 'name' ? 'UnitTestProvider' : null;
+            }
+        };
+
+        $response = $processor->process();
+        $this->assertIsArray($response);
+        $this->assertTrue($response['success']);
+        $this->assertSame(
+            $this->modx->lexicon('package_err_uptodate', ['signature' => self::SIGNATURE]),
+            $response['message']
+        );
+        $this->assertSame([], $response['object']);
+    }
+}

--- a/_build/test/phpunit.xml
+++ b/_build/test/phpunit.xml
@@ -46,6 +46,7 @@
             <directory>Tests/Processors/Context</directory>
             <directory>Tests/Processors/Element</directory>
             <directory>Tests/Processors/Resource</directory>
+            <directory>Tests/Processors/Workspace</directory>
         </testsuite>
         <testsuite name="Transport">
             <directory>Tests/Transport</directory>

--- a/core/lexicon/en/workspace.inc.php
+++ b/core/lexicon/en/workspace.inc.php
@@ -93,6 +93,7 @@ $_lang['package_err_transfer'] = 'Could not transfer package [[+sourceFile]] to 
 $_lang['package_err_transfer_fopen'] = 'Could not transfer package [[+sourceFile]] to [[+packageDir]]; allow_url_fopen is not enabled on your configuration.';
 $_lang['package_err_uninstall'] = 'Error uninstalling package with signature: [[+signature]]';
 $_lang['package_err_uptodate'] = 'Your package is already up-to-date at: [[+signature]]';
+$_lang['package_uptodate'] = 'Package Up to Date';
 $_lang['package_information'] = 'Package Information';
 $_lang['package_install'] = 'Install Package';
 $_lang['package_install_info_start'] = 'Attempting to install package with signature: [[+signature]]';

--- a/core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
  * This file is part of MODX Revolution.
  *
@@ -26,8 +27,8 @@ class CheckForUpdates extends Processor
     /** @var modTransportPackage $package */
     public $package;
 
-    /** @var modTransportProvider $provider */
-    public $provider;
+    /** @var modTransportProvider|null $provider */
+    public $provider = null;
 
     /** @var string $packageSignature */
     public $packageSignature = '';
@@ -61,18 +62,13 @@ class CheckForUpdates extends Processor
             return $msg;
         }
         $this->package->parseSignature();
-        if ($this->package->provider !== 0) { /* if package has a provider */
+        if ((int)$this->package->get('provider') !== 0) {
             $this->provider = $this->package->getOne('Provider');
             if ($this->provider === null) {
                 $msg = $this->modx->lexicon('provider_err_nf');
                 $this->modx->log(modX::LOG_LEVEL_ERROR, $msg);
                 return $msg;
             }
-        } else {
-            /* if no provider, indicate it is up to date */
-            $msg = $this->modx->lexicon('package_err_uptodate', ['signature' => $this->package->get('signature')]);
-            $this->modx->log(modX::LOG_LEVEL_INFO, $msg);
-            return $msg;
         }
 
         return parent::initialize();
@@ -83,19 +79,25 @@ class CheckForUpdates extends Processor
      */
     public function process()
     {
-        $this->modx->log(modX::LOG_LEVEL_INFO,
-            $this->modx->lexicon('package_update_info_provider_scan', ['provider' => $this->provider->get('name')]));
-
-        $packages = $this->provider->latest($this->getProperty('signature'));
+        $packages = [];
+        if ($this->provider !== null) {
+            $this->modx->log(
+                modX::LOG_LEVEL_INFO,
+                $this->modx->lexicon('package_update_info_provider_scan', ['provider' => $this->provider->get('name')])
+            );
+            $packages = $this->provider->latest($this->getProperty('signature'));
+        }
         if (is_string($packages)) {
             return $this->failure($packages);
         }
 
-        /* if no newer packages were found */
-        if (count($packages) < 1) {
-            $msg = $this->modx->lexicon('package_err_uptodate', ['signature' => $this->package->get('signature')]);
+        if (count($packages) === 0) {
+            $msg = $this->modx->lexicon('package_err_uptodate', [
+                'signature' => $this->package->get('signature'),
+            ]);
             $this->modx->log(modX::LOG_LEVEL_INFO, $msg);
-            return $this->failure($msg);
+
+            return $this->success($msg, []);
         }
 
         $list = [];

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -399,10 +399,15 @@ Ext.extend(MODx.grid.Package, MODx.grid.Grid, {
             listeners: {
                 success: {
                     fn: function(response) {
+                        const packages = response.object;
+                        if (!Ext.isArray(packages) || packages.length === 0) {
+                            MODx.msg.alert(_('package_uptodate'), response.message);
+                            return;
+                        }
                         this.loadWindow(btn, e, {
                             xtype: 'modx-window-package-update',
                             cls: 'modx-alert',
-                            packages: response.object,
+                            packages: packages,
                             record: this.menu.record,
                             force: true,
                             listeners: {
@@ -419,12 +424,9 @@ Ext.extend(MODx.grid.Package, MODx.grid.Grid, {
                     },
                     scope: this
                 },
+                // Required so MODx.Ajax still runs errorJSON for real processor failures
                 failure: {
-                    fn: function(response) {
-                        MODx.msg.alert(_('package_update'), response.message);
-                        return false;
-                    },
-                    scope: this
+                    fn: Ext.emptyFn
                 }
             }
         });


### PR DESCRIPTION
### What changed and why

In Package Manager, Check for Updates on an Extra that already has the latest version opened a modal titled **Error**. `Workspace/Packages/CheckForUpdates` returned `failure()` for that case, and `MODx.Ajax` always follows a failure listener with `MODx.form.Handler.errorJSON`, which hard-codes the `_('error')` title.

I changed the processor so “already up to date” (no provider, or provider with an empty `latest()` list) returns `success` with the existing `package_err_uptodate` message and an empty object list. The packages grid treats that empty list as an info alert titled `Package Up to Date`. Real processor failures still use a minimal `failure` listener so `errorJSON` can show the Error dialog once.

### How to test

1. In the manager, open Extras → Installer.
2. On an installed Extra that has no newer version from its provider, choose Check for Updates.
3. You should see a dialog titled **Package Up to Date** with the up-to-date message, not **Error**.
4. Repeat on an Extra that does have an update: the update window should still open as before.
5. Optional: force a provider/package-not-found failure and confirm a single Error dialog still appears.

```
php -l core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
# exit 0

core/vendor/bin/phpcs --standard=phpcs.xml \
  core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php \
  _build/test/Tests/Processors/Workspace/Packages/CheckForUpdatesTest.php
# exit 0

core/vendor/bin/phpunit -c _build/test/phpunit.xml --filter CheckForUpdatesTest
# exit 0 (3 tests, 10 assertions)
```

### Related issue(s)/PR(s)

Resolves #14824

### Compatibility notes

Manager Package Management UI and the CheckForUpdates connector response. PHP 8.1+. English lexicon key `package_uptodate` added in-repo; other locales via Crowdin.

### Breaking change assessment

Connector clients that treated “already up to date” as `success: false` will now see `success: true`, `object: []`, and the up-to-date message. The manager grid is updated for that contract. Safe for a patch release for the manager path; note the response-shape change if any custom tooling called this processor directly.

### Test coverage

`_build/test/Tests/Processors/Workspace/Packages/CheckForUpdatesTest.php` — missing package fails; package with no provider succeeds as up to date; stub provider with empty `latest()` succeeds as up to date. Registered under the Processors suite in `_build/test/phpunit.xml`.

### Contributors

@sjmclean24 reported the original repro.

### AI tool use

Cursor (Composer) drafted the processor/JS change, focused PHPUnit cases, and this PR body. I checked the MODx.Ajax failure/`errorJSON` path against the #14824 repro and ran the Gate E commands above before opening the PR.