### PR TITLE
Fix DocumentDataManagerController not found for legacy class_key

### DIFF
--- a/_build/test/Tests/Controllers/Resources/ResourceManagerControllerGetInstanceTest.php
+++ b/_build/test/Tests/Controllers/Resources/ResourceManagerControllerGetInstanceTest.php
@@ -1,0 +1,222 @@
+<?php
+
+namespace MODX\Revolution\Tests\Controllers\Resources;
+
+use MODX\Revolution\modDocument;
+use MODX\Revolution\modResource;
+use MODX\Revolution\modWebLink;
+use MODX\Revolution\MODxTestCase;
+
+/**
+ * @covers ResourceManagerController::getInstance
+ */
+class ResourceManagerControllerGetInstanceTest extends MODxTestCase
+{
+    /** @var array<int, int> */
+    private $createdResourceIds = [];
+
+
+    /**
+     * @before
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+        require_once MODX_MANAGER_PATH . 'controllers/default/resource/resource.class.php';
+        require_once MODX_MANAGER_PATH . 'controllers/default/resource/data.class.php';
+        require_once MODX_MANAGER_PATH . 'controllers/default/resource/create.class.php';
+        require_once MODX_MANAGER_PATH . 'controllers/default/resource/weblink/data.class.php';
+    }
+
+
+    /**
+     * @after
+     */
+    public function tearDownFixtures()
+    {
+        foreach ($this->createdResourceIds as $id) {
+            $resource = $this->modx->getObject(modResource::class, $id);
+            if ($resource) {
+                $resource->remove();
+            }
+        }
+        $this->createdResourceIds = [];
+        $_REQUEST = [];
+        $_GET = [];
+        parent::tearDownFixtures();
+    }
+
+
+    private function createResourceWithClassKey(string $classKey, string $objectClass = modDocument::class): int
+    {
+        $resource = $this->modx->newObject($objectClass);
+        $resource->fromArray([
+            'pagetitle' => '15080-getinstance-' . uniqid('', true),
+            'alias' => '15080-gi-' . uniqid(),
+            'parent' => 0,
+            'template' => 0,
+            'context_key' => 'web',
+            'class_key' => $classKey,
+            'published' => 0,
+        ]);
+        $this->assertTrue($resource->save(), 'Failed to save test resource');
+        if ($resource->get('class_key') !== $classKey) {
+            $resource->set('class_key', $classKey);
+            $this->assertTrue($resource->save(), 'Failed to force class_key on test resource');
+        }
+        $id = (int)$resource->get('id');
+        $this->createdResourceIds[] = $id;
+
+        return $id;
+    }
+
+
+    private function getDataController(array $request)
+    {
+        $_REQUEST = $request;
+        $_GET = $request;
+
+        return \ResourceManagerController::getInstance($this->modx, 'ResourceDataManagerController', [
+            'namespace' => 'core',
+            'namespace_path' => MODX_MANAGER_PATH,
+            'action' => 'Resource/Data',
+        ]);
+    }
+
+
+    public function testDocumentDataManagerControllerAlias()
+    {
+        $this->assertTrue(class_exists('DocumentDataManagerController'));
+        $this->assertTrue(is_a('DocumentDataManagerController', \ResourceDataManagerController::class, true));
+    }
+
+
+    public function testGetInstanceWithShortClassKeyInDatabase()
+    {
+        $id = $this->createResourceWithClassKey('modDocument');
+        $stored = $this->modx->getObject(modResource::class, $id);
+        $this->assertSame('modDocument', $stored->get('class_key'));
+
+        $controller = $this->getDataController([
+            'id' => (string)$id,
+            'a' => 'resource/data',
+        ]);
+
+        $this->assertInstanceOf(\ResourceDataManagerController::class, $controller);
+        $this->assertSame(modDocument::class, $controller->resourceClass);
+
+        $stored = $this->modx->getObject(modResource::class, $id);
+        $this->assertSame(
+            'modDocument',
+            $stored->get('class_key'),
+            'Overview must not rewrite short modDocument on GET'
+        );
+    }
+
+
+    public function testGetInstanceWithShortModResourceClassKeyInDatabase()
+    {
+        $id = $this->createResourceWithClassKey('modResource');
+        $controller = $this->getDataController([
+            'id' => (string)$id,
+            'a' => 'resource/data',
+        ]);
+
+        $this->assertInstanceOf(\ResourceDataManagerController::class, $controller);
+        $this->assertSame(modDocument::class, $controller->resourceClass);
+
+        $stored = $this->modx->getObject(modResource::class, $id);
+        $this->assertSame(modDocument::class, $stored->get('class_key'));
+    }
+
+
+    public function testOverviewLoadsResourceWithShortClassKey()
+    {
+        $id = $this->createResourceWithClassKey('modDocument');
+        $controller = $this->getDataController([
+            'id' => (string)$id,
+            'a' => 'resource/data',
+        ]);
+        $controller->setProperties(['id' => $id]);
+
+        $loaded = $this->modx->getObject(modResource::class, $id);
+        $this->assertNotNull($loaded);
+        $this->assertSame('modDocument', $loaded->get('class_key'));
+
+        // Mirror ResourceDataManagerController::process load path
+        $fromProcessPath = $this->modx->getObject(modResource::class, $id);
+        $this->assertNotNull($fromProcessPath);
+        $this->assertSame($id, (int)$fromProcessPath->get('id'));
+    }
+
+
+    public function testGetInstanceWithFqcnClassKeyRequest()
+    {
+        $controller = $this->getDataController([
+            'a' => 'resource/data',
+            'class_key' => modDocument::class,
+        ]);
+
+        $this->assertInstanceOf(\ResourceDataManagerController::class, $controller);
+        $this->assertSame(modDocument::class, $controller->resourceClass);
+    }
+
+
+    public function testGetInstanceWithShortClassKeyRequest()
+    {
+        $controller = $this->getDataController([
+            'a' => 'resource/data',
+            'class_key' => 'modDocument',
+        ]);
+
+        $this->assertInstanceOf(\ResourceDataManagerController::class, $controller);
+        $this->assertSame(modDocument::class, $controller->resourceClass);
+    }
+
+
+    public function testGetInstanceCreateWithFqcnClassKeyRequest()
+    {
+        $_REQUEST = [
+            'a' => 'resource/create',
+            'class_key' => modDocument::class,
+            'parent' => 1,
+            'context_key' => 'web',
+        ];
+        $_GET = $_REQUEST;
+
+        $controller = \ResourceManagerController::getInstance($this->modx, 'ResourceCreateManagerController', [
+            'namespace' => 'core',
+            'namespace_path' => MODX_MANAGER_PATH,
+            'action' => 'Resource/Create',
+        ]);
+
+        $this->assertInstanceOf(\ResourceCreateManagerController::class, $controller);
+        $this->assertSame(modDocument::class, $controller->resourceClass);
+    }
+
+
+    public function testGetInstanceKeepsWeblinkDerivative()
+    {
+        $id = $this->createResourceWithClassKey(modWebLink::class, modWebLink::class);
+
+        $controller = $this->getDataController([
+            'id' => (string)$id,
+            'a' => 'resource/data',
+        ]);
+
+        $this->assertInstanceOf(\WebLinkDataManagerController::class, $controller);
+        $this->assertSame(modWebLink::class, $controller->resourceClass);
+    }
+
+
+    public function testGetInstanceWeblinkClassKeyRequest()
+    {
+        $controller = $this->getDataController([
+            'a' => 'resource/data',
+            'class_key' => modWebLink::class,
+        ]);
+
+        $this->assertInstanceOf(\WebLinkDataManagerController::class, $controller);
+        $this->assertSame(modWebLink::class, $controller->resourceClass);
+    }
+}

