### PR TITLE
fix(security): use CSPRNG for passwordless and reset token hashes

### DIFF
--- a/manager/controllers/default/security/login.class.php
+++ b/manager/controllers/default/security/login.class.php
@@ -315,7 +315,7 @@ class SecurityLoginManagerController extends modManagerController
             $this->modx->lexicon->load('core:user');
 
             // create a temporary password and immediately use it once to login with the standard method
-            $password = uniqid("tmp-password-", true);
+            $password = "tmp-password-" . bin2hex(random_bytes(16));
             $user->set('password', $password);
             $user->save();
 
@@ -535,7 +535,7 @@ class SecurityLoginManagerController extends modManagerController
      */
     private function setActivationHash($user, $ttl = 86400, $topic = '/pwd/change/')
     {
-        $hash = md5(uniqid(md5($user->get('email') . '/' . $user->get('id')), true));
+        $hash = bin2hex(random_bytes(32));
 
         /** @var modRegistry $registry */
         $registry = $this->modx->getService('registry', modRegistry::class);


### PR DESCRIPTION
## Security fix: use CSPRNG for passwordless login and reset token hashes

This PR replaces time-based, predictable token generation with a CSPRNG.

### Problem

`SecurityController::setActivationHash()` currently builds the one-time hash for **both** the passwordless login link (`/pwd/magiclink/`) and the password reset link (`/pwd/change/`) as:

```
$hash = md5(uniqid(md5($user->get('email') . '/' . $user->get('id')), true));
```

`uniqid()` is not a CSPRNG: it encodes the current server time (seconds + microseconds) and derives its remaining "entropy" from PHP's combined LCG. The prefix is built from values known to an attacker (email + incremental id), and the outer `md5()` adds no entropy. With no rate limiting on token verification, the remaining search space (the microsecond window) is small enough to be guessed online after triggering the email — leading to manager account takeover for any role. The magic-link temporary password is also `uniqid()`-based and overwrites the user's real password.

Related (GET-consumption by link scanners): #16833.

### Fix

- `bin2hex(random_bytes(32))` for the token hash (256-bit CSPRNG).
- `random_bytes()`-based temporary password in the passwordless login flow.

Both changes are drop-in: tokens are opaque strings used as register message keys and email placeholders; registry TTL and the `PasswordResetToken::sign()` / `verify()` flow are unchanged. This PR does not include the two-phase confirmation from #16833 — they compose well and can be merged independently.

### Disclosure note

The fix branch was previously published in the `AgelxNash` fork; no attack code was published. Maintainers may prefer folding this into the #16833 work and/or requesting a coordinated advisory (huntr / CVE) — happy to cooperate.
