### PR TITLE
[3.x] Form handler refactor to allow more flexible and accurate status reporting in the manager UI

### DIFF
--- a/_build/test/Tests/Utilities/modStringSanitizerTest.php
+++ b/_build/test/Tests/Utilities/modStringSanitizerTest.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For complete copyright and license information, see the COPYRIGHT and LICENSE
+ * files found in the top-level directory of this distribution.
+ *
+ * @package modx-test
+ */
+
+/** @phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps */
+
+namespace MODX\Revolution\Tests\Utilities\Sanitizers;
+
+use MODX\Revolution\MODxTestCase;
+use MODX\Revolution\Utilities\Sanitizers\modStringSanitizer;
+
+class modStringSanitizerTest extends MODxTestCase
+{
+    /** @var modStringSanitizer $sanitizers */
+    public $sanitizers;
+
+    /**
+     * Setup fixtures before each test.
+     *
+     * @before
+     */
+    public function setUpFixtures()
+    {
+        parent::setUpFixtures();
+        $this->sanitizers = $this->modx->services->get(modStringSanitizer::class);
+    }
+
+    /**
+     * @param string $expected
+     * @param string $htmlSource The html string to clean
+     * @param ?string|array $allowedTags An array or comma-separated list of tag names to allow
+     * @param ?string|array $allowedAttr An array or comma-separated list of tag attribute names to allow
+     * @param bool $allowScripts Whether to allow javascript in html source passed to this method
+     * @param bool $allowComments Whether to allow comments in the final output
+     * @dataProvider providerStripHTML
+     */
+    public function testStripHTML(
+        $expected,
+        string $htmlSource,
+        string|array|null $allowedTags = '',
+        string|array|null $allowedAttr = '',
+        bool $allowScripts = false,
+        bool $allowComments = false
+    ) {
+
+        $allowedTags = $allowedTags ?? '';
+        $allowedAttr = $allowedAttr ?? '';
+
+        $result = $this->sanitizers->stripHTML($htmlSource, $allowedTags, $allowedAttr, $allowScripts, $allowComments);
+        $this->assertEquals($expected, $result);
+    }
+
+    public function providerStripHTML(): array
+    {
+        $nullParams = [null, null];
+        // String list configs (including odd spacing)
+        $parmSet1 = ['a, strong  , em', 'href,  title,id'];
+        // Array list configs (including odd spacing)
+        $parmSet2 = [['p', 'a', ' strong', 'em'], ['href  ', 'class', 'style', 'onclick', 'title']];
+        // Custom/non-existing
+        $parmSet3 = ['p, notatag', 'notanattr'];
+        // Data attr and allowing scripts
+        $parmSet4 = ['div,img, script', 'data, src', true];
+
+        // Have to hack this to keep parser from interpreting as actual opening short tag in the tests below
+        $shortOpenTag = <<<TAG
+        <? 
+        TAG;
+
+        return [
+            // Full strip, nothing passed in for allowed params
+            'Should remove all tags and attrs' => [
+                'My great string',
+                '<p class="gone">My <em>great</em> string</p>'
+            ],
+            'Should remove all tags and attrs (when null is passed to allowed params)' => [
+                'My great string',
+                '<p class="gone">My <em>great</em> string</p>',
+                ...$nullParams
+            ],
+            'Should remove script tag and its contents' => [
+                'This would , but we fixed it.',
+                'This would <script>alert("be bad");</script>, but we fixed it.'
+            ],
+            'Should remove broken script tag and remaining contents (no closing)' => [
+                'This would ',
+                'This would <script>alert("be bad");, but we fixed it.'
+            ],
+            'Should remove broken script tag (no opening)' => [
+                'This would alert("be bad");',
+                'This would alert("be bad");</script>'
+            ],
+            'Should remove php (long tag)' => [
+                '',
+                '<?php echo "Also not great!"; ?>'
+            ],
+            'Should remove php (long incomplete tag)' => [
+                '',
+                '<?php echo "Again, not great!";'
+            ],
+            'Should remove php (short tag)' => [
+                '',
+                trim($shortOpenTag) . ' echo "Still not great!"; ?>'
+            ],
+            'Should remove php (short incomplete tag)' => [
+                '',
+                trim($shortOpenTag) . ' echo "You know ... not great!";'
+            ],
+            /*
+                paramSet1 rules, allowed:
+                    tags -- a, strong, em
+                    attr -- href, title, id
+            */
+            'Should auto complete broken em (incorrect closing tags)' => [
+                'A <em>jazzy<em> caption</em></em>',
+                'A <em>jazzy<em> caption',
+                ...$parmSet1
+            ],
+            'Should handle removals in nested structures' => [
+                'A <em>jazzy</em> caption <a id="myId">more</a>',
+                'A <b><em><span>jazzy</span></em></b> caption <span><a id="myId" style="color: red;"><b>more</b></a></span>',
+                ...$parmSet1
+            ],
+            /*
+                paramSet2 rules, allowed, given in array instead of string:
+                    tags -- ['p', 'a', 'strong', 'em']
+                    attr -- ['href', 'class', 'style', 'onclick', 'title'] {1}
+
+                    {1} note that event handlers should always be removed, even when scripts
+                    are allowed as it is bad practice mixing javascript directly in html
+            */
+            'Should remove non-standard tag and others not in list' => [
+                '<p>A jazzy caption</p>',
+                '<div><p>A <notatag>jazzy</notatag> caption</p></div>',
+                ...$parmSet2
+            ],
+            'Should remove event handlers' => [
+                '<p class="myClass">This element does <strong>all</strong> these things</p>',
+                '<p class="myClass" data-someprop="hello">This <b>element</b> does <strong onclick="javascript:alert(hello);">all</strong> these things</p>',
+                ...$parmSet2
+            ],
+            'Should replace javascript in all attrs' => [
+                '<p class="myClass">This element does <strong title="#js-not-allowed#">all</strong> these things</p>',
+                '<p class="myClass" data-someprop="hello">This <b>element</b> does <strong title="javascript:alert(hello);">all</strong> these things</p>',
+                ...$parmSet2
+            ],
+            /*
+                paramSet3 rules, allowed:
+                    tags -- p, notatag
+                    attr -- notanattr
+            */
+            'Should retain non-standard and other allowed tags' => [
+                '<p>A <notatag>jazzy</notatag> caption</p>',
+                '<div><p>A <notatag>jazzy</notatag> caption</p></div>',
+                ...$parmSet3
+            ],
+            'Should retain non-standard and other allowed attributes' => [
+                '<p notanattr="technically ok, but not advisable">A <notatag>jazzy</notatag> caption</p>',
+                '<div><p notanattr="technically ok, but not advisable">A <notatag>jazzy</notatag> caption</p></div>',
+                ...$parmSet3
+            ],
+            /*
+                paramSet4 rules, allowed:
+                    tags -- div, img, script
+                    attr -- data, src
+            */
+            'Should retain data attributes' => [
+                '<div data-someprop="hello" data-otherprop="world">A jazzy caption</div>',
+                '<div data-someprop="hello" data-otherprop="world"><p>A <notatag>jazzy</notatag> caption</p></div>',
+                ...$parmSet4
+            ],
+            'Should retain script tag and contents' => [
+                '<div>As long as you are sure, </div><script>alert("you can do this");</script>',
+                '<div>As long as you are sure, </div><script>alert("you can do this");</script>',
+                ...$parmSet4
+            ],
+            'Should handle retention and removals in multiline html' => [
+                <<<EXP
+                    <div>
+                        These tags will disappear
+                        <img src="/some/path/to.png">
+                    </div>
+                    <script>
+                        let x = 1;
+                        console.log('X is ', x);
+                    </script>
+                EXP,
+                <<<SRC
+                    <div>
+                        <p>These tags will <span>disappear</span></p>
+                        <img src="/some/path/to.png" alt="should have this but not in list">
+                    </div>
+                    <script>
+                        let x = 1;
+                        console.log('X is ', x);
+                    </script>
+                SRC,
+                ...$parmSet4
+            ]
+        ];
+    }
+}

--- a/_build/test/phpunit.xml
+++ b/_build/test/phpunit.xml
@@ -54,6 +54,9 @@
             <directory>Tests/Cases/Modx/</directory>
             <directory>Tests/Cases/Request/</directory>
         </testsuite>
+        <testsuite name="Utilities">
+            <directory>Tests/Utilities</directory>
+        </testsuite>
         <testsuite name="Teardown">
             <file>Tests/modXTeardownTest.php</file>
         </testsuite>

--- a/core/lexicon/en/default.inc.php
+++ b/core/lexicon/en/default.inc.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  * Default English lexicon topic
  *