--- a/manager/controllers/default/resource/data.class.php
+++ b/manager/controllers/default/resource/data.class.php
@@ -81,7 +81,8 @@ class ResourceDataManagerController extends ResourceManagerController
         $placeholders = [];
 
         $id = (int)$this->scriptProperties['id'];
-        if (!$this->resource = $this->modx->getObject($this->resourceClass, $id)) {
+        // Load via modResource so legacy short class_key values (e.g. modDocument) still resolve under STI
+        if (!$this->resource = $this->modx->getObject(modResource::class, $id)) {
             return $this->modx->lexicon('resource_err_nfs', ['id' => $this->scriptProperties['id']]);
         }
 
@@ -196,3 +197,5 @@ class ResourceDataManagerController extends ResourceManagerController
     {
     }
 }
+
+class_alias(ResourceDataManagerController::class, 'DocumentDataManagerController');

--- a/manager/controllers/default/resource/resource.class.php
+++ b/manager/controllers/default/resource/resource.class.php
@@ -61,6 +61,18 @@ abstract class ResourceManagerController extends modManagerController
 
 
     /**
+     * Legacy and FQCN class keys that resolve to the core document controllers,
+     * not a derivative resource type (weblink, symlink, static, custom).
+     */
+    private const CORE_DOCUMENT_CLASS_KEYS = [
+        modDocument::class,
+        modResource::class,
+        'modDocument',
+        'modResource',
+    ];
+
+
+    /**
      * Return the appropriate Resource controller class based on the class_key request parameter
      *
      * @static
@@ -76,19 +88,28 @@ abstract class ResourceManagerController extends modManagerController
         $resourceClass = modDocument::class;
         $isDerivative = false;
         if (!empty($_REQUEST['class_key'])) {
-            $isDerivative = true;
-            $resourceClass = in_array($_REQUEST['class_key'], [modDocument::class, modResource::class]) ? modDocument::class
-                : $_REQUEST['class_key'];
-            if ($resourceClass == modResource::class) $resourceClass = modDocument::class;
+            if (in_array($_REQUEST['class_key'], self::CORE_DOCUMENT_CLASS_KEYS, true)) {
+                $resourceClass = modDocument::class;
+            } else {
+                $isDerivative = true;
+                $resourceClass = $_REQUEST['class_key'];
+            }
         } elseif (!empty($_REQUEST['id']) && $_REQUEST['id'] != 'undefined' && strlen($_REQUEST['id']) === strlen((int)$_REQUEST['id'])) {
             /** @var modResource $resource */
             $resource = $modx->getObject(modResource::class, ['id' => $_REQUEST['id']]);