@@ -6,6 +7,7 @@
  * @package modx
  * @subpackage lexicon
  */
+
 $_lang['access'] = 'Access';
 $_lang['access_denied'] = 'Access denied.';
 $_lang['action'] = 'Action';
@@ -150,6 +152,7 @@ $_lang['error_grid_get_content_no_msg'] = 'A server error prevented this grid’
 $_lang['error_grid_get_content_tolog'] = 'A server error prevented this grid’s content from loading. Refer to your browser’s console, manager logs, and/or php server logs for more information.';
 $_lang['error_grid_get_content_toscreen'] = 'This grid’s content could not be loaded due to the following server error: [[+message]]';
 $_lang['error_loading_feed'] = 'An error occurred loading the feed.';
+$_lang['error_ui_message_error'] = 'A system error occurred while retrieving the message to display here. See browser console for more details.';
 $_lang['event_id'] = 'Event Id';
 $_lang['existing_category'] = 'Existing Category';
 $_lang['expand_all'] = 'Expand All';
@@ -527,6 +530,7 @@ $_lang['update'] = 'Update';
 $_lang['updated'] = 'Updated';
 $_lang['upload'] = 'Upload';
 $_lang['username'] = 'Username';
+$_lang['validation_error'] = 'Validation Error';
 $_lang['value'] = 'Value';
 $_lang['version'] = 'Version';
 $_lang['view'] = 'View';

--- a/core/lexicon/en/workspace.inc.php
+++ b/core/lexicon/en/workspace.inc.php
@@ -130,6 +130,7 @@ $_lang['package_select_download_ns'] = 'Please select at least one package to do
 $_lang['package_select_upload'] = 'Select a Package to Upload';
 $_lang['package_signature'] = 'Signature';
 $_lang['package_state'] = 'State';
+$_lang['package_status'] = 'Package Status';
 $_lang['package_uninstall'] = 'Uninstall Package';
 $_lang['package_uninstall_info_find'] = 'Finding package with signature: [[+signature]]';
 $_lang['package_uninstall_info_prep'] = 'Package found. Preparing to uninstall.';

--- a/core/src/Revolution/Error/modError.php
+++ b/core/src/Revolution/Error/modError.php
@@ -30,6 +30,15 @@ class modError
      * @var string The error message to output.
      */
     public  $message;
+
+    /**
+     * @var array An optional set of customization specifications to tailor the message output. Config options include:
+     * - messageType: (string) The type of message to output. Options include the status constants defined in the base processor (i.e., Processor::STATUS_TYPE_INFO, etc.).
+     * - messageWindowTitle: (string) Overrides the default window title
+     * - messageIsFormatted: (bool) Whether the message source is html-formatted (must be set to true to preserve formatting).
+     */
+    public $messageConfig = [];
+
     /**
      * @var modX A reference to the $modx object.
      */
@@ -160,13 +169,13 @@ class modError
             unset ($obj);
         }
         $objarray = $this->toArray($object);
-        return [
+        return array_merge([
             'success' => $status,
             'message' => $this->message,
             'total' => isset ($this->total) && $this->total != 0 ? $this->total : count($this->errors),
             'errors' => $this->errors,
-            'object' => $objarray,
-        ];
+            'object' => $objarray
+        ], $this->messageConfig);
     }
 
     /**

--- a/core/src/Revolution/Processors/Processor.php
+++ b/core/src/Revolution/Processors/Processor.php
@@ -322,6 +322,66 @@ abstract class Processor
     }
 
     /**
+     * Converts an html-formatted message to JSON, configured such that it can be
+     * reliably decoded and consumed as a value in a javascript config object
+     *
+     * @param string $message The unencoded html message
+     * @return string The JSON-encoded html message
+     */
+    protected function htmlMessageToJSON(string $message): string
+    {
+        $message = trim($message);
+        if (empty($message)) {
+            return '';
+        }
+        $message = $this->modx->stripTags(
+            $message,
+            '<div><p><ul><ol><li><strong><em><br>'
+        );
+        // Collapse presentational (code formatting) space
+        $regex = '/(?<=>)[\s]*(?=<)/';
+        return json_encode(
+            preg_replace($regex, '', $message),
+            JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES
+        );
+    }
+
+    /**
+     * Prepare formatting and titling config for optional customizations to be
+     * sent via $this->failure as its $object argument
+     *
+     * @param string $windowTitle Optional title to replace the default, generic error title
+     * @param string $type Optional indicator of the message type (error, warn, info)
+     * @param bool $isFormatted Indicates whether message contains and should render html
+     * @return array The prepared configuration
+     */
+    protected function setCustomMessageOptions(
+        string $windowTitle = '',
+        string $type = 'error',
+        bool $isFormatted = false
+    ): array {
+        $options = [];
+        if (empty($windowTitle) && $type === 'error' && empty($isFormatted)) {
+            return $options;
+        }
+        switch (true) {
+            case $isFormatted || $type !== 'error':
+                $options['messageConfig'] = [];
+                // fall through to keep building
+            case $isFormatted:
+                $options['messageConfig']['messageIsFormatted'] = $isFormatted;
+                // fall through to keep building
+            case $type !== 'error':
+                $options['messageConfig']['messageType'] = $type;
+                // fall through to keep building
+            case !empty($windowTitle):
+                $options['messageWindowTitle'] = $windowTitle;
+            // no default
+        }
+        return $options;
+    }
+
+    /**
      * Encodes certain JavaScript literal strings for later decoding.
      *
      * @access protected

--- a/core/src/Revolution/Processors/Processor.php
+++ b/core/src/Revolution/Processors/Processor.php
@@ -22,16 +22,21 @@ use MODX\Revolution\Utilities\Converters\modUtilsStringConverters;
  */
 abstract class Processor
 {
+    // Status message types, currently aligned with ExtJS message types
+    /** Status message type: Error */
     const STATUS_TYPE_ERROR = 'error';
+    /** Status message type: Warning */
     const STATUS_TYPE_WARN = 'warning';
+    /** Status message type: Info */
     const STATUS_TYPE_INFO = 'info';
+    /** Status message type: Success */
     const STATUS_TYPE_SUCCESS = 'success';
 
     /**
      * A reference to the modX object.
      * @var modX $modx
      */
-    public ?modX $modx = null;
+    public $modx = null;
     /**
      * The absolute path to this processor
      * @var string $path
@@ -48,7 +53,10 @@ abstract class Processor
      */
     public $permission = '';
 
+    /** A reference to the modUtilsStringSanitizers service */
     public modUtilsStringSanitizers $stringSanitizers;
+
+    /** A reference to the modUtilsStringConverters service */
     public modUtilsStringConverters $stringConverters;
 
     /**

--- a/core/src/Revolution/Processors/Processor.php
+++ b/core/src/Revolution/Processors/Processor.php
@@ -12,6 +12,8 @@
 namespace MODX\Revolution\Processors;
 
 use MODX\Revolution\modX;
+use MODX\Revolution\Utilities\Sanitizers\modUtilsStringSanitizers;
+use MODX\Revolution\Utilities\Converters\modUtilsStringConverters;
 
 /**
  * Abstracts a MODX processor, handling its response and error formatting.
@@ -20,11 +22,16 @@ use MODX\Revolution\modX;
  */
 abstract class Processor
 {
+    const STATUS_TYPE_ERROR = 'error';
+    const STATUS_TYPE_WARN = 'warning';
+    const STATUS_TYPE_INFO = 'info';
+    const STATUS_TYPE_SUCCESS = 'success';
+
     /**
      * A reference to the modX object.
      * @var modX $modx
      */
-    public $modx = null;
+    public ?modX $modx = null;
     /**
      * The absolute path to this processor
      * @var string $path
@@ -41,15 +48,20 @@ abstract class Processor
      */
     public $permission = '';
 
+    public modUtilsStringSanitizers $stringSanitizers;
+    public modUtilsStringConverters $stringConverters;
+
     /**
      * Creates a modProcessor object.
-     *
+     *x
      * @param modX $modx A reference to the modX instance
      * @param array $properties An array of properties
      */
     public function __construct(modX $modx, array $properties = [])
     {
         $this->modx =& $modx;
+        $this->stringSanitizers = $this->modx->services->get(modUtilsStringSanitizers::class);
+        $this->stringConverters = $this->modx->services->get(modUtilsStringConverters::class);
         $this->setProperties($properties);
     }
 
@@ -137,6 +149,42 @@ abstract class Processor
     public function failure($msg = '', $object = null)
     {
         return $this->modx->error->failure($msg, $object);
+    }
+
+    /**
+     * Return a type-specific message with optional customizations from the processor.
+     *
+     * @param string $message The message to send.
+     * @param string $messageWindowTitle Optional title to replace the default, generic title for the specified message type.
+     * @param string $messageType Optional indicator of the message type (error, warn, info, etc)
+     * @param boolean $messageIsFormatted Indicates whether message contains and should render html
+     * @param object|array|string $object An object to send back to the output.
+     * @return string|array The status response
+     */
+    public function status(
+        $message = '',
+        $messageWindowTitle = '',
+        $messageType = self::STATUS_TYPE_ERROR,
+        $messageIsFormatted = false,
+        $object = null
+    ) {
+        if ($messageIsFormatted) {
+            $message = $this->stringSanitizers->stripHTML(
+                $message,
+                modX::MGR_MESSAGES_ALLOWED_TAGS,
+                modX::MGR_MESSAGES_ALLOWED_ATTRS
+            );
+            $message = $this->stringConverters->htmlToJSON($message);
+        }
+
+        $hasCustomMessageOptions = !empty($messageWindowTitle) || $messageType !== self::STATUS_TYPE_ERROR || $messageIsFormatted;
+
+        if ($hasCustomMessageOptions) {
+            $this->modx->error->messageConfig = $this->setCustomMessageOptions($messageWindowTitle, $messageType, $messageIsFormatted);
+        }
+        $status = $messageType !== self::STATUS_TYPE_ERROR ? 'success' : 'failure';
+
+        return $this->modx->error->$status($message, $object);
     }
 
     /**
@@ -322,40 +370,15 @@ abstract class Processor
     }
 
     /**
-     * Converts an html-formatted message to JSON, configured such that it can be
-     * reliably decoded and consumed as a value in a javascript config object
-     *
-     * @param string $message The unencoded html message
-     * @return string The JSON-encoded html message
-     */
-    protected function htmlMessageToJSON(string $message): string
-    {
-        $message = trim($message);
-        if (empty($message)) {
-            return '';
-        }
-        $message = $this->modx->stripTags(
-            $message,
-            '<div><p><ul><ol><li><strong><em><br>'
-        );
-        // Collapse presentational (code formatting) space
-        $regex = '/(?<=>)[\s]*(?=<)/';
-        return json_encode(
-            preg_replace($regex, '', $message),
-            JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES
-        );
-    }
-
-    /**
      * Prepare formatting and titling config for optional customizations to be
-     * sent via $this->failure as its $object argument
+     * sent via $this->status
      *
      * @param string $windowTitle Optional title to replace the default, generic error title
      * @param string $type Optional indicator of the message type (error, warn, info)
      * @param bool $isFormatted Indicates whether message contains and should render html
      * @return array The prepared configuration
      */
-    protected function setCustomMessageOptions(
+    private function setCustomMessageOptions(
         string $windowTitle = '',
         string $type = 'error',
         bool $isFormatted = false
@@ -364,10 +387,8 @@ abstract class Processor
         if (empty($windowTitle) && $type === 'error' && empty($isFormatted)) {
             return $options;
         }
+        $options['messageConfig'] = [];
         switch (true) {
-            case $isFormatted || $type !== 'error':
-                $options['messageConfig'] = [];
-                // fall through to keep building
             case $isFormatted:
                 $options['messageConfig']['messageIsFormatted'] = $isFormatted;
                 // fall through to keep building
@@ -375,7 +396,7 @@ abstract class Processor
                 $options['messageConfig']['messageType'] = $type;
                 // fall through to keep building
             case !empty($windowTitle):
-                $options['messageWindowTitle'] = $windowTitle;
+                $options['messageConfig']['messageWindowTitle'] = $windowTitle;
             // no default
         }
         return $options;

--- a/core/src/Revolution/Processors/Processor.php
+++ b/core/src/Revolution/Processors/Processor.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+/** @phpcs:disable PSR2.Methods.MethodDeclaration.Underscore */
+
 namespace MODX\Revolution\Processors;
 
 use MODX\Revolution\modX;
@@ -24,13 +26,13 @@ abstract class Processor
 {
     // Status message types, currently aligned with ExtJS message types
     /** Status message type: Error */
-    const STATUS_TYPE_ERROR = 'error';
+    public const STATUS_TYPE_ERROR = 'error';
     /** Status message type: Warning */
-    const STATUS_TYPE_WARN = 'warning';
+    public const STATUS_TYPE_WARN = 'warning';
     /** Status message type: Info */
-    const STATUS_TYPE_INFO = 'info';
+    public const STATUS_TYPE_INFO = 'info';
     /** Status message type: Success */
-    const STATUS_TYPE_SUCCESS = 'success';
+    public const STATUS_TYPE_SUCCESS = 'success';
 
     /**
      * A reference to the modX object.
@@ -163,9 +165,12 @@ abstract class Processor
      * Return a type-specific message with optional customizations from the processor.
      *
      * @param string $message The message to send.
-     * @param string $messageWindowTitle Optional title to replace the default, generic title for the specified message type.
-     * @param string $messageType Optional indicator of the message type (error, warn, info, etc)
-     * @param boolean $messageIsFormatted Indicates whether message contains and should render html
+     * @param string $messageWindowTitle Optional title to replace the default,
+     * generic title for the specified message type.
+     * @param string $messageType Optional indicator of the message type
+     * (error, warn, info, etc)
+     * @param bool $messageIsFormatted Indicates whether message contains
+     * and should render html
      * @param object|array|string $object An object to send back to the output.
      * @return string|array The status response
      */

--- a/core/src/Revolution/Processors/Processor.php
+++ b/core/src/Revolution/Processors/Processor.php
@@ -181,7 +181,9 @@ abstract class Processor
         $messageIsFormatted = false,
         $object = null
     ) {
-        if ($messageIsFormatted) {
+        if (!$messageIsFormatted) {
+            $message = $this->stringSanitizers->stripHTML($message);
+        } else {
             $message = $this->stringSanitizers->stripHTML(
                 $message,
                 modX::MGR_MESSAGES_ALLOWED_TAGS,

--- a/core/src/Revolution/Processors/Processor.php
+++ b/core/src/Revolution/Processors/Processor.php
@@ -12,8 +12,8 @@
 namespace MODX\Revolution\Processors;
 
 use MODX\Revolution\modX;
-use MODX\Revolution\Utilities\Sanitizers\modUtilsStringSanitizers;
-use MODX\Revolution\Utilities\Converters\modUtilsStringConverters;
+use MODX\Revolution\Utilities\Sanitizers\modStringSanitizer;
+use MODX\Revolution\Utilities\Converters\modStringConverter;
 
 /**
  * Abstracts a MODX processor, handling its response and error formatting.
@@ -53,11 +53,11 @@ abstract class Processor
      */
     public $permission = '';
 
-    /** A reference to the modUtilsStringSanitizers service */
-    public modUtilsStringSanitizers $stringSanitizers;
+    /** A reference to the modStringSanitizer service */
+    public modStringSanitizer $stringSanitizers;
 
-    /** A reference to the modUtilsStringConverters service */
-    public modUtilsStringConverters $stringConverters;
+    /** A reference to the modStringConverter service */
+    public modStringConverter $stringConverters;
 
     /**
      * Creates a modProcessor object.
@@ -68,8 +68,8 @@ abstract class Processor
     public function __construct(modX $modx, array $properties = [])
     {
         $this->modx =& $modx;
-        $this->stringSanitizers = $this->modx->services->get(modUtilsStringSanitizers::class);
-        $this->stringConverters = $this->modx->services->get(modUtilsStringConverters::class);
+        $this->stringSanitizers = $this->modx->services->get(modStringSanitizer::class);
+        $this->stringConverters = $this->modx->services->get(modStringConverter::class);
         $this->setProperties($properties);
     }
 

--- a/core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
@@ -95,7 +95,7 @@ class CheckForUpdates extends Processor
         if (count($packages) < 1) {
             $msg = $this->modx->lexicon('package_err_uptodate', ['signature' => $this->package->get('signature')]);
             $this->modx->log(modX::LOG_LEVEL_INFO, $msg);
-            return $this->failure($msg);     
+            return $this->failure($msg);
         }
 
         $list = [];

--- a/core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
@@ -95,18 +95,7 @@ class CheckForUpdates extends Processor
         if (count($packages) < 1) {
             $msg = $this->modx->lexicon('package_err_uptodate', ['signature' => $this->package->get('signature')]);
             $this->modx->log(modX::LOG_LEVEL_INFO, $msg);
-            $msg = <<<HTML
-                <strong>Special Message</strong><br>
-                <span>It's a special intro:</span><br>
-                <em>{$msg}</em>
-                <script>return 'do something bad';</script>
-            HTML;
-            // $msg = '';
-            return $this->failure(
-                $this->htmlMessageToJSON($msg),
-                $this->setCustomMessageOptions('Package\'s Status', 'info', true)
-                // $this->setCustomMessageOptions('Package\'s Status', 'info')
-            );
+            return $this->failure($msg);     
         }
 
         $list = [];

--- a/core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
@@ -95,7 +95,11 @@ class CheckForUpdates extends Processor
         if (count($packages) < 1) {
             $msg = $this->modx->lexicon('package_err_uptodate', ['signature' => $this->package->get('signature')]);
             $this->modx->log(modX::LOG_LEVEL_INFO, $msg);
-            return $this->failure($msg);
+            return $this->status(
+                $msg,
+                $this->modx->lexicon('package_status'),
+                Processor::STATUS_TYPE_INFO
+            );
         }
 
         $list = [];

--- a/core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
+++ b/core/src/Revolution/Processors/Workspace/Packages/CheckForUpdates.php
@@ -95,7 +95,18 @@ class CheckForUpdates extends Processor
         if (count($packages) < 1) {
             $msg = $this->modx->lexicon('package_err_uptodate', ['signature' => $this->package->get('signature')]);
             $this->modx->log(modX::LOG_LEVEL_INFO, $msg);
-            return $this->failure($msg);
+            $msg = <<<HTML
+                <strong>Special Message</strong><br>
+                <span>It's a special intro:</span><br>
+                <em>{$msg}</em>
+                <script>return 'do something bad';</script>
+            HTML;
+            // $msg = '';
+            return $this->failure(
+                $this->htmlMessageToJSON($msg),
+                $this->setCustomMessageOptions('Package\'s Status', 'info', true)
+                // $this->setCustomMessageOptions('Package\'s Status', 'info')
+            );
         }
 
         $list = [];

--- a/core/src/Revolution/Utilities/Converters/modStringConverter.php
+++ b/core/src/Revolution/Utilities/Converters/modStringConverter.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+/** @phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps */
+
 namespace MODX\Revolution\Utilities\Converters;
 
 use MODX\Revolution\modX;

--- a/core/src/Revolution/Utilities/Converters/modStringConverter.php
+++ b/core/src/Revolution/Utilities/Converters/modStringConverter.php
@@ -18,7 +18,7 @@ use MODX\Revolution\modX;
  *
  * @package MODX\Revolution
  */
-class modUtilsStringConverters
+class modStringConverter
 {
     /**
      * A reference to the modX object.

--- a/core/src/Revolution/Utilities/Converters/modUtilsStringConverters.php
+++ b/core/src/Revolution/Utilities/Converters/modUtilsStringConverters.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MODX\Revolution\Utilities\Converters;
+
+use MODX\Revolution\modX;
+
+/**
+ * Provides utility methods to processors and controllers for converting text content from one format to another
+ *
+ * @package MODX\Revolution
+ */
+class modUtilsStringConverters
+{
+    /**
+     * A reference to the modX object.
+     * @var modX $modx
+     */
+    protected ?modX $modx = null;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx =& $modx;
+    }
+
+    /**
+     * Converts an html-formatted string to JSON, configured such that it can be
+     * reliably decoded and consumed as a value in a javascript config object
+     *
+     * @param string $string The unencoded html string
+     * @return string The JSON-encoded string
+     */
+    public function htmlToJSON(string $string): string
+    {
+        $string = trim($string);
+        if (empty($string)) {
+            return '';
+        }
+
+        // Collapse presentational (code formatting) space
+        $regex = '/(?<=>)[\s]*(?=<)/';
+
+        return json_encode(
+            preg_replace($regex, '', $string),
+            JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_SLASHES
+        );
+    }
+}

--- a/core/src/Revolution/Utilities/Sanitizers/modStringSanitizer.php
+++ b/core/src/Revolution/Utilities/Sanitizers/modStringSanitizer.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+/** @phpcs:disable Squiz.Classes.ValidClassName.NotCamelCaps */
+
 namespace MODX\Revolution\Utilities\Sanitizers;
 
 use MODX\Revolution\modX;
@@ -32,7 +34,9 @@ class modStringSanitizer
     }
 
     /**
-     * Removes unwanted tags and/or tag attributes from an HTML string
+     * Removes unwanted tags and/or tag attributes from an HTML string.
+     * Assumes well-designed HTML without inline php (which is not supported
+     * and always stripped).
      *
      * @param string $htmlSource The html string to clean
      * @param ?string|array $allowedTags An array or comma-separated list of tag names to allow
@@ -47,13 +51,7 @@ class modStringSanitizer
             return '';
         }
 
-        libxml_use_internal_errors(true);
-
         $allowedTags = is_string($allowedTags) ? trim($allowedTags) : $allowedTags ;
-
-        if (empty($allowedTags)) {
-            return strip_tags($htmlSource);
-        }
 
         if (!is_array($allowedTags)) {
             $allowedTags = preg_replace('/[\s<>]+/', '', $allowedTags);
@@ -64,6 +62,9 @@ class modStringSanitizer
             }, $allowedTags);
         }
 
+        // Strip php before encoding
+        $htmlSource = preg_replace('/<\s*?\?(?:php)?[\s\S]*?\?\s*?>|<\s*?\?(?:php)?[\s\S]*/m', '', $htmlSource);
+
         if (!empty($allowedAttr)) {
             if (!is_array($allowedAttr)) {
                 $allowedAttr = explode(',', $allowedAttr);
@@ -73,17 +74,26 @@ class modStringSanitizer
             $allowedAttr = [];
         }
 
+        libxml_use_internal_errors(true);
+
         $dom = new \DOMDocument();
         // Prevent additional formatting of the source string
         $dom->formatOutput = false;
 
+        /*
+            To support multiple languages, the source needs to be mb-encoded to
+            ensure DOMDocument can cleanly parse the string and avoid errors.
+        */
         $content = mb_encode_numericentity(
             $htmlSource,
             [0x80, 0x10FFFF, 0, ~0],
             'UTF-8'
         );
 
-        // Need a placeholder wrapping tag, as loadHTML will automatically wrap strings with no root tag with a <p> tag (do not want that)
+        /*
+            Need a placeholder wrapping tag, as loadHTML will automatically
+            wrap strings with no root tag with a <p> tag (do not want that)
+        */
         $dom->loadHTML(
             '<phwrap>' . $content . '</phwrap>',
             LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
@@ -103,7 +113,7 @@ class modStringSanitizer
             in most cases not be able to identify the content to remove
             because its enclosing tag had already been removed.
         */
-        if (!$allowScripts) {
+        if (!$allowScripts || !in_array('script', $allowedTags)) {
             foreach ($xpath->query("//script") as $node) {
                 $node->parentNode->removeChild($node);
             }
@@ -165,6 +175,7 @@ class modStringSanitizer
         if (strpos($output, '<phwrap>') !== false) {
             $output = str_replace(['<phwrap>', '</phwrap>'], '', $output);
         }
+
         return $output;
     }
 }

--- a/core/src/Revolution/Utilities/Sanitizers/modStringSanitizer.php
+++ b/core/src/Revolution/Utilities/Sanitizers/modStringSanitizer.php
@@ -18,7 +18,7 @@ use MODX\Revolution\modX;
  *
  * @package MODX\Revolution
  */
-class modUtilsStringSanitizers
+class modStringSanitizer
 {
     /**
      * A reference to the modX object.

--- a/core/src/Revolution/Utilities/Sanitizers/modUtilsStringSanitizers.php
+++ b/core/src/Revolution/Utilities/Sanitizers/modUtilsStringSanitizers.php
@@ -1,0 +1,170 @@
+<?php
+
+/*
+ * This file is part of the MODX Revolution package.
+ *
+ * Copyright (c) MODX, LLC
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace MODX\Revolution\Utilities\Sanitizers;
+
+use MODX\Revolution\modX;
+
+/**
+ * Provides utility methods to processors and controllers for sanitizing text content
+ *
+ * @package MODX\Revolution
+ */
+class modUtilsStringSanitizers
+{
+    /**
+     * A reference to the modX object.
+     * @var modX $modx
+     */
+    protected ?modX $modx = null;
+
+    public function __construct(modX $modx)
+    {
+        $this->modx =& $modx;
+    }
+
+    /**
+     * Removes unwanted tags and/or tag attributes from an HTML string
+     *
+     * @param string $htmlSource The html string to clean
+     * @param ?string|array $allowedTags An array or comma-separated list of tag names to allow
+     * @param ?string|array $allowedAttr An array or comma-separated list of tag attribute names to allow.
+     * Note that data-[xyz] attributes may be allowed by adding "data" to the list.
+     * @param bool $allowScripts Whether to allow javascript in html source passed to this method
+     * @param bool $allowComments Whether to allow comments in the final output
+     */
+    public function stripHTML(string $htmlSource, string|array|null $allowedTags = '', string|array|null $allowedAttr = '', bool $allowScripts = false, bool $allowComments = false): string
+    {
+        if (trim($htmlSource) === '') {
+            return '';
+        }
+
+        libxml_use_internal_errors(true);
+
+        $allowedTags = is_string($allowedTags) ? trim($allowedTags) : $allowedTags ;
+
+        if (empty($allowedTags)) {
+            return strip_tags($htmlSource);
+        }
+
+        if (!is_array($allowedTags)) {
+            $allowedTags = preg_replace('/[\s<>]+/', '', $allowedTags);
+            $allowedTags = explode(',', $allowedTags);
+        } else {
+            $allowedTags = array_map(function ($tag) {
+                return preg_replace('/[\s<>]+/', '', $tag);
+            }, $allowedTags);
+        }
+
+        if (!empty($allowedAttr)) {
+            if (!is_array($allowedAttr)) {
+                $allowedAttr = explode(',', $allowedAttr);
+            }
+            $allowedAttr = array_map('trim', $allowedAttr);
+        } else {
+            $allowedAttr = [];
+        }
+
+        $dom = new \DOMDocument();
+        // Prevent additional formatting of the source string
+        $dom->formatOutput = false;
+
+        $content = mb_encode_numericentity(
+            $htmlSource,
+            [0x80, 0x10FFFF, 0, ~0],
+            'UTF-8'
+        );
+
+        // Need a placeholder wrapping tag, as loadHTML will automatically wrap strings with no root tag with a <p> tag (do not want that)
+        $dom->loadHTML(
+            '<phwrap>' . $content . '</phwrap>',
+            LIBXML_HTML_NOIMPLIED | LIBXML_HTML_NODEFDTD
+        );
+
+        $xpath = new \DOMXPath($dom);
+
+        if (!$allowComments) {
+            foreach ($xpath->query("//comment()") as $node) {
+                $node->parentNode->removeChild($node);
+            }
+        }
+
+        /*
+            Before the main query, remove nodes where not only the tag,
+            but its contents should be removed. Otherwise the parse will
+            in most cases not be able to identify the content to remove
+            because its enclosing tag had already been removed.
+        */
+        if (!$allowScripts) {
+            foreach ($xpath->query("//script") as $node) {
+                $node->parentNode->removeChild($node);
+            }
+        }
+
+        // Main query
+        foreach ($xpath->query("//*") as $node) {
+            $parent = $node->parentNode;
+            if (in_array($node->nodeName, $allowedTags)) {
+                if ($node->attributes->length > 0) {
+                    if (empty($allowedAttr)) {
+                        for ($i = 0; $i < $node->attributes->length; $i++) {
+                            /** @disregard P1013 */
+                            $node->removeAttribute($node->attributes->item(0)->nodeName);
+                        }
+                    } else {
+                        $nodeAttrRemove = [];
+                        for ($i = 0; $i < $node->attributes->length; $i++) {
+                            $name = $node->attributes->item($i)->nodeName;
+                            /*
+                                Because data attributes are infinitly variable, but always begin with 'data-', allowing this attribute is done by simply entering
+                                'data' in the allowed list. Special handling for that done here.
+                            */
+                            $attrIsAllowed = in_array($name, $allowedAttr) || (in_array('data', $allowedAttr) && strpos($name, 'data-') === 0);
+                            if (!$allowScripts && strpos($name, 'on') === 0) {
+                                // Event handlers are the only attributes beginning with 'on'
+                                $nodeAttrRemove[] = $name;
+                                continue;
+                            }
+                            if ($attrIsAllowed) {
+                                if (!$allowScripts) {
+                                    // Javascript shouldn't be able to run in other attributes, but just in case replace it with a placeholder when scripts are disallowed
+                                    $testVal = preg_replace('/[^a-zA-Z:]+/', '', $node->attributes->item($i)->nodeValue);
+                                    if (stripos($testVal, 'javascript:') !== false) {
+                                        $node->attributes->item($i)->nodeValue = '#js-not-allowed#';
+                                    }
+                                }
+                            } else {
+                                $nodeAttrRemove[] = $name;
+                            }
+                        }
+                        foreach ($nodeAttrRemove as $attr) {
+                            /** @disregard P1013 */
+                            $node->removeAttribute($attr);
+                        }
+                    }
+                }
+            } else {
+                while ($node->hasChildNodes()) {
+                    $parent->insertBefore($node->lastChild, $node->nextSibling);
+                }
+                $parent->removeChild($node);
+            }
+        }
+        // Account for cases where libxml adds a trailing newline
+        $output = rtrim($dom->saveHTML(), "\n");
+
+        // The loop above should already have dropped this placeholder tag, but just in case it did not...
+        if (strpos($output, '<phwrap>') !== false) {
+            $output = str_replace(['<phwrap>', '</phwrap>'], '', $output);
+        }
+        return $output;
+    }
+}

--- a/core/src/Revolution/modConnectorResponse.php
+++ b/core/src/Revolution/modConnectorResponse.php
@@ -183,13 +183,14 @@ class modConnectorResponse extends modResponse
             $json = $this->modx->toJSON([
                 'success' => isset($this->body['success']) ? $this->body['success'] : 0,
                 'message' => isset($this->body['message']) ? $this->body['message'] : $this->modx->lexicon('error'),
+                'messageConfig' => $this->body['messageConfig'] ?? [],
                 'total' => (isset($this->body['total']) && $this->body['total'] > 0)
                     ? intval($this->body['total'])
                     : (isset($this->body['errors'])
                         ? count($this->body['errors'])
                         : 1),
                 'data' => isset($this->body['errors']) ? $this->body['errors'] : [],
-                'object' => isset($this->body['object']) ? $this->body['object'] : [],
+                'object' => isset($this->body['object']) ? $this->body['object'] : []
             ]);
 
             die($json);

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -23,8 +23,8 @@ use MODX\Revolution\Registry\modRegister;
 use MODX\Revolution\Registry\modRegistry;
 use MODX\Revolution\Services\Container;
 use MODX\Revolution\Smarty\modSmarty;
-use MODX\Revolution\Utilities\Sanitizers\modUtilsStringSanitizers;
-use MODX\Revolution\Utilities\Converters\modUtilsStringConverters;
+use MODX\Revolution\Utilities\Sanitizers\modStringSanitizer;
+use MODX\Revolution\Utilities\Converters\modStringConverter;
 use MODX\Revolution\Validation\modValidator;
 use PDO;
 use PDOStatement;
@@ -601,8 +601,8 @@ class modX extends xPDO {
             $this->registry = $this->services->get('registry');
 
             $this->services->add(modManagerDateFormatter::class, fn() => new modManagerDateFormatter($this));
-            $this->services->add(modUtilsStringSanitizers::class, fn() => new modUtilsStringSanitizers($this));
-            $this->services->add(modUtilsStringConverters::class, fn() => new modUtilsStringConverters($this));
+            $this->services->add(modStringSanitizer::class, fn() => new modStringSanitizer($this));
+            $this->services->add(modStringConverter::class, fn() => new modStringConverter($this));
 
             if (!$this->getOption(xPDO::OPT_SETUP)) {
                 $this->invokeEvent(

--- a/core/src/Revolution/modX.php
+++ b/core/src/Revolution/modX.php
@@ -13,16 +13,18 @@ namespace MODX\Revolution;
 use Exception;
 use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\HttpFactory;
-use MODX\Revolution\Formatter\modManagerDateFormatter;
-use MODX\Revolution\Services\Container;
 use MODX\Revolution\Error\modError;
 use MODX\Revolution\Error\modErrorHandler;
+use MODX\Revolution\Formatter\modManagerDateFormatter;
 use MODX\Revolution\Mail\modMail;
 use MODX\Revolution\Processors\Processor;
 use MODX\Revolution\Processors\ProcessorResponse;
 use MODX\Revolution\Registry\modRegister;
 use MODX\Revolution\Registry\modRegistry;
+use MODX\Revolution\Services\Container;
 use MODX\Revolution\Smarty\modSmarty;
+use MODX\Revolution\Utilities\Sanitizers\modUtilsStringSanitizers;
+use MODX\Revolution\Utilities\Converters\modUtilsStringConverters;
 use MODX\Revolution\Validation\modValidator;
 use PDO;
 use PDOStatement;
@@ -72,6 +74,13 @@ class modX extends xPDO {
      * @const SESSION_STATE_EXTERNAL
      */
     const SESSION_STATE_EXTERNAL = 2;
+
+    /** The html tag names that are allowed in formatted manager dialog messages. */
+    const MGR_MESSAGES_ALLOWED_TAGS = 'div,p,ul,ol,li,strong,em,br,a';
+
+    /** The html attributes that are allowed in formatted manager dialog messages. */
+    const MGR_MESSAGES_ALLOWED_ATTRS = 'href,class';
+
     /**
      * @var Container The DI services container.
      */
@@ -592,6 +601,8 @@ class modX extends xPDO {
             $this->registry = $this->services->get('registry');
 
             $this->services->add(modManagerDateFormatter::class, fn() => new modManagerDateFormatter($this));
+            $this->services->add(modUtilsStringSanitizers::class, fn() => new modUtilsStringSanitizers($this));
+            $this->services->add(modUtilsStringConverters::class, fn() => new modUtilsStringConverters($this));
 
             if (!$this->getOption(xPDO::OPT_SETUP)) {
                 $this->invokeEvent(
@@ -1509,6 +1520,9 @@ class modX extends xPDO {
                 $this->config['error_handler_class']= modErrorHandler::class;
             if (!isset ($this->config['server_port']))
                 $this->config['server_port']= isset($_SERVER['SERVER_PORT']) ? $_SERVER['SERVER_PORT'] : '';
+            
+            $this->config['manager_messages_allowed_tags'] = self::MGR_MESSAGES_ALLOWED_TAGS;
+            $this->config['manager_messages_allowed_attrs'] = self::MGR_MESSAGES_ALLOWED_ATTRS;
 
             $this->_config= $this->config;
             if (!$this->_loadConfig()) {

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -841,6 +841,8 @@ Ext.extend(MODx.Ajax,Ext.Component,{
      * @param {Array} args - An array of arguments to pass to the callback
      */
     ,_runCallback: function(config, args) {
+        // console.log('MODx.Ajax._runCallback, args', args);
+        
         var scope = window
             ,fn = config.fn;
 
@@ -863,10 +865,12 @@ MODx.form.Handler = function(config) {
 Ext.extend(MODx.form.Handler,Ext.Component,{
     fields: []
 
+    /** @todo Seems to be unused; confirm and remove */
     ,handle: function(o,s,r) {
+        // console.log('MODx.form.Handler:handle');
         r = Ext.decode(r.responseText);
         if (!r.success) {
-            this.showError(r.message);
+            this.routeErrorMessage(r);
             return false;
         }
         return true;
@@ -893,37 +897,156 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
         this.fields = [];
     }
 
-    ,errorJSON: function(e) {
-        if (e === '') { return this.showError(e); }
-        if (e.data && e.data !== null) {
-            for (var p=0;p<e.data.length;p=p+1) {
-                this.highlightField(e.data[p]);
+    /**
+     * Error handling used by ajax calls
+     * 
+     * Aside from being called by the base MODx.Ajax.request success/failure listeners (in this file), this gets directly called by the _handleDrag method's failure listener in:
+     * - modx.tree.js
+     * - modx.tree.column.js
+     * - modx.tree.directory.js
+     * - modx.tree.resource.js
+     * 
+     * @param {Object} response
+     * @return {void}
+     */
+    ,errorJSON: function(response) {
+        // console.log('MODx.form.Handler:errorJSON, response', response);
+        if (response && response?.data) {
+            for (let i = 0; i < response.data.length; i++) {
+                this.highlightField(response.data[i]);
             }
         }
-
-        this.showError(e.message);
-        return false;
+        this.routeErrorMessage(response);
+        // return false;
     }
 
-    ,errorExt: function(r,frm) {
+    /**
+     * Error handling used by panel and window forms (via submit method's failure listener)
+     * 
+     * @param {Object} response
+     * @param {Ext.form.BasicForm} form The form config/data that was submitted
+     * @return {void}
+     */
+    ,errorExt: function(response, form) {
+        // console.log('MODx.form.Handler:errorExt, form', form);
         this.unhighlightFields();
-        if (r && r.errors !== null && frm) {
-            frm.markInvalid(r.errors);
+        if (response && response.errors !== null && form) {
+            // As currently implemented, message prop will be empty. An array of field error messages are collected in the errors prop.
+            if (Ext.isEmpty(response.message)) {
+                response.message = _('correct_errors');
+
+                // Assign a default window title if not passed/set in upstream failure listeners
+                if (Ext.isEmpty(response.object)) {
+                    response.object = { messageWindowTitle: _('validation_error') };
+                } else if (Ext.isObject(response.object) && !Object.hasOwn(response.object, 'messageWindowTitle')) {
+                    response.object.messageWindowTitle = _('validation_error');
+                }
+            }
+            form.markInvalid(response.errors);
         }
-        if (r && r.message !== undefined && r.message !== '') {
-            this.showError(r.message);
-        } else {
-            MODx.msg.hide();
-        }
+        this.routeErrorMessage(response);
         return false;
     }
 
-    ,showError: function(e) {
-        if (e === '') {
-            MODx.msg.hide();
-        } else {
-            MODx.msg.alert(_('error'),e,Ext.emptyFn);
+    /**
+     * Generates simplified object with only data needed for display in the error window
+     * 
+     * @param {Object} response
+     * @param {Boolean} isFormatted Whether the message contains html formatting
+     * @return {Object|null} If response is valid, returns object with window title and error message
+     */
+    ,prepareMessageData: function(response, messageType, isFormatted) {
+        if (response === '' || Ext.isEmpty(response?.message)) {
+            return null;
         }
+        const data = {};
+        data.title = Ext.isObject(response.object) && Object.hasOwn(response.object, 'messageWindowTitle')
+            ? Ext.util.Format.stripTags(response.object.messageWindowTitle)
+            : _('error')
+        ;
+        // While the title is always restricted to plain text, messages can optionally be formatted
+        data.message = isFormatted
+            ? response.message
+            : Ext.util.Format.stripTags(response.message)
+        ;
+        data.type = messageType;
+
+        return data;
+    }
+
+    /**
+     * Routes message data to the appropriate method depending on whether it is html-formatted or plain text
+     * 
+     * @param {Object} response
+     * @return {void}
+     */
+    ,routeErrorMessage: function(response) {
+        // console.log('MODx.form.Handler:routeErrorMessage, response', response);
+        const
+            isFormatted = response.object?.messageConfig?.messageIsFormatted || false,
+            messageType = response.object?.messageConfig?.messageType || 'error',
+            messageData = this.prepareMessageData(response, messageType, isFormatted)
+        ;
+        if (messageData === null) {
+            const reference = response.options?.params?.action;
+            this.closeError();
+            console.warn(`A dialog window was requested${!Ext.isEmpty(reference) ? ' from ' +  reference : ''}, but there was no message content.`);
+            return;
+        } else if (isFormatted) {
+            this.showFormattedError(messageData);
+        } else {
+            this.showError(messageData);
+        }
+    }
+
+    /**
+     * Displays a plain text message in an alert modal
+     * 
+     * @param {Object|String} data A prepared data object containing the modal title and error message. Legacy implementation passes message string directly.
+     * @return {void}
+     */
+    ,showError: function(data) {
+        // console.log('MODx.form.Handler:showError, data: ', data);
+        /** @deprecated Support for non-core entities that directly use showError with legacy implementation of passing only the message string as an argument. Remove in MODX 3.4 */
+        if (typeof data === 'string') {
+            data = { title: _('error'), message: data };
+        }
+        MODx.msg.alert(data.title, data.message, Ext.emptyFn);
+    }
+
+    /**
+     * Displays a message with limited html formatting. Use sparingly for detailed messages only.
+     * 
+     * @param {Object} data Contains title and a json-encoded message (with hex entities)
+     * @return {void}
+     */
+    ,showFormattedError: function(data) {
+        let message;
+        const iconType = data.type.toUpperCase();
+        try {
+            message = JSON.parse(data.message);
+            console.log('message: ', message);
+            
+            if (typeof message !== 'string' || message === '') {
+                // This message will only be sent to browser console, so not translating
+                throw 'A JSON-formatted message was successfully parsed, but its contents were empty or the wrong data type.';
+            }
+        } catch (e) {
+            message = _('error_ui_message_error');
+            console.warn(e);
+        }
+        
+        message = MODx.util.safeHtml(
+            message,
+            '<div><p><ul><ol><li><strong><em><br>'
+        );
+        
+        Ext.Msg.show({
+            title: data.title,
+            msg: message,
+            buttons: Ext.MessageBox.OK,
+            icon: Ext.MessageBox[iconType]
+        });
     }
 
     ,closeError: function() { MODx.msg.hide(); }
@@ -939,6 +1062,7 @@ MODx.Msg = function(config) {
         ,'cancel': true
     });
     Ext.MessageBox.minWidth = 200;
+    Ext.MessageBox.maxWidth = 400;
 };
 Ext.extend(MODx.Msg,Ext.Component,{
     confirm: function(config) {

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -799,18 +799,27 @@ Ext.extend(MODx.Ajax,Ext.Component,{
     request: function(config) {
         Ext.apply(config,{
             success: function(r,o) {
+                let reportStatus = false;
                 r = Ext.decode(r.responseText);
                 if (!r) {
                     return false;
                 }
                 r.options = o;
+                
                 if (r.success) {
                     if (config.listeners.success && config.listeners.success.fn) {
                         this._runCallback(config.listeners.success, [r]);
                     }
+                    // Account for the fact that some success responses may still contain a message to display to the user and that warning and info messages will typically be sent via a success rather than failure response.
+                    if (r.message || !Ext.isEmpty(r.messageConfig)) {
+                        reportStatus = true;
+                    }
                 } else if (config.listeners.failure && config.listeners.failure.fn) {
                     this._runCallback(config.listeners.failure, [r]);
-                    MODx.form.Handler.errorJSON(r);
+                    reportStatus = true;
+                }
+                if (reportStatus) {
+                    MODx.form.Handler.statusJSON(r);
                 }
                 return true;
             }
@@ -822,7 +831,7 @@ Ext.extend(MODx.Ajax,Ext.Component,{
                 r.options = o;
                 if (config.listeners.failure && config.listeners.failure.fn) {
                     this._runCallback(config.listeners.failure, [r]);
-                    MODx.form.Handler.errorJSON(r);
+                    MODx.form.Handler.statusJSON(r);
                 }
                 return true;
             }
@@ -867,10 +876,9 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
 
     /** @todo Seems to be unused; confirm and remove */
     ,handle: function(o,s,r) {
-        // console.log('MODx.form.Handler:handle');
         r = Ext.decode(r.responseText);
         if (!r.success) {
-            this.routeErrorMessage(r);
+            this.routeStatusMessage(r);
             return false;
         }
         return true;
@@ -898,7 +906,14 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
     }
 
     /**
-     * Error handling used by ajax calls
+     * @deprecated Renamed to statusJSON to reflect expanded usage for both error and non-error messages. Legacy implementations may still call this method directly, so it is retained for backward compatibility. Remove in MODX 3.4.
+     */
+    ,errorJSON: function(response) {
+        this.statusJSON(response);
+    }
+
+    /**
+     * Message handling used by ajax calls and select listener callbacks
      * 
      * Aside from being called by the base MODx.Ajax.request success/failure listeners (in this file), this gets directly called by the _handleDrag method's failure listener in:
      * - modx.tree.js
@@ -909,15 +924,14 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
      * @param {Object} response
      * @return {void}
      */
-    ,errorJSON: function(response) {
-        // console.log('MODx.form.Handler:errorJSON, response', response);
+    ,statusJSON: function(response) {
+        console.log('MODx.form.Handler:statusJSON, response', response);
         if (response && response?.data) {
             for (let i = 0; i < response.data.length; i++) {
                 this.highlightField(response.data[i]);
             }
         }
-        this.routeErrorMessage(response);
-        // return false;
+        this.routeStatusMessage(response);
     }
 
     /**
@@ -928,23 +942,23 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
      * @return {void}
      */
     ,errorExt: function(response, form) {
-        // console.log('MODx.form.Handler:errorExt, form', form);
+        console.log('MODx.form.Handler:errorExt, response', response);
         this.unhighlightFields();
         if (response && response.errors !== null && form) {
-            // As currently implemented, message prop will be empty. An array of field error messages are collected in the errors prop.
+            // As currently implemented, message prop may be empty. An array of field error messages are collected in the errors prop.
             if (Ext.isEmpty(response.message)) {
                 response.message = _('correct_errors');
-
-                // Assign a default window title if not passed/set in upstream failure listeners
-                if (Ext.isEmpty(response.object)) {
-                    response.object = { messageWindowTitle: _('validation_error') };
-                } else if (Ext.isObject(response.object) && !Object.hasOwn(response.object, 'messageWindowTitle')) {
-                    response.object.messageWindowTitle = _('validation_error');
-                }
+            }
+            if (!Object.hasOwn(response, 'messageConfig')) {
+                response.messageConfig = {};
+            }
+            // Assign a default window title if not passed/set in upstream failure listeners
+            if (Ext.isEmpty(response.messageConfig?.messageWindowTitle)) {
+                response.messageConfig.messageWindowTitle = _('validation_error');
             }
             form.markInvalid(response.errors);
         }
-        this.routeErrorMessage(response);
+        this.routeStatusMessage(response);
         return false;
     }
 
@@ -960,8 +974,8 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
             return null;
         }
         const data = {};
-        data.title = Ext.isObject(response.object) && Object.hasOwn(response.object, 'messageWindowTitle')
-            ? Ext.util.Format.stripTags(response.object.messageWindowTitle)
+        data.title = Object.hasOwn(response.messageConfig, 'messageWindowTitle')
+            ? Ext.util.Format.stripTags(response.messageConfig.messageWindowTitle)
             : _('error')
         ;
         // While the title is always restricted to plain text, messages can optionally be formatted
@@ -980,23 +994,34 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
      * @param {Object} response
      * @return {void}
      */
-    ,routeErrorMessage: function(response) {
-        // console.log('MODx.form.Handler:routeErrorMessage, response', response);
+    ,routeStatusMessage: function(response) {
         const
-            isFormatted = response.object?.messageConfig?.messageIsFormatted || false,
-            messageType = response.object?.messageConfig?.messageType || 'error',
+            isFormatted = response.messageConfig?.messageIsFormatted || false,
+            messageType = response.messageConfig?.messageType || 'error',
             messageData = this.prepareMessageData(response, messageType, isFormatted)
         ;
         if (messageData === null) {
             const reference = response.options?.params?.action;
-            this.closeError();
+            this.closeStatusMessage();
+            /*
+                If there is no message content, the dialog will not appear in the UI so report
+                to the console for debugging purposes. Leaving untranslated since this is
+                a developer-facing message.
+            */
             console.warn(`A dialog window was requested${!Ext.isEmpty(reference) ? ' from ' +  reference : ''}, but there was no message content.`);
             return;
         } else if (isFormatted) {
-            this.showFormattedError(messageData);
+            this.showFormattedMessage(messageData);
         } else {
-            this.showError(messageData);
+            this.showMessage(messageData);
         }
+    }
+
+    /**
+     * @deprecated Renamed to showMessage to reflect expanded usage for both error and non-error messages. Legacy implementations may still call this method directly, so it is retained for backward compatibility. Remove in MODX 3.4.
+     */
+    ,showError: function(data) {
+        this.showMessage(data);
     }
 
     /**
@@ -1005,8 +1030,7 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
      * @param {Object|String} data A prepared data object containing the modal title and error message. Legacy implementation passes message string directly.
      * @return {void}
      */
-    ,showError: function(data) {
-        // console.log('MODx.form.Handler:showError, data: ', data);
+    ,showMessage: function(data) {
         /** @deprecated Support for non-core entities that directly use showError with legacy implementation of passing only the message string as an argument. Remove in MODX 3.4 */
         if (typeof data === 'string') {
             data = { title: _('error'), message: data };
@@ -1020,15 +1044,21 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
      * @param {Object} data Contains title and a json-encoded message (with hex entities)
      * @return {void}
      */
-    ,showFormattedError: function(data) {
+    ,showFormattedMessage: function(data) {
         let message;
-        const iconType = data.type.toUpperCase();
+        const
+            iconType = data.type.toUpperCase(),
+            allowedTags = (MODx.config?.manager_messages_allowed_tags && (MODx.config.manager_messages_allowed_tags)
+                .split(',')
+                .map(tag => `<${tag.trim()}>`)
+                .join('')) || '',
+            allowedAttributes = MODx.config?.manager_messages_allowed_attrs || ''
+        ;
         try {
             message = JSON.parse(data.message);
-            console.log('message: ', message);
-            
+
             if (typeof message !== 'string' || message === '') {
-                // This message will only be sent to browser console, so not translating
+                // This message will only be sent to browser console, so leaving untranslated
                 throw 'A JSON-formatted message was successfully parsed, but its contents were empty or the wrong data type.';
             }
         } catch (e) {
@@ -1038,7 +1068,8 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
         
         message = MODx.util.safeHtml(
             message,
-            '<div><p><ul><ol><li><strong><em><br>'
+            allowedTags,
+            allowedAttributes
         );
         
         Ext.Msg.show({
@@ -1049,7 +1080,16 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
         });
     }
 
-    ,closeError: function() { MODx.msg.hide(); }
+    /**
+     * @deprecated Renamed to closeStatusMessage to reflect expanded usage for both error and non-error messages. Legacy implementations may still call this method directly, so it is retained for backward compatibility. Remove in MODX 3.4.
+     */
+    ,closeError: function() {
+        this.closeStatusMessage();
+    }
+
+    ,closeStatusMessage: function() {
+        MODx.msg.hide();
+    }
 });
 Ext.reg('modx-form-handler',MODx.form.Handler);
 

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -925,7 +925,6 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
      * @return {void}
      */
     ,statusJSON: function(response) {
-        console.log('MODx.form.Handler:statusJSON, response', response);
         if (response && response?.data) {
             for (let i = 0; i < response.data.length; i++) {
                 this.highlightField(response.data[i]);

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -986,6 +986,8 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
             : Ext.util.Format.stripTags(response.message)
         ;
         data.type = messageType;
+        data.iconType = messageType.toUpperCase() || ERROR;
+        data.dialogClass = `modx-dialog-${messageType.toLowerCase() || 'error'}`;
 
         return data;
     }
@@ -1037,7 +1039,13 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
         if (typeof data === 'string') {
             data = { title: _('error'), message: data };
         }
-        MODx.msg.alert(data.title, data.message, Ext.emptyFn);
+        Ext.Msg.show({
+            title: data.title,
+            msg: data.message,
+            buttons: Ext.MessageBox.OK,
+            icon: Ext.MessageBox[data.iconType],
+            cls: data.dialogClass
+        });
     }
 
     /**
@@ -1049,7 +1057,6 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
     ,showFormattedMessage: function(data) {
         let message;
         const
-            iconType = data.type.toUpperCase(),
             allowedTags = (MODx.config?.manager_messages_allowed_tags && (MODx.config.manager_messages_allowed_tags)
                 .split(',')
                 .map(tag => `<${tag.trim()}>`)
@@ -1078,7 +1085,8 @@ Ext.extend(MODx.form.Handler,Ext.Component,{
             title: data.title,
             msg: message,
             buttons: Ext.MessageBox.OK,
-            icon: Ext.MessageBox[iconType]
+            icon: Ext.MessageBox[data.iconType],
+            cls: data.dialogClass
         });
     }
 

--- a/manager/assets/modext/core/modx.js
+++ b/manager/assets/modext/core/modx.js
@@ -810,7 +810,12 @@ Ext.extend(MODx.Ajax,Ext.Component,{
                     if (config.listeners.success && config.listeners.success.fn) {
                         this._runCallback(config.listeners.success, [r]);
                     }
-                    // Account for the fact that some success responses may still contain a message to display to the user and that warning and info messages will typically be sent via a success rather than failure response.
+                    /*
+                        Account for the fact that some success responses may still
+                        contain a message to display to the user and that warning
+                        and info messages will typically be sent via a success
+                        rather than failure response.
+                    */
                     if (r.message || !Ext.isEmpty(r.messageConfig)) {
                         reportStatus = true;
                     }
@@ -850,8 +855,6 @@ Ext.extend(MODx.Ajax,Ext.Component,{
      * @param {Array} args - An array of arguments to pass to the callback
      */
     ,_runCallback: function(config, args) {
-        // console.log('MODx.Ajax._runCallback, args', args);
-        
         var scope = window
             ,fn = config.fn;
 

--- a/manager/assets/modext/workspace/package.grid.js
+++ b/manager/assets/modext/workspace/package.grid.js
@@ -399,32 +399,32 @@ Ext.extend(MODx.grid.Package, MODx.grid.Grid, {
             listeners: {
                 success: {
                     fn: function(response) {
-                        this.loadWindow(btn, e, {
-                            xtype: 'modx-window-package-update',
-                            cls: 'modx-alert',
-                            packages: response.object,
-                            record: this.menu.record,
-                            force: true,
-                            listeners: {
-                                success: {
-                                    fn: function(o) {
-                                        this.refresh();
-                                        this.menu.record = { data: o.a.result.object };
-                                        this.install(this.menu.record);
-                                    },
-                                    scope: this
+                        if (!Ext.isEmpty(response.object)) {
+                            this.loadWindow(btn, e, {
+                                xtype: 'modx-window-package-update',
+                                cls: 'modx-alert',
+                                packages: response.object,
+                                record: this.menu.record,
+                                force: true,
+                                listeners: {
+                                    success: {
+                                        fn: function(o) {
+                                            this.refresh();
+                                            this.menu.record = { data: o.a.result.object };
+                                            this.install(this.menu.record);
+                                        },
+                                        scope: this
+                                    }
                                 }
-                            }
-                        });
+                            });
+                        } else {
+                            // response.messageConfig.messageWindowTitle = 'So Sorry...But';
+                        }
                     },
                     scope: this
                 },
                 failure: {
-                    fn: function(response) {
-                        MODx.msg.alert(_('package_update'), response.message);
-                        return false;
-                    },
-                    scope: this
+                    fn: Ext.emptyFn
                 }
             }
         });


### PR DESCRIPTION
**Note:** Don't get scared off by the changed-line count; a significant number of those lines are documentation and unit test-related ;-)

### What changed and why

Rewires the `MODx.form.Handler` (js) methods and associated backend methods to:

- support reporting of intermediate statuses (_i.e._, warning and info) via customizable dialog titling and styling that matches each state (style is only minimally applied in this PR by assigning the associated icon for each status in the dialog body; more fine-tuned/elegant styling will be the job of a separate PR);
- allow intermediate statuses to route to success or failure, depending on which is more appropriate;
- allow HTML in dialog messages via a new `MODx.form.Handler.showFormattedMessage` method, which is opt-in and does not affect any of the current success/failure messaging unless explicitly changed in the back end logic by using the new `Processor::status` method [_e.g._, instead of `$this->failure(...)`, one would use `$this->status(...) with the `messageIsFormatted` param set to true`]; and
- in the case of HTML dialogs, match the front and back end sanitization rules via backend constants that are relayed to the front end in new MODx.config props.

In support of the HTML dialog option, two new php utilities were added as services (`modStringSanitizer` and `modStringConverter`). Note that:

- Although these were purpose-built for this PR, they can be useful and are accessible for consumption outside the core.
- Their classes were envisioned to house other related utils over time. Particularly, there are many util methods in the `modX` base class, the `Processor` class, and probably elsewhere that can be more appropriately located in these utility classes.

There are many instances where a failure _is not_ a failure per se, but we've only had an unrealistic binary success or failure path for reporting the state of a process in the UI. That, along with the inability to format messages when needed was the motivation for this change.

### How to test

This update touches many areas, so I advise a general run through of creating objects and purposely causing failures. One easy way is via any object emits a dialog on validation errors (Resource, Element, etc.).

A specific case in included in this PR to see how the change is applied and to verify it works. See the changes in the final commit of this PR for reference (Packages `CheckForUpdates`).* 

1. Go to the _Extras/Installer_ (Package Management page) and install a package or two if you have none in your testing install. 
2. Before and after applying this PR, click the _Check For Updates_ button on any of these packages to verify the old against the new behavior.

\* To see the effects of the new behavior under different scenarios, make changes in `CheckForUpdates` ~L97-98+; play with the message itself and the $this->status (new) vs $this->failure (existing) statement. An example of what I used to test:

_For checking support of html in message, and full stripping of it when not in formatted mode:_
```php
$msg = <<<HTML
    <strong>Special Message</strong><br>
    <span>It's a special intro:</span><br>
    <em>{$msg}</em>
    <script>return 'do something bad';</script>
HTML;
return $this->status(
    $msg,
    $this->modx->lexicon('package_status'), // <- change the window title
    Processor::STATUS_TYPE_WARN, // <- change for various status types (_ERROR, _INFO)
    true // <- change for formatted vs unformatted (false)
);
```

### Related issue(s)/PR(s)

Although not specifically created for this, the included verification case (`CheckForUpdates`) illustrates this PR's way of handling what's addressed in #17000.

### Compatibility notes

n/a

### Breaking change assessment

No BC anticipated, as current behavior is preserved and handler methods marked as deprecated pass through to new methods at least until 3.4 when removal is suggested.

### Test coverage

New UT for `stripHTML` method located in Tests/Utilities/Sanitizers.

### Contributors

n/a

### AI tool use

n/a