-            if ($resource && !in_array($resource->get('class_key'), [modDocument::class, modResource::class])) {
-                $isDerivative = true;
-                $resourceClass = $resource->get('class_key');
-            } elseif ($resource && $resource->get('class_key') == modResource::class) { /* fix improper class key */
-                $resource->set('class_key', modDocument::class);
-                $resource->save();
+            if ($resource) {
+                $classKey = $resource->get('class_key');
+                if (in_array($classKey, self::CORE_DOCUMENT_CLASS_KEYS, true)) {
+                    /* Fix improper class_key values that are not real derivatives */
+                    if (in_array($classKey, [modResource::class, 'modResource'], true)) {
+                        $resource->set('class_key', modDocument::class);
+                        $resource->save();
+                    }
+                    $resourceClass = modDocument::class;
+                } else {
+                    $isDerivative = true;
+                    $resourceClass = $classKey;
+                }
             }
         }
 


### PR DESCRIPTION
### What changed and why

Resource Overview (`resource/data`) threw `Class 'DocumentDataManagerController' not found` when a resource stored the legacy short `class_key` `modDocument` (common for API/extra creates) or when `class_key` was present in the request.

`ResourceManagerController::getInstance()` treated those keys as derivatives and rewrote the controller name via `getAlias()`, but unlike create/update (#15997) the data controller had no `DocumentDataManagerController` alias. Short keys also failed STI lookup when overview loaded via `modDocument::class`.

This change:
- Treats short and FQCN core document keys as non-derivative in `getInstance()`
- Adds `DocumentDataManagerController` alias (parity with create/update)
- Loads overview through `modResource::class` so short keys still resolve
- Keeps the existing rewrite of improper `modResource` / `modResource` short keys only (does not rewrite short `modDocument` on GET)

### How to test

1. Create a resource with `class_key` = `modDocument` (short), open Manager → Overview for that resource. Expect no class-not-found error.
2. Open `?a=resource/data&id=1&class_key=MODX\Revolution\modDocument` (and with short `modDocument`). Expect the overview controller to load.
3. Overview a Weblink. Expect `WebLinkDataManagerController` still.
4. Gate E:
   - `php -l manager/controllers/default/resource/resource.class.php` → exit 0
   - `php -l manager/controllers/default/resource/data.class.php` → exit 0
   - `core/vendor/bin/phpunit -c _build/test/phpunit.xml --filter ResourceManagerControllerGetInstanceTest --no-coverage` → OK (9 tests, 27 assertions)
   - `core/vendor/bin/phpcs --standard=phpcs.xml _build/test/Tests/Controllers/Resources/ResourceManagerControllerGetInstanceTest.php` → exit 0

### Related issue(s)/PR(s)

Resolves #15080

Related: #16004 / #15997 (DocumentCreate/DocumentUpdate aliases). Collections short `class_key` context: modxcms/Collections#353.

### Compatibility notes

Universal. Helps installs/extras that still persist short `modDocument`. Does not migrate existing short `modDocument` rows on overview GET.

### Breaking change assessment

No public API signature changes. Create with a core-document `class_key` request param now skips the derivative controller rename path and instantiates `ResourceCreateManagerController` directly (equivalent to the previous alias path).

### Test coverage

Added `_build/test/Tests/Controllers/Resources/ResourceManagerControllerGetInstanceTest.php` for short/FQCN document keys, Weblink derivative regression, and the DocumentData alias.

### Contributors

Thanks @Ruslan-Aleev for the original report and @Lystapad for identifying the short `class_key` path.

### AI tool use

Cursor agent assisted with investigation, implementation, tests, and PR drafting under human direction.